### PR TITLE
fix: update deprecated ESPHome schemas for 2025.6.0 compatibility

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -1,4 +1,7 @@
 ---
+esphome:
+  min_version: 2025.6.0
+
 external_components:
   - source:
       type: git

--- a/base_drycontact.yaml
+++ b/base_drycontact.yaml
@@ -1,4 +1,6 @@
 ---
+esphome:
+  min_version: 2025.6.0
 
 external_components:
   - source:

--- a/base_secplusv1.yaml
+++ b/base_secplusv1.yaml
@@ -1,4 +1,6 @@
 ---
+esphome:
+  min_version: 2025.6.0
 
 external_components:
   - source:

--- a/components/ratgdo/cover/__init__.py
+++ b/components/ratgdo/cover/__init__.py
@@ -24,20 +24,24 @@ CONF_ON_OPENING = "on_opening"
 CONF_ON_CLOSING = "on_closing"
 CONF_ON_STATE_CHANGE = "on_state_change"
 
-CONFIG_SCHEMA = cover.COVER_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(RATGDOCover),
-        cv.Optional(CONF_ON_OPENING): automation.validate_automation(
-            {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(CoverOpeningTrigger)}
-        ),
-        cv.Optional(CONF_ON_CLOSING): automation.validate_automation(
-            {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(CoverClosingTrigger)}
-        ),
-        cv.Optional(CONF_ON_STATE_CHANGE): automation.validate_automation(
-            {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(CoverStateTrigger)}
-        ),
-    }
-).extend(RATGDO_CLIENT_SCHMEA)
+CONFIG_SCHEMA = (
+    cover.cover_schema()
+    .extend(
+        {
+            cv.GenerateID(): cv.declare_id(RATGDOCover),
+            cv.Optional(CONF_ON_OPENING): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(CoverOpeningTrigger)}
+            ),
+            cv.Optional(CONF_ON_CLOSING): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(CoverClosingTrigger)}
+            ),
+            cv.Optional(CONF_ON_STATE_CHANGE): automation.validate_automation(
+                {cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(CoverStateTrigger)}
+            ),
+        }
+    )
+    .extend(RATGDO_CLIENT_SCHMEA)
+)
 
 
 async def to_code(config):

--- a/components/ratgdo/lock/__init__.py
+++ b/components/ratgdo/lock/__init__.py
@@ -9,11 +9,15 @@ DEPENDENCIES = ["ratgdo"]
 
 RATGDOLock = ratgdo_ns.class_("RATGDOLock", lock.Lock, cg.Component)
 
-CONFIG_SCHEMA = lock.LOCK_SCHEMA.extend(
-    {
-        cv.GenerateID(): cv.declare_id(RATGDOLock),
-    }
-).extend(RATGDO_CLIENT_SCHMEA)
+CONFIG_SCHEMA = (
+    lock.lock_schema()
+    .extend(
+        {
+            cv.GenerateID(): cv.declare_id(RATGDOLock),
+        }
+    )
+    .extend(RATGDO_CLIENT_SCHMEA)
+)
 
 
 async def to_code(config):


### PR DESCRIPTION
## Summary

This PR updates the esphome-ratgdo component to use the new ESPHome schema functions, replacing deprecated uppercase schema constants that will be removed in ESPHome 2025.11.0.

## Changes

### Schema Updates
- Updated `lock.LOCK_SCHEMA` → `lock.lock_schema()` in `components/ratgdo/lock/__init__.py`
- Updated `cover.COVER_SCHEMA` → `cover.cover_schema()` in `components/ratgdo/cover/__init__.py`

### Configuration Updates
- Set minimum ESPHome version to `2025.6.0` in all base YAML files:
  - `base.yaml`
  - `base_drycontact.yaml`
  - `base_secplusv1.yaml`

## Context

ESPHome is deprecating the uppercase schema constants (e.g., `LOCK_SCHEMA`, `COVER_SCHEMA`) in favor of lowercase function calls (e.g., `lock_schema()`, `cover_schema()`). These deprecated schemas will be completely removed in ESPHome 2025.11.0.

This change ensures the ratgdo component remains compatible with future ESPHome releases and eliminates deprecation warnings for users.

## Testing

- [x] Code follows ESPHome's new schema pattern
- [x] All other components already use the modern schema functions
- [ ] Tested with ESPHome 2025.6.0

## Related Issues

Fixes #414