### PR TITLE
Fix remaining C++20 implicit lambda captures

### DIFF
--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -602,7 +602,7 @@ namespace ratgdo {
     {
         if (*this->door_state == DoorState::OPENING || *this->door_state == DoorState::CLOSING) {
             this->door_action(DoorAction::STOP);
-            this->on_door_state_([this](DoorState s) {
+            this->on_door_state_([this, position](DoorState s) {
                 if (s == DoorState::STOPPED) {
                     this->door_move_to_position(position);
                 }
@@ -749,10 +749,10 @@ namespace ratgdo {
         auto name = "door_state" + std::to_string(num++);
 
         this->door_state.subscribe([this, f, name](DoorState state) {
-            defer(name, [this, f] { f(state, *this->door_position); });
+            defer(name, [this, f, state] { f(state, *this->door_position); });
         });
         this->door_position.subscribe([this, f, name](float position) {
-            defer(name, [this, f] { f(*this->door_state, position); });
+            defer(name, [this, f, position] { f(*this->door_state, position); });
         });
     }
     void RATGDOComponent::subscribe_light_state(std::function<void(LightState)>&& f)

--- a/components/ratgdo/secplus1.cpp
+++ b/components/ratgdo/secplus1.cpp
@@ -99,7 +99,7 @@ namespace ratgdo {
                         index = 15;
                     }
                 }
-                this->scheduler_->set_timeout(this->ratgdo_, "wall_panel_emulation", 250, [this] {
+                this->scheduler_->set_timeout(this->ratgdo_, "wall_panel_emulation", 250, [this, index] {
                     this->wall_panel_emulation(index);
                 });
             }

--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -110,7 +110,7 @@ namespace ratgdo {
                 if (tries % 3 == 0) {
                     delay *= 1.5;
                 }
-                this->scheduler_->set_timeout(this->ratgdo_, "sync", delay, [this]() {
+                this->scheduler_->set_timeout(this->ratgdo_, "sync", delay, [this, start, delay, tries]() {
                     this->sync_helper(start, delay, tries + 1);
                 });
             };
@@ -176,7 +176,7 @@ namespace ratgdo {
         void Secplus2::door_command(DoorAction action)
         {
             this->send_command(Command(CommandType::DOOR_ACTION, static_cast<uint8_t>(action), 1, 1), IncrementRollingCode::NO, [this]() {
-                this->scheduler_->set_timeout(this->ratgdo_, "", 150, [this] {
+                this->scheduler_->set_timeout(this->ratgdo_, "", 150, [this, action] {
                     this->send_command(Command(CommandType::DOOR_ACTION, static_cast<uint8_t>(action), 0, 1));
                 });
             });
@@ -204,7 +204,7 @@ namespace ratgdo {
             uint32_t timeout = 0;
             for (auto kind : kinds) {
                 timeout += 200;
-                this->scheduler_->set_timeout(this->ratgdo_, "", timeout, [this] { this->query_paired_devices(kind); });
+                this->scheduler_->set_timeout(this->ratgdo_, "", timeout, [this, kind] { this->query_paired_devices(kind); });
             }
         }
 
@@ -232,7 +232,7 @@ namespace ratgdo {
                 uint8_t dev_kind = static_cast<uint8_t>(kind) - 1;
                 this->send_command(Command { CommandType::CLEAR_PAIRED_DEVICES, dev_kind }); // just requested device
                 this->scheduler_->set_timeout(this->ratgdo_, "", 200, [this] { this->query_status(); });
-                this->scheduler_->set_timeout(this->ratgdo_, "", 400, [this] { this->query_paired_devices(kind); });
+                this->scheduler_->set_timeout(this->ratgdo_, "", 400, [this, kind] { this->query_paired_devices(kind); });
             }
         }
 


### PR DESCRIPTION
## Summary
This PR completes the C++20 lambda capture fixes that were started in #433. Several lambdas were still missing explicit captures, causing compilation failures with the newer ESPHome toolchain.

## Changes
Fixed implicit lambda captures in the following locations:

### components/ratgdo/secplus1.cpp
- Line 102: Added `index` to capture list for `wall_panel_emulation` callback

### components/ratgdo/ratgdo.cpp  
- Line 605: Added `position` to capture list for `door_move_to_position` callback
- Line 752: Added `state` to capture list in `subscribe_door_state` defer callback
- Line 755: Added `position` to capture list in `subscribe_door_state` defer callback

### components/ratgdo/secplus2.cpp
- Line 113: Added `start`, `delay`, `tries` to capture list for `sync_helper` callback
- Line 179: Added `action` to capture list for `door_command` callback
- Line 207: Added `kind` to capture list for `query_paired_devices` callback
- Line 235: Added `kind` to capture list for `clear_paired_devices` callback

## Technical Details
C++20 deprecated implicit lambda captures by copy. All variables from the enclosing scope that are used within a lambda must now be explicitly listed in the capture clause. This ensures clearer intent and prevents accidental captures.

## Testing
These changes fix the compilation errors seen in CI:
- `error: 'variable' is not captured`
- `note: the lambda has no capture-default`

All lambdas now properly capture the variables they reference, allowing successful compilation with C++20.