### PR TITLE
Improve compatibility for non-dry-contact configurations.

### DIFF
--- a/components/ratgdo/dry_contact.cpp
+++ b/components/ratgdo/dry_contact.cpp
@@ -1,8 +1,9 @@
 
-#include "dry_contact.h"
 #include "ratgdo.h"
 
-#include "esphome/components/gpio/binary_sensor/gpio_binary_sensor.h"
+#ifdef PROTOCOL_DRYCONTACT
+
+#include "dry_contact.h"
 #include "esphome/core/gpio.h"
 #include "esphome/core/log.h"
 #include "esphome/core/scheduler.h"
@@ -128,6 +129,8 @@ namespace ratgdo {
             return {};
         }
 
-    } // namespace DryContact
+    } // namespace dry_contact
 } // namespace ratgdo
 } // namespace esphome
+
+#endif

--- a/components/ratgdo/dry_contact.h
+++ b/components/ratgdo/dry_contact.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include "esphome/core/defines.h"
+
+#ifdef PROTOCOL_DRYCONTACT
+
 #include "SoftwareSerial.h" // Using espsoftwareserial https://github.com/plerup/espsoftwareserial
-#include "esphome/components/gpio/binary_sensor/gpio_binary_sensor.h"
 #include "esphome/core/gpio.h"
 #include "esphome/core/optional.h"
 
@@ -72,6 +75,8 @@ namespace ratgdo {
             bool last_close_limit_;
         };
 
-    } // namespace secplus1
+    } // namespace dry_contact
 } // namespace ratgdo
 } // namespace esphome
+
+#endif

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -686,8 +686,9 @@ namespace ratgdo {
         this->learn_state.subscribe([=](LearnState state) { defer("learn_state", [=] { f(state); }); });
     }
 
+#ifdef PROTOCOL_DRYCONTACT
     // dry contact methods
-    void RATGDOComponent::set_dry_contact_open_sensor(esphome::gpio::GPIOBinarySensor* dry_contact_open_sensor)
+    void RATGDOComponent::set_dry_contact_open_sensor(esphome::binary_sensor::BinarySensor* dry_contact_open_sensor)
     {
         dry_contact_open_sensor_ = dry_contact_open_sensor;
         dry_contact_open_sensor_->add_on_state_callback([this](bool sensor_value) {
@@ -695,13 +696,14 @@ namespace ratgdo {
         });
     }
 
-    void RATGDOComponent::set_dry_contact_close_sensor(esphome::gpio::GPIOBinarySensor* dry_contact_close_sensor)
+    void RATGDOComponent::set_dry_contact_close_sensor(esphome::binary_sensor::BinarySensor* dry_contact_close_sensor)
     {
         dry_contact_close_sensor_ = dry_contact_close_sensor;
         dry_contact_close_sensor_->add_on_state_callback([this](bool sensor_value) {
             this->protocol_->set_close_limit(sensor_value);
         });
     }
+#endif
 
 } // namespace ratgdo
 } // namespace esphome

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -13,10 +13,13 @@
 
 #pragma once
 
-#include "esphome/components/gpio/binary_sensor/gpio_binary_sensor.h"
 #include "esphome/core/component.h"
+#include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
 #include "esphome/core/preferences.h"
+#ifdef PROTOCOL_DRYCONTACT
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
 
 #include "callbacks.h"
 #include "macros.h"
@@ -92,11 +95,13 @@ namespace ratgdo {
         void set_input_gdo_pin(InternalGPIOPin* pin) { this->input_gdo_pin_ = pin; }
         void set_input_obst_pin(InternalGPIOPin* pin) { this->input_obst_pin_ = pin; }
 
+#ifdef PROTOCOL_DRYCONTACT
         // dry contact methods
-        void set_dry_contact_open_sensor(esphome::gpio::GPIOBinarySensor* dry_contact_open_sensor_);
-        void set_dry_contact_close_sensor(esphome::gpio::GPIOBinarySensor* dry_contact_close_sensor_);
+        void set_dry_contact_open_sensor(esphome::binary_sensor::BinarySensor* dry_contact_open_sensor_);
+        void set_dry_contact_close_sensor(esphome::binary_sensor::BinarySensor* dry_contact_close_sensor_);
         void set_discrete_open_pin(InternalGPIOPin* pin) { this->protocol_->set_discrete_open_pin(pin); }
         void set_discrete_close_pin(InternalGPIOPin* pin) { this->protocol_->set_discrete_close_pin(pin); }
+#endif
 
         Result call_protocol(Args args);
 
@@ -181,8 +186,10 @@ namespace ratgdo {
         InternalGPIOPin* output_gdo_pin_;
         InternalGPIOPin* input_gdo_pin_;
         InternalGPIOPin* input_obst_pin_;
-        esphome::gpio::GPIOBinarySensor* dry_contact_open_sensor_;
-        esphome::gpio::GPIOBinarySensor* dry_contact_close_sensor_;
+#ifdef PROTOCOL_DRYCONTACT
+        esphome::binary_sensor::BinarySensor* dry_contact_open_sensor_;
+        esphome::binary_sensor::BinarySensor* dry_contact_close_sensor_;
+#endif
     }; // RATGDOComponent
 
 } // namespace ratgdo


### PR DESCRIPTION
* Don't compile any dry-contact code unless PROTOCOL_DRYCONTACT is defined.

* Use BinarySensor instead of GPIOBinarySensor to allow the user to use a template binary sensor (or any other type) if they wish. This is the recommendation of the ESPHome maintainers, and also aligns the C++ code with the Python configuration code (which will accept any type of binary sensor).

Closes #264.