### PR TITLE
Fix CI to test local code instead of fetching from GitHub

### DIFF
--- a/scripts/update_refs_for_ci.py
+++ b/scripts/update_refs_for_ci.py
@@ -1,52 +1,19 @@
 #!/usr/bin/env python3
-"""Update YAML files to use current Git branch instead of main."""
+"""Update YAML files to use local paths instead of GitHub URLs for CI testing."""
 
-import json
 import os
 import re
 import sys
 from pathlib import Path
-from typing import Optional, Tuple
-
-RATGDO_REPO = "ratgdo/esphome-ratgdo"
-
-
-def get_pr_info() -> Tuple[str, Optional[str]]:
-    """Get PR branch and repository info from GitHub environment."""
-    # For PRs, check GITHUB_REF first
-    github_ref = os.environ.get("GITHUB_REF", "")
-    if "/pull/" in github_ref:
-        # It's a PR, get info from event file
-        github_event_path = os.environ.get("GITHUB_EVENT_PATH")
-        if github_event_path and os.path.exists(github_event_path):
-            with open(github_event_path) as f:
-                event_data = json.load(f)
-                pr_data = event_data.get("pull_request", {})
-                head = pr_data.get("head", {})
-                branch = head.get("ref", "main")
-                repo = head.get("repo", {})
-                fork_repo = repo.get("full_name")  # e.g., "someuser/esphome-ratgdo"
-                return branch, fork_repo
-
-    # For pushes, extract branch from GITHUB_REF
-    if github_ref.startswith("refs/heads/"):
-        branch = github_ref.replace("refs/heads/", "")
-        return branch, None
-
-    return "main", None
 
 
 def main():
     """Main function."""
-    branch, fork_repo = get_pr_info()
+    # Get the absolute path to the project root
+    project_root = Path(__file__).parent.parent.absolute()
 
-    if branch == "main":
-        print("On main branch, skipping ref updates")
-        return 0
-
-    print(f"Updating refs to: {branch}")
-    if fork_repo and fork_repo != RATGDO_REPO:
-        print(f"Using fork repository: {fork_repo}")
+    print(f"Project root: {project_root}")
+    print("Updating YAML files to use local paths for CI testing...")
 
     # Process all YAML files
     for yaml_file in Path(".").glob("*.yaml"):
@@ -55,50 +22,44 @@ def main():
 
         original = content
 
-        # Only process files that reference the ratgdo repository
-        if RATGDO_REPO not in content and "ratgdo/esphome-ratgdo" not in content:
-            continue
-
-        # Update ref: main to ref: <branch>
-        content = re.sub(r"(\s+)ref:\s*main\b", rf"\1ref: {branch}", content)
-
-        # Update @main in dashboard imports
-        content = re.sub(r"@main\b", f"@{branch}", content)
-
-        # If this is a fork, update repository URLs
-        if fork_repo and fork_repo != RATGDO_REPO:
-            # Update repository URL in external_components
+        # Update external_components to use local path
+        if (
+            "external_components:" in content
+            and "type: git" in content
+            and "ratgdo/esphome-ratgdo" in content
+        ):
+            # Replace the git source with local source
             content = re.sub(
-                rf"(url:\s*https://github\.com/){RATGDO_REPO}",
-                rf"\1{fork_repo}",
+                r"(\s*-\s*source:\s*\n\s*)type:\s*git\s*\n\s*url:\s*https://github\.com/ratgdo/esphome-ratgdo\s*\n\s*ref:\s*\w+",
+                rf"\1type: local\n\1path: {project_root}/components",
                 content,
             )
-            # Update dashboard imports to use fork
+
+        # Update remote_package to use local path
+        if "remote_package:" in content:
+            # Replace URL with local path
             content = re.sub(
-                rf"github://{RATGDO_REPO}/", f"github://{fork_repo}/", content
+                r"(remote_package:\s*\n\s*)url:\s*https://github\.com/ratgdo/esphome-ratgdo",
+                rf"\1url: file://{project_root}",
+                content,
             )
+            # Remove ref if present (local doesn't need it)
+            content = re.sub(r"(\s+ref:\s*\w+\s*\n)(\s*files:)", r"\2", content)
 
