### PR TITLE
ota: add esphome platform

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -6,6 +6,8 @@ external_components:
       url: https://github.com/ratgdo/esphome-ratgdo
     refresh: 1s
 
+safe_mode:
+
 preferences:
   flash_write_interval: 1min
 

--- a/base.yaml
+++ b/base.yaml
@@ -45,6 +45,9 @@ api:
             id($id_prefix).clear_paired_devices(ratgdo::PairedDevice::ACCESSORY);
           }
 
+ota:
+  - platform: esphome
+
 sensor:
   - platform: ratgdo
     id: ${id_prefix}_openings

--- a/base_drycontact.yaml
+++ b/base_drycontact.yaml
@@ -25,6 +25,9 @@ ratgdo:
   discrete_close_pin: ${discrete_close_pin}
   protocol: drycontact
 
+ota:
+  - platform: esphome
+
 binary_sensor:
   - platform: ratgdo
     type: obstruction

--- a/base_drycontact.yaml
+++ b/base_drycontact.yaml
@@ -8,6 +8,8 @@ external_components:
       url: https://github.com/ratgdo/esphome-ratgdo
     refresh: 1s
 
+safe_mode:
+
 preferences:
   flash_write_interval: 1min
 

--- a/base_secplusv1.yaml
+++ b/base_secplusv1.yaml
@@ -28,6 +28,9 @@ ratgdo:
             message: "Failed to communicate with garage opener on startup."
             notification_id: "esphome_ratgdo_${id_prefix}_sync_failed"
 
+ota:
+  - platform: esphome
+
 lock:
   - platform: ratgdo
     id: ${id_prefix}_lock_remotes

--- a/base_secplusv1.yaml
+++ b/base_secplusv1.yaml
@@ -6,6 +6,8 @@ external_components:
       url: https://github.com/ratgdo/esphome-ratgdo
     refresh: 1s
 
+safe_mode:
+
 preferences:
   flash_write_interval: 1min
 

--- a/static/v25board_esp32_d1_mini.yaml
+++ b/static/v25board_esp32_d1_mini.yaml
@@ -41,8 +41,6 @@ time:
 api:
   id: api_server
 
-ota:
-
 improv_serial:
 
 wifi:

--- a/static/v25board_esp32_d1_mini_secplusv1.yaml
+++ b/static/v25board_esp32_d1_mini_secplusv1.yaml
@@ -41,8 +41,6 @@ time:
 api:
   id: api_server
 
-ota:
-
 improv_serial:
 
 wifi:

--- a/static/v25board_esp8266_d1_mini.yaml
+++ b/static/v25board_esp8266_d1_mini.yaml
@@ -42,8 +42,6 @@ time:
 api:
   id: api_server
 
-ota:
-
 improv_serial:
 
 wifi:

--- a/static/v25board_esp8266_d1_mini_lite.yaml
+++ b/static/v25board_esp8266_d1_mini_lite.yaml
@@ -42,8 +42,6 @@ time:
 api:
   id: api_server
 
-ota:
-
 improv_serial:
 
 wifi:

--- a/static/v25board_esp8266_d1_mini_lite_secplusv1.yaml
+++ b/static/v25board_esp8266_d1_mini_lite_secplusv1.yaml
@@ -42,8 +42,6 @@ time:
 api:
   id: api_server
 
-ota:
-
 improv_serial:
 
 wifi:

--- a/static/v25board_esp8266_d1_mini_secplusv1.yaml
+++ b/static/v25board_esp8266_d1_mini_secplusv1.yaml
@@ -42,8 +42,6 @@ time:
 api:
   id: api_server
 
-ota:
-
 improv_serial:
 
 wifi:

--- a/static/v25iboard.yaml
+++ b/static/v25iboard.yaml
@@ -42,8 +42,6 @@ time:
 api:
   id: api_server
 
-ota:
-
 improv_serial:
 
 wifi:

--- a/static/v25iboard_drycontact.yaml
+++ b/static/v25iboard_drycontact.yaml
@@ -42,8 +42,6 @@ time:
 api:
   id: api_server
 
-ota:
-
 improv_serial:
 
 wifi:

--- a/static/v25iboard_secplusv1.yaml
+++ b/static/v25iboard_secplusv1.yaml
@@ -42,8 +42,6 @@ time:
 api:
   id: api_server
 
-ota:
-
 improv_serial:
 
 wifi:

--- a/static/v2board_esp32_d1_mini.yaml
+++ b/static/v2board_esp32_d1_mini.yaml
@@ -41,8 +41,6 @@ time:
 api:
   id: api_server
 
-ota:
-
 improv_serial:
 
 wifi:

--- a/static/v2board_esp32_lolin_s2_mini.yaml
+++ b/static/v2board_esp32_lolin_s2_mini.yaml
@@ -41,8 +41,6 @@ time:
 api:
   id: api_server
 
-ota:
-
 improv_serial:
 
 wifi:

--- a/static/v2board_esp8266_d1_mini.yaml
+++ b/static/v2board_esp8266_d1_mini.yaml
@@ -42,8 +42,6 @@ time:
 api:
   id: api_server
 
-ota:
-
 improv_serial:
 
 wifi:

--- a/static/v2board_esp8266_d1_mini_lite.yaml
+++ b/static/v2board_esp8266_d1_mini_lite.yaml
@@ -42,8 +42,6 @@ time:
 api:
   id: api_server
 
-ota:
-
 improv_serial:
 
 wifi:


### PR DESCRIPTION
Starting on version 2024.6.0, at least one platform must be specified for 'ota'; add 'platform: esphome' for original OTA functionality.

Fixes: https://github.com/ratgdo/esphome-ratgdo/issues/289
