### PR TITLE
fix: v2.5i boards should use d1_mini

### DIFF
--- a/static/v25iboard.yaml
+++ b/static/v25iboard.yaml
@@ -22,7 +22,7 @@ esphome:
     version: "2.5i"
 
 esp8266:
-  board: d1_mini_lite
+  board: d1_mini
   restore_from_flash: true
 
 dashboard_import:


### PR DESCRIPTION
fixes #155