-        # For remote_package sections without ref, add it after the URL
-        # Look for patterns like:
-        #   remote_package:
-        #     url: https://github.com/<repo>/esphome-ratgdo
-        #     files: [...]
-        repo_pattern = fork_repo if fork_repo else RATGDO_REPO
-        pattern = (
-            r"(remote_package:\s*\n\s*url:\s*https://github\.com/"
-            + repo_pattern.replace("/", r"\/")
-            + r"\s*\n)(\s*files:)"
-        )
-
-        # Check if this pattern exists without a ref line
-        if re.search(pattern, content) and not re.search(
-            pattern.replace(r"(\s*files:)", r"(\s*ref:.*\n\s*files:)"), content
-        ):
-            # Get the indentation from the url line
-            match = re.search(r"(remote_package:\s*\n(\s*)url:)", content)
+        # Update dashboard_import to point to local file
+        if "dashboard_import:" in content:
+            # Extract filename from the github URL
+            match = re.search(
+                r"github://ratgdo/esphome-ratgdo/(\S+\.yaml)@\w+", content
+            )
             if match:
-                indent = match.group(2)
-                content = re.sub(pattern, rf"\1{indent}ref: {branch}\n\2", content)
+                filename = match.group(1)
+                # Replace with local file path
+                content = re.sub(
+                    r"(package_import_url:\s*)github://ratgdo/esphome-ratgdo/\S+\.yaml@\w+",
+                    rf"\1file://{project_root}/{filename}",
+                    content,
+                )
 
         if content != original:
             with open(yaml_file, "w") as f:


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where the CI system was not actually testing the code from pull requests and branches. Even though PR #438 updated YAML files to reference the correct branch, ESPHome would still fetch components from GitHub, meaning we were always testing against the wrong code.

This change modifies the `update_refs_for_ci.py` script to replace all GitHub references with local file paths, ensuring that CI tests use the actual checked-out code.

## Problem

Previously, the CI workflow would:
1. Check out the PR/branch code
2. Update YAML files to point to the correct branch (e.g., `ref: main` → `ref: feature-branch`)
3. ESPHome would still fetch from GitHub, effectively ignoring the local changes

This meant that:
- Pull requests weren't testing their actual changes
- Branch builds were testing the wrong code
- Component changes couldn't be properly validated before merging

## Solution

The updated script now replaces all GitHub references with local paths:

### External Components
**Before:**
```yaml
external_components:
  - source:
      type: git
      url: https://github.com/ratgdo/esphome-ratgdo
      ref: main
```

**After:**
```yaml
external_components:
  - source:
      type: local
      path: /path/to/project/components
```

### Remote Packages
**Before:**
```yaml
packages:
  remote_package:
    url: https://github.com/ratgdo/esphome-ratgdo
    ref: main
    files: [base.yaml]
```

**After:**
```yaml
packages:
  remote_package:
    url: file:///path/to/project
    files: [base.yaml]
```

### Dashboard Imports
**Before:**
```yaml
dashboard_import:
  package_import_url: github://ratgdo/esphome-ratgdo/v25board.yaml@main
```

**After:**
```yaml
dashboard_import:
  package_import_url: file:///path/to/project/v25board.yaml
```

## Changes Made

1. **Modified `scripts/update_refs_for_ci.py`**:
   - Removed branch/fork detection logic (no longer needed)
   - Added logic to replace git sources with local paths
   - Updated remote package URLs to use `file://` protocol
   - Simplified dashboard import handling

2. **Updated `tests/scripts/test_update_refs_for_ci.py`**:
   - Removed tests for branch/fork detection
   - Added tests for local path conversion
   - Ensured all conversion patterns are tested

## Testing

- All existing tests have been updated and pass
- The script correctly handles all three types of references (external_components, remote_package, dashboard_import)
- Files that don't contain ratgdo references are left unchanged
- ESPHome tags and formatting are preserved

## Impact

This ensures that:
- Pull requests test their actual code changes
- Branch builds validate the correct components
- CI results accurately reflect the state of the code being tested

Fixes the issue identified in PR #438 where CI was not effectively testing branch-specific changes.