### PR TITLE
fix: add ifdef guards to protocol implementation files for conditional compilation

### DIFF
--- a/components/ratgdo/dry_contact.cpp
+++ b/components/ratgdo/dry_contact.cpp
@@ -1,4 +1,6 @@
 
+#ifdef PROTOCOL_DRYCONTACT
+
 #include "dry_contact.h"
 #include "esphome/core/gpio.h"
 #include "esphome/core/log.h"
@@ -129,3 +131,5 @@ namespace ratgdo {
     } // namespace dry_contact
 } // namespace ratgdo
 } // namespace esphome
+
+#endif // PROTOCOL_DRYCONTACT

--- a/components/ratgdo/dry_contact.h
+++ b/components/ratgdo/dry_contact.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifdef PROTOCOL_DRYCONTACT
+
 #include "esphome/core/defines.h"
 
 #include "SoftwareSerial.h" // Using espsoftwareserial https://github.com/plerup/espsoftwareserial
@@ -81,3 +83,5 @@ namespace ratgdo {
     } // namespace dry_contact
 } // namespace ratgdo
 } // namespace esphome
+
+#endif // PROTOCOL_DRYCONTACT

--- a/components/ratgdo/secplus1.cpp
+++ b/components/ratgdo/secplus1.cpp
@@ -1,4 +1,6 @@
 
+#ifdef PROTOCOL_SECPLUSV1
+
 #include "secplus1.h"
 #include "ratgdo.h"
 
@@ -451,3 +453,5 @@ namespace ratgdo {
     } // namespace secplus1
 } // namespace ratgdo
 } // namespace esphome
+
+#endif // PROTOCOL_SECPLUSV1

--- a/components/ratgdo/secplus1.h
+++ b/components/ratgdo/secplus1.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifdef PROTOCOL_SECPLUSV1
+
 #include <queue>
 
 #include "SoftwareSerial.h" // Using espsoftwareserial https://github.com/plerup/espsoftwareserial
@@ -161,3 +163,5 @@ namespace ratgdo {
     } // namespace secplus1
 } // namespace ratgdo
 } // namespace esphome
+
+#endif // PROTOCOL_SECPLUSV1

--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -1,4 +1,6 @@
 
+#ifdef PROTOCOL_SECPLUSV2
+
 #include "secplus2.h"
 #include "ratgdo.h"
 
@@ -510,3 +512,5 @@ namespace ratgdo {
     } // namespace secplus2
 } // namespace ratgdo
 } // namespace esphome
+
+#endif // PROTOCOL_SECPLUSV2

--- a/components/ratgdo/secplus2.h
+++ b/components/ratgdo/secplus2.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#ifdef PROTOCOL_SECPLUSV2
+
 #include "SoftwareSerial.h" // Using espsoftwareserial https://github.com/plerup/espsoftwareserial
 #include "esphome/core/optional.h"
 
@@ -166,3 +168,5 @@ namespace ratgdo {
     } // namespace secplus2
 } // namespace ratgdo
 } // namespace esphome
+
+#endif // PROTOCOL_SECPLUSV2


### PR DESCRIPTION
## Summary
- Added preprocessor ifdef guards around protocol implementation files to prevent compilation of unused protocols
- Each protocol (secplusv1, secplusv2, dry_contact) is now only compiled when its corresponding define is set
- Reduces compilation time by excluding unused protocol code

## Changes
- Wrapped `secplus2.cpp` and `secplus2.h` with `#ifdef PROTOCOL_SECPLUSV2`
- Wrapped `secplus1.cpp` and `secplus1.h` with `#ifdef PROTOCOL_SECPLUSV1`
- Wrapped `dry_contact.cpp` and `dry_contact.h` with `#ifdef PROTOCOL_DRYCONTACT`

## Benefits
- Faster compilation times when building firmware for a specific protocol
- Reduced binary size by excluding unused protocol implementations
- Consistent with the existing ifdef usage in `ratgdo.cpp` for protocol instantiation

