### PR TITLE
Fix issue #89 by imposing some limits on the random client_id

### DIFF
--- a/components/ratgdo/number/ratgdo_number.cpp
+++ b/components/ratgdo/number/ratgdo_number.cpp
@@ -27,7 +27,7 @@ namespace ratgdo {
         this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
         if (!this->pref_.load(&value)) {
             if (this->number_type_ == RATGDO_CLIENT_ID) {
-                value = random(0x1, 0xFFFF);
+                value = ((random_uint32() + 1) % 0xFFFF) << 12 | 0x539;
             } else {
                 value = 0;
             }
@@ -82,7 +82,7 @@ namespace ratgdo {
         } else if (this->number_type_ == RATGDO_CLIENT_ID) {
             this->parent_->set_client_id(value);
         }
-        this->pref_.save(&value);
+        this->update_state(value);
     }
 
 } // namespace ratgdo

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -101,7 +101,7 @@ namespace ratgdo {
         uint16_t cmd = ((fixed >> 24) & 0xf00) | (data & 0xff);
         data &= ~0xf000; // clear parity nibble
 
-        if ((fixed & 0xfffffff) == this->client_id_) { // my commands
+        if ((fixed & 0xFFFFFFFF) == this->client_id_) { // my commands
             ESP_LOG1(TAG, "[%ld] received mine: rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, millis(), rolling, fixed, data);
             return static_cast<uint16_t>(Command::UNKNOWN);
         } else {
@@ -547,9 +547,7 @@ namespace ratgdo {
             return;
         }
 
-        // Sometimes the door doesn't always close when its fully open
-        // so we use ensure_door_command to make sure it closes
-        this->ensure_door_command(data::DOOR_CLOSE);
+        this->door_command(data::DOOR_CLOSE);
     }
 
     void RATGDOComponent::stop_door()

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -133,7 +133,7 @@ namespace ratgdo {
         void set_output_gdo_pin(InternalGPIOPin* pin) { this->output_gdo_pin_ = pin; }
         void set_input_gdo_pin(InternalGPIOPin* pin) { this->input_gdo_pin_ = pin; }
         void set_input_obst_pin(InternalGPIOPin* pin) { this->input_obst_pin_ = pin; }
-        void set_client_id(uint64_t client_id) { this->client_id_ = client_id & 0xffffff; } // not sure how large client_id can be, assuming not more than 24 bits
+        void set_client_id(uint64_t client_id) { this->client_id_ = client_id & 0xFFFFFFFF; }
 
         void gdo_state_loop();
         uint16_t decode_packet(const WirePacket& packet);


### PR DESCRIPTION
This should fix #89 (and reverts #88). It enforces the client_id to always end with `0x539`, but randomizes the two bytes before that. As an added benefit, it's easy to recognize the esp client_id (always ends in `0x539`).

Also fixes a bug in ratgdo_number where the component's state was not updated when the number value was changed (for example changing the client_id and refreshing/re-opening the web page or the HA device info page would show the old client_id, although the flash and ratgdo used the new one).