### PR TITLE
Correct ID and friendlyname for v32 drycontact yaml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
             name: V32 Board Security+ 1.0
             manifest_filename: v32board_secplusv1-manifest.json
           - file: v32board_drycontact.yaml
-            name: V32 Board Board Dry Contact
+            name: V32 Board Dry Contact
             manifest_filename: v32board_drycontact-manifest.json
           - file: v32disco.yaml
             name: V32 Disco Board Security+ 2.0

--- a/static/v32board_drycontact.yaml
+++ b/static/v32board_drycontact.yaml
@@ -1,7 +1,7 @@
 ---
 substitutions:
-  id_prefix: ratgdo32disco
-  friendly_name: "ratgdo32disco"
+  id_prefix: ratgdov32
+  friendly_name: "ratgdov32"
   uart_tx_pin: GPIO17
   uart_rx_pin: GPIO21
   input_obst_pin: GPIO4


### PR DESCRIPTION
Quick typo fix, I believe these are the only reference out of place. This lines the v32 dry contact board naming up with the other types.

If we really do want to make it consistent for the model names, it should probably be `ratgdo32` for all three (sec+ builds as well) :innocent: I'll make a commit for that if we want. 