### PR TITLE
Bump actions/deploy-pages to 1.2.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,4 +95,4 @@ jobs:
         uses: actions/configure-pages@v2
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1.2.3
+        uses: actions/deploy-pages@v1.2.9


### PR DESCRIPTION
1.2.3 stopped working with no other changes.. lets hope 1.2.9 fixes it

otherwise it might be https://github.com/actions/upload-artifact/issues/472