### PR TITLE
Add `esphome` as platform for OTA

### DIFF
--- a/static/v25iboard.yaml
+++ b/static/v25iboard.yaml
@@ -43,6 +43,7 @@ api:
   id: api_server
 
 ota:
+  - platform: esphome
 
 improv_serial:
 


### PR DESCRIPTION
Compilation fails with latest esphome version without this. It's required to specify platform in the ota section.