### PR TITLE
If obstruction sensor is triggered during CLOSING, set door state to OPENING

### DIFF
--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -466,6 +466,12 @@ namespace ratgdo {
                     // if the line is high and was last asleep more than 700ms ago, then there is an obstruction present
                     if (current_millis - last_asleep > 700) {
                         this->obstruction_state = ObstructionState::OBSTRUCTED;
+
+                        if (*this->door_state == DoorState::CLOSING) {
+                            this->received(DoorState::OPENING);
+                            // If obstruction sensor is tripped during closing,
+                            // assume the motor has reversed direction.
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Partially addresses https://github.com/ratgdo/esphome-ratgdo/issues/344. Likely need to handle the low-pulse condition differently. 

Curious if this applies only to dry contact protocol, I noticed the wiring diagrams for the other protocols also include these sensors. 