### PR TITLE
Dry Contact Limit sensor improvements

### DIFF
--- a/components/ratgdo/dry_contact.cpp
+++ b/components/ratgdo/dry_contact.cpp
@@ -92,12 +92,12 @@ namespace ratgdo {
 
         void DryContact::door_action(DoorAction action)
         {
-            if (action == DoorAction::OPEN && this->door_state_ != DoorState::CLOSED) {
-                ESP_LOGW(TAG, "The door is not closed. Ignoring door action: %s", LOG_STR_ARG(DoorAction_to_string(action)));
+            if (action == DoorAction::OPEN && this->limits_.open_limit_reached) {
+                ESP_LOGW(TAG, "The door is already fully open. Ignoring door action: %s", LOG_STR_ARG(DoorAction_to_string(action)));
                 return;
             }
-            if (action == DoorAction::CLOSE && this->door_state_ != DoorState::OPEN) {
-                ESP_LOGW(TAG, "The door is not open. Ignoring door action: %s", LOG_STR_ARG(DoorAction_to_string(action)));
+            if (action == DoorAction::CLOSE && this->limits_.close_limit_reached) {
+                ESP_LOGW(TAG, "The door is already fully closed. Ignoring door action: %s", LOG_STR_ARG(DoorAction_to_string(action)));
                 return;
             }
 

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -920,6 +920,7 @@ namespace ratgdo {
         dry_contact_open_sensor_ = dry_contact_open_sensor;
         dry_contact_open_sensor_->add_on_state_callback([this](bool sensor_value) {
             this->protocol_->set_open_limit(sensor_value);
+            this->door_position = 1.0;
         });
     }
 
@@ -928,6 +929,7 @@ namespace ratgdo {
         dry_contact_close_sensor_ = dry_contact_close_sensor;
         dry_contact_close_sensor_->add_on_state_callback([this](bool sensor_value) {
             this->protocol_->set_close_limit(sensor_value);
+            this->door_position = 0.0;
         });
     }
 


### PR DESCRIPTION
All dry-contact setups require two limit switches for the open+closed positions. We can utilize these sensors for additional checks and awareness, especially with the OPEN status potentially representing a partially-opened state. 

- The existing checks for the open+closed state in `dry_contact.cpp` are updated to check the sensors before ignoring the open/close command. 
  - This resolves behavior following a reboot with the door positioned partway, the resulting DoorState::UNKNOWN would cause both cover up+down commands to be declined. 
  - It also prevents additional "close" commands while closed from bouncing the door into an inverted state. 

- The limit sensor methods in `ratgdo.cpp` are updated to manually set the door position for the cover once triggered. 
  - This fixes if out-of-sync due to the wall button/obstacle sensor, but requires a "check-in" to a sensor.
    - This could also be fixed or added to by handling the obstruction sensor event to set `Opening` state.
  - The code states this should ideally be done in `drycontact::sync`, for testing i've set them in the main routine. The sensors and door state could potentially be tracked there more efficiently. 

Prerequisite for: 
https://github.com/ratgdo/esphome-ratgdo/pull/396
https://github.com/ratgdo/esphome-ratgdo/pull/401