### PR TITLE
Fix ESP8266 LoadStoreError crash in wall panel emulation due to PROGMEM access

### DIFF
--- a/components/ratgdo/secplus1.cpp
+++ b/components/ratgdo/secplus1.cpp
@@ -3,6 +3,7 @@
 #include "ratgdo.h"
 
 #include "esphome/core/gpio.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 #include "esphome/core/scheduler.h"
 
@@ -82,14 +83,28 @@ namespace ratgdo {
                 });
                 return;
             } else if (this->wall_panel_emulation_state_ == WallPanelEmulationState::RUNNING) {
+#ifdef USE_ESP8266
+                // ESP_LOG2(TAG, "[Wall panel emulation] Sending byte: [%02X]", progmem_read_byte(&secplus1_states[index]));
+#else
                 // ESP_LOG2(TAG, "[Wall panel emulation] Sending byte: [%02X]", secplus1_states[index]);
+#endif
 
                 if (index < 15 || !this->do_transmit_if_pending()) {
+#ifdef USE_ESP8266
+                    this->transmit_byte(progmem_read_byte(&secplus1_states[index]));
+#else
                     this->transmit_byte(secplus1_states[index]);
+#endif
                     // gdo response simulation for testing
+#ifdef USE_ESP8266
+                    // auto resp = progmem_read_byte(&secplus1_states[index]) == 0x39 ? 0x00 :
+                    //             progmem_read_byte(&secplus1_states[index]) == 0x3A ? 0x5C :
+                    //             progmem_read_byte(&secplus1_states[index]) == 0x38 ? 0x52 : 0xFF;
+#else
                     // auto resp = secplus1_states[index] == 0x39 ? 0x00 :
                     //             secplus1_states[index] == 0x3A ? 0x5C :
                     //             secplus1_states[index] == 0x38 ? 0x52 : 0xFF;
+#endif
                     // if (resp != 0xFF) {
                     //     this->transmit_byte(resp, true);
                     // }


### PR DESCRIPTION
# Summary
This PR fixes a critical crash on ESP8266 devices that occurs when the Security+ 1.0 wall panel emulation enters "RUNNING" mode. The crash manifests as a LoadStoreError exception when trying to access the `secplus1_states` array.

## Root Cause
In commit a2d71d3 (PR #428 "Reduce memory needed"), the `secplus1_states` array was changed to use PROGMEM for memory optimization. However, the code continued to access this array directly, which works on ESP32 but causes a processor exception on ESP8266.

On ESP8266, PROGMEM data is stored in flash memory which requires special accessor functions (`progmem_read_byte()`) to read. Direct array access attempts to read from an invalid memory address, resulting in the LoadStoreError.

## Changes
- Added conditional compilation to use `progmem_read_byte()` for ESP8266 while maintaining direct access on ESP32
- Fixed all three locations where `secplus1_states` is accessed (one active code path, two commented sections)
- Added include for `esphome/core/hal.h` to get the `progmem_read_byte()` function

## Testing
This fix should be tested on:
- ESP8266 devices with Security+ 1.0 garage door openers
- ESP32 devices to ensure no regression
- Both with and without physical wall panels present (to trigger emulation mode)

## Related Issues
Fixes #450 - "Not sync after update"