### PR TITLE
Change board in v25board_esp8266_d1_mini.yaml to d1_mini

### DIFF
--- a/static/v25board_esp8266_d1_mini.yaml
+++ b/static/v25board_esp8266_d1_mini.yaml
@@ -22,7 +22,7 @@ esphome:
     version: "2.5"
 
 esp8266:
-  board: d1_mini_lite
+  board: d1_mini
   restore_from_flash: true
 
 dashboard_import:


### PR DESCRIPTION
I think static/v25board_esp8266_d1_mini.yaml needs a board definition update to reflect that the board is d1_mini now.