### PR TITLE
fix package import urls for the v25 boards

### DIFF
--- a/static/v25board_esp32_d1_mini.yaml
+++ b/static/v25board_esp32_d1_mini.yaml
@@ -25,7 +25,7 @@ esp32:
   board: wemos_d1_mini32
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v2board_esp32_d1_mini.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v25board_esp32_d1_mini.yaml@main
 
 packages:
   remote_package:

--- a/static/v25board_esp8266_d1_mini_lite.yaml
+++ b/static/v25board_esp8266_d1_mini_lite.yaml
@@ -26,7 +26,7 @@ esp8266:
   restore_from_flash: true
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v2board_esp8266_d1_mini_lite.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v25board_esp8266_d1_mini_lite.yaml@main
 
 packages:
   remote_package:


### PR DESCRIPTION
reported in https://github.com/ratgdo/esphome-ratgdo/issues/96#issuecomment-1799536674