### PR TITLE
remove garage from cover entity, so devices can be named consistently

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -142,7 +142,7 @@ binary_sensor:
           condition:
             binary_sensor.is_off: ${id_prefix}_dry_contact_close
           then:
-            - cover.open: ${id_prefix}_garage_door
+            - cover.open: ${id_prefix}_door
   - platform: gpio
     id: "${id_prefix}_dry_contact_close"
     pin:
@@ -160,7 +160,7 @@ binary_sensor:
           condition:
             binary_sensor.is_off: ${id_prefix}_dry_contact_open
           then:
-            - cover.close: ${id_prefix}_garage_door
+            - cover.close: ${id_prefix}_door
   - platform: gpio
     id: "${id_prefix}_dry_contact_light"
     pin:
@@ -212,7 +212,7 @@ number:
 
 cover:
   - platform: ratgdo
-    id: ${id_prefix}_garage_door
+    id: ${id_prefix}_door
     device_class: garage
     name: "Door"
     ratgdo_id: ${id_prefix}

--- a/base_secplusv1.yaml
+++ b/base_secplusv1.yaml
@@ -94,7 +94,7 @@ binary_sensor:
           condition:
             binary_sensor.is_off: ${id_prefix}_dry_contact_close
           then:
-            - cover.open: ${id_prefix}_garage_door
+            - cover.open: ${id_prefix}_door
   - platform: gpio
     id: "${id_prefix}_dry_contact_close"
     pin:
@@ -112,7 +112,7 @@ binary_sensor:
           condition:
             binary_sensor.is_off: ${id_prefix}_dry_contact_open
           then:
-            - cover.close: ${id_prefix}_garage_door
+            - cover.close: ${id_prefix}_door
   - platform: gpio
     id: "${id_prefix}_dry_contact_light"
     pin:
@@ -164,7 +164,7 @@ number:
 
 cover:
   - platform: ratgdo
-    id: ${id_prefix}_garage_door
+    id: ${id_prefix}_door
     device_class: garage
     name: "Door"
     ratgdo_id: ${id_prefix}


### PR DESCRIPTION
as it stands, if you call your ratgdo "Little Garage", you end up with a cover named `cover.little_garage_garage_door`, and a light named `light.little_garage_light`

After this change, you'd have `cover.little_garage_door` and `light.little_garage_light`, which feels more internally correct.

Conversely if you name a ratgdo "Little" to avoid the "double garage" in your cover entity, you'd end up with `cover.little_garage_door` and `light.little_light`. The light entity could be troublesome - call your garage "Main" and you suddenly have a "main_light" which probably overstates its importance in your environment.