### PR TITLE
Add ID to OTA to allow extension for overrides

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -49,6 +49,7 @@ api:
 
 ota:
   - platform: esphome
+    id: ratgdo_ota
 
 sensor:
   - platform: ratgdo

--- a/base_drycontact.yaml
+++ b/base_drycontact.yaml
@@ -29,6 +29,7 @@ ratgdo:
 
 ota:
   - platform: esphome
+    id: ratgdo_ota
 
 binary_sensor:
   - platform: ratgdo

--- a/base_secplusv1.yaml
+++ b/base_secplusv1.yaml
@@ -32,6 +32,7 @@ ratgdo:
 
 ota:
   - platform: esphome
+    id: ratgdo_ota
 
 lock:
   - platform: ratgdo


### PR DESCRIPTION
Due to how esphome handles inheritance, merging and replacing in packages[[link](https://esphome.io/guides/configuration-types.html#packages)], having _ota:_ as part of the base package will override any changes a user may make in their own config. 

So in the case of _ota:_ if you have a password defined as below in their local config:

```
ota:
  - platform: esphome
     password: "***"
```

They will no longer be able to update as the package will overwrite the entire _ota:_ section with what is in the base config, and result in the following error:

```
INFO Uploading /data/build/left-garage-door/.pioenvs/left-garage-door/firmware.bin (620640 bytes)
INFO Compressed to 417852 bytes
ERROR ESP requests password, but no password given!

```

So the option is either disable the OTA password by plugging the device in to flash, or add an ID to allow !extend to work on the OTA settings.

With an ID added, a user can use _!extend_ in their config to add additional settings, such as password

```
ota:
  - id: !extend ratgdo_ota
    password: "...."
```

Hopefully this is just a short-term fix and esphome makes some changes upstream to resolve this... as the !extend function isn't commonly used (there is an [issue open](https://github.com/esphome/issues/issues/5971) for it currently, but only 5hrs old).