### PR TITLE
Change ID and friendlyname of v32 boards to better match branding

### DIFF
--- a/static/v32board.yaml
+++ b/static/v32board.yaml
@@ -1,7 +1,7 @@
 ---
 substitutions:
-  id_prefix: ratgdov32
-  friendly_name: "ratgdov32"
+  id_prefix: ratgdo32
+  friendly_name: "ratgdo32"
   uart_tx_pin: GPIO17
   uart_rx_pin: GPIO21
   input_obst_pin: GPIO4

--- a/static/v32board_drycontact.yaml
+++ b/static/v32board_drycontact.yaml
@@ -1,7 +1,7 @@
 ---
 substitutions:
-  id_prefix: ratgdov32
-  friendly_name: "ratgdov32"
+  id_prefix: ratgdo32
+  friendly_name: "ratgdo32"
   uart_tx_pin: GPIO17
   uart_rx_pin: GPIO21
   input_obst_pin: GPIO4

--- a/static/v32board_secplusv1.yaml
+++ b/static/v32board_secplusv1.yaml
@@ -1,7 +1,7 @@
 ---
 substitutions:
-  id_prefix: ratgdov32
-  friendly_name: "ratgdov32"
+  id_prefix: ratgdo32
+  friendly_name: "ratgdo32"
   uart_tx_pin: GPIO17
   uart_rx_pin: GPIO21
   input_obst_pin: GPIO4


### PR DESCRIPTION
I probably should have proposed this as part of https://github.com/ratgdo/esphome-ratgdo/pull/397 rather than following convention. The v32 boards are documented as `ratgdo32` and `ratgdo32disco`, makes sense to have the yaml names reflect this.