### PR TITLE
Fix close_door bug without obstruction sensor

### DIFF
--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -462,9 +462,13 @@ namespace ratgdo {
 
         if (this->obstruction_sensor_detected_) {
             this->door_action(DoorAction::CLOSE);
-        } else if (*this->door_state == DoorState::OPEN) {
-            ESP_LOGD(TAG, "No obstruction sensors detected. Close using TOGGLE.");
-            this->door_action(DoorAction::TOGGLE);
+        } else {
+            if (*this->door_state == DoorState::OPEN || *this->door_state == DoorState::STOPPED) {
+                ESP_LOGD(TAG, "No obstruction sensors detected. Close using TOGGLE.");
+                this->door_action(DoorAction::TOGGLE);
+            } else {
+                this->door_action(DoorAction::CLOSE);
+            }
         }
 
         if (*this->closing_duration > 0) {


### PR DESCRIPTION
With the old code, the door would not close the door when stopped, if you don't have the obstruction sensor connect (e.g door stopped)