### PR TITLE
Door opening/close relliability updates

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -4,7 +4,6 @@ external_components:
   - source:
       type: git
       url: https://github.com/ratgdo/esphome-ratgdo
-      ref: reliability_updates
     refresh: 1s
 
 preferences:

--- a/base.yaml
+++ b/base.yaml
@@ -211,3 +211,11 @@ button:
       then:
         lambda: !lambda |-
           id($id_prefix).sync();
+
+  - platform: template
+    id: ${id_prefix}_toggle_door
+    name: "Toggle door"
+    on_press: 
+      then:
+        lambda: !lambda |-
+          id($id_prefix).toggle_door();

--- a/base.yaml
+++ b/base.yaml
@@ -4,6 +4,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/ratgdo/esphome-ratgdo
+      ref: reliability_updates
     refresh: 1s
 
 preferences:

--- a/components/ratgdo/callbacks.h
+++ b/components/ratgdo/callbacks.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <vector>
 #include <functional>
 #include <utility>
+#include <vector>
 
 namespace esphome {
 namespace ratgdo {

--- a/components/ratgdo/callbacks.h
+++ b/components/ratgdo/callbacks.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <vector>
+#include <functional>
+#include <utility>
+
+namespace esphome {
+namespace ratgdo {
+
+    template <typename... X>
+    class OnceCallbacks;
+
+    template <typename... Ts>
+    class OnceCallbacks<void(Ts...)> {
+    public:
+        template <typename Callback>
+        void then(Callback&& callback) { this->callbacks_.push_back(std::forward<Callback>(callback)); }
+
+        void operator()(Ts... args)
+        {
+            for (auto& cb : this->callbacks_)
+                cb(args...);
+            this->callbacks_.clear();
+        }
+
+    protected:
+        std::vector<std::function<void(Ts...)>> callbacks_;
+    };
+
+} // namespace ratgdo
+} // namespace esphome

--- a/components/ratgdo/observable.h
+++ b/components/ratgdo/observable.h
@@ -1,4 +1,7 @@
 #pragma once
+#include <vector>
+#include <functional>
+#include <utility>
 
 namespace esphome {
 namespace ratgdo {

--- a/components/ratgdo/observable.h
+++ b/components/ratgdo/observable.h
@@ -1,7 +1,7 @@
 #pragma once
-#include <vector>
 #include <functional>
 #include <utility>
+#include <vector>
 
 namespace esphome {
 namespace ratgdo {

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -13,6 +13,7 @@
 
 #pragma once
 #include "SoftwareSerial.h" // Using espsoftwareserial https://github.com/plerup/espsoftwareserial
+#include "callbacks.h"
 #include "enum.h"
 #include "esphome/core/component.h"
 #include "esphome/core/gpio.h"
@@ -124,6 +125,9 @@ namespace ratgdo {
         observable<ButtonState> button_state { ButtonState::UNKNOWN };
         observable<MotionState> motion_state { MotionState::UNKNOWN };
 
+        OnceCallbacks<void(DoorState)> door_state_received;
+        OnceCallbacks<void()> command_sent;
+
         observable<bool> sync_failed { false };
 
         void set_output_gdo_pin(InternalGPIOPin* pin) { this->output_gdo_pin_ = pin; }
@@ -136,6 +140,7 @@ namespace ratgdo {
         uint16_t decode_packet(const WirePacket& packet);
         void obstruction_loop();
         void send_command(Command command, uint32_t data = 0, bool increment = true);
+        void send_command(Command command, uint32_t data, bool increment, std::function<void()>&& on_sent);
         bool transmit_packet();
         void encode_packet(Command command, uint32_t data, bool increment, WirePacket& packet);
         void print_packet(const WirePacket& packet) const;
@@ -145,6 +150,7 @@ namespace ratgdo {
 
         // door
         void door_command(uint32_t data);
+        void ensure_door_command(uint32_t data, uint32_t delay = 1500);
         void toggle_door();
         void open_door();
         void close_door();

--- a/static/v2board_esp8266_d1_mini_lite.yaml
+++ b/static/v2board_esp8266_d1_mini_lite.yaml
@@ -33,7 +33,6 @@ packages:
     url: https://github.com/ratgdo/esphome-ratgdo
     files: [base.yaml]
     refresh: 1s
-    ref: reliability_updates
 
 # Sync time with Home Assistant.
 time:

--- a/static/v2board_esp8266_d1_mini_lite.yaml
+++ b/static/v2board_esp8266_d1_mini_lite.yaml
@@ -33,6 +33,7 @@ packages:
     url: https://github.com/ratgdo/esphome-ratgdo
     files: [base.yaml]
     refresh: 1s
+    ref: reliability_updates
 
 # Sync time with Home Assistant.
 time:


### PR DESCRIPTION
This adds two callbacks for command sent and door status received to ensure more predictable sequencing of events. 

For example, one case I encountered was when sending a door command (which is emulating a button press and a button release 100ms later), simultaneously with some motion events that caused the button press to be delayed, causing it to be too close or after the button release and thus ignored. This add a callback for when a door command was actually sent and only sends the next command then (instead of a fixed delay).

The door state callback is useful for things like sending a door command and waiting for a status message until another door command can be sent. This PR adds an `ensure_door_command` which can be used to ensure a command is actually received by the opener, otherwise it re-sends it after a certain delay.