### PR TITLE
Fix remaining lambda capture issue in secplus2.cpp

### DIFF
--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -175,7 +175,7 @@ namespace ratgdo {
 
         void Secplus2::door_command(DoorAction action)
         {
-            this->send_command(Command(CommandType::DOOR_ACTION, static_cast<uint8_t>(action), 1, 1), IncrementRollingCode::NO, [this]() {
+            this->send_command(Command(CommandType::DOOR_ACTION, static_cast<uint8_t>(action), 1, 1), IncrementRollingCode::NO, [this, action]() {
                 this->scheduler_->set_timeout(this->ratgdo_, "", 150, [this, action] {
                     this->send_command(Command(CommandType::DOOR_ACTION, static_cast<uint8_t>(action), 0, 1));
                 });


### PR DESCRIPTION

This PR fixes a lambda capture issue that was missed in previous PRs #433 and #440. The outer lambda in `Secplus2::door_command` was not capturing the `action` parameter, which caused compilation errors when the inner lambda tried to access it.
