### PR TITLE
Simplify configuration by auto-detecting ratgdo_id

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -65,7 +65,6 @@ sensor:
     id: ${id_prefix}_openings
     type: openings
     entity_category: diagnostic
-    ratgdo_id: ${id_prefix}
     name: "Openings"
     unit_of_measurement: "openings"
     icon: mdi:open-in-app
@@ -73,14 +72,12 @@ sensor:
     id: ${id_prefix}_paired_devices_total
     type: paired_devices_total
     entity_category: diagnostic
-    ratgdo_id: ${id_prefix}
     name: "Paired Devices"
     icon: mdi:remote
 
 lock:
   - platform: ratgdo
     id: ${id_prefix}_lock_remotes
-    ratgdo_id: ${id_prefix}
     name: "Lock remotes"
 
 switch:
@@ -105,7 +102,6 @@ switch:
   - platform: ratgdo
     id: "${id_prefix}_learn"
     type: learn
-    ratgdo_id: ${id_prefix}
     name: "Learn"
     icon: mdi:plus-box
     entity_category: config
@@ -114,13 +110,11 @@ binary_sensor:
   - platform: ratgdo
     type: motion
     id: ${id_prefix}_motion
-    ratgdo_id: ${id_prefix}
     name: "Motion"
     device_class: motion
   - platform: ratgdo
     type: obstruction
     id: ${id_prefix}_obstruction
-    ratgdo_id: ${id_prefix}
     name: "Obstruction"
     device_class: problem
     on_press:
@@ -130,13 +124,11 @@ binary_sensor:
   - platform: ratgdo
     type: button
     id: ${id_prefix}_button
-    ratgdo_id: ${id_prefix}
     name: "Button"
     entity_category: diagnostic
   - platform: ratgdo
     type: motor
     id: ${id_prefix}_motor
-    ratgdo_id: ${id_prefix}
     name: "Motor"
     device_class: running
     entity_category: diagnostic
@@ -216,7 +208,6 @@ number:
     id: ${id_prefix}_rolling_code_counter
     type: rolling_code_counter
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Rolling code counter"
     mode: box
     unit_of_measurement: "codes"
@@ -225,7 +216,6 @@ number:
     id: ${id_prefix}_opening_duration
     type: opening_duration
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Opening duration"
     unit_of_measurement: "s"
 
@@ -233,7 +223,6 @@ number:
     id: ${id_prefix}_closing_duration
     type: closing_duration
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Closing duration"
     unit_of_measurement: "s"
 
@@ -241,7 +230,6 @@ number:
     id: ${id_prefix}_client_id
     type: client_id
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Client ID"
     mode: box
 
@@ -250,7 +238,6 @@ cover:
     id: ${id_prefix}_garage_door
     device_class: garage
     name: "Door"
-    ratgdo_id: ${id_prefix}
     on_closed:
       - switch.turn_off: ${id_prefix}_status_door
     on_open:
@@ -260,7 +247,6 @@ light:
   - platform: ratgdo
     id: ${id_prefix}_light
     name: "Light"
-    ratgdo_id: ${id_prefix}
 
 button:
   - platform: restart

--- a/base_drycontact.yaml
+++ b/base_drycontact.yaml
@@ -43,7 +43,6 @@ binary_sensor:
   - platform: ratgdo
     type: obstruction
     id: ${id_prefix}_obstruction
-    ratgdo_id: ${id_prefix}
     name: "Obstruction"
     device_class: problem
   - platform: gpio
@@ -76,7 +75,6 @@ number:
     id: ${id_prefix}_opening_duration
     type: opening_duration
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Opening duration"
     unit_of_measurement: "s"
 
@@ -84,7 +82,6 @@ number:
     id: ${id_prefix}_closing_duration
     type: closing_duration
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Closing duration"
     unit_of_measurement: "s"
 
@@ -93,7 +90,6 @@ cover:
     id: ${id_prefix}_garage_door
     device_class: garage
     name: "Door"
-    ratgdo_id: ${id_prefix}
 
 button:
   - platform: restart

--- a/base_secplusv1.yaml
+++ b/base_secplusv1.yaml
@@ -46,7 +46,6 @@ ota:
 lock:
   - platform: ratgdo
     id: ${id_prefix}_lock_remotes
-    ratgdo_id: ${id_prefix}
     name: "Lock remotes"
 
 switch:
@@ -73,13 +72,11 @@ binary_sensor:
   - platform: ratgdo
     type: motion
     id: ${id_prefix}_motion
-    ratgdo_id: ${id_prefix}
     name: "Motion"
     device_class: motion
   - platform: ratgdo
     type: obstruction
     id: ${id_prefix}_obstruction
-    ratgdo_id: ${id_prefix}
     name: "Obstruction"
     device_class: problem
     on_press:
@@ -89,7 +86,6 @@ binary_sensor:
   - platform: ratgdo
     type: button
     id: ${id_prefix}_button
-    ratgdo_id: ${id_prefix}
     name: "Button"
     entity_category: diagnostic
   - platform: gpio
@@ -168,7 +164,6 @@ number:
     id: ${id_prefix}_rolling_code_counter
     type: rolling_code_counter
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Rolling code counter"
     mode: box
     unit_of_measurement: "codes"
@@ -177,7 +172,6 @@ number:
     id: ${id_prefix}_opening_duration
     type: opening_duration
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Opening duration"
     unit_of_measurement: "s"
 
@@ -185,7 +179,6 @@ number:
     id: ${id_prefix}_closing_duration
     type: closing_duration
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Closing duration"
     unit_of_measurement: "s"
 
@@ -193,7 +186,6 @@ number:
     id: ${id_prefix}_client_id
     type: client_id
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Client ID"
     mode: box
 
@@ -202,7 +194,6 @@ cover:
     id: ${id_prefix}_garage_door
     device_class: garage
     name: "Door"
-    ratgdo_id: ${id_prefix}
     on_closed:
       - switch.turn_off: ${id_prefix}_status_door
     on_open:
@@ -212,7 +203,6 @@ light:
   - platform: ratgdo
     id: ${id_prefix}_light
     name: "Light"
-    ratgdo_id: ${id_prefix}
 
 button:
   - platform: restart

--- a/components/ratgdo/__init__.py
+++ b/components/ratgdo/__init__.py
@@ -103,7 +103,7 @@ CONFIG_SCHEMA = cv.All(
 
 RATGDO_CLIENT_SCHMEA = cv.Schema(
     {
-        cv.Required(CONF_RATGDO_ID): cv.use_id(RATGDO),
+        cv.GenerateID(CONF_RATGDO_ID): cv.use_id(RATGDO),
     }
 )
 

--- a/static/customized_examples/v32board_gate_party_mode.yaml
+++ b/static/customized_examples/v32board_gate_party_mode.yaml
@@ -38,7 +38,6 @@ packages:
 
 switch:
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_led
     type: led
     pin: GPIO2

--- a/static/v32board.yaml
+++ b/static/v32board.yaml
@@ -39,7 +39,6 @@ packages:
 
 switch:
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_led
     type: led
     pin: GPIO2

--- a/static/v32board_drycontact.yaml
+++ b/static/v32board_drycontact.yaml
@@ -38,7 +38,6 @@ packages:
 
 switch:
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_led
     type: led
     pin: GPIO2

--- a/static/v32board_secplusv1.yaml
+++ b/static/v32board_secplusv1.yaml
@@ -39,7 +39,6 @@ packages:
 
 switch:
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_led
     type: led
     pin: GPIO2

--- a/static/v32disco.yaml
+++ b/static/v32disco.yaml
@@ -60,17 +60,14 @@ logger:
 
 binary_sensor:
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_vehicle_detected
     type: vehicle_detected
     name: "Vehicle detected"
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_vehicle_arriving
     type: vehicle_arriving
     name: "Vehicle arriving"
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_vehicle_leaving
     type: vehicle_leaving
     name: "Vehicle leaving"
@@ -80,7 +77,6 @@ number:
     id: ${id_prefix}_target_distance_measurement
     type: target_distance_measurement
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Vehicle distance target"
     mode: box
     unit_of_measurement: "mm"
@@ -88,7 +84,6 @@ number:
     id: ${id_prefix}_closing_delay
     type: closing_delay
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Closing Delay"
     unit_of_measurement: "s"
 
@@ -97,7 +92,6 @@ output:
     pin: GPIO33
     id: ${id_prefix}_ledc
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_beeper
     type: beeper
     rtttl: ${id_prefix}_rtttl
@@ -109,14 +103,12 @@ rtttl:
 
 switch:
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_led
     type: led
     pin: GPIO2
     name: "LED"
     entity_category: config
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_laser
     type: led
     pin: GPIO23
@@ -131,7 +123,6 @@ sensor:
     id: ${id_prefix}_vehicle_distance_actual
     type: distance
     name: "Vehicle distance actual"
-    ratgdo_id: ${id_prefix}
     unit_of_measurement: "mm"
     internal: true
     filters:

--- a/static/v32disco_drycontact.yaml
+++ b/static/v32disco_drycontact.yaml
@@ -56,17 +56,14 @@ logger:
 
 binary_sensor:
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_vehicle_detected
     type: vehicle_detected
     name: "Vehicle detected"
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_vehicle_arriving
     type: vehicle_arriving
     name: "Vehicle arriving"
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_vehicle_leaving
     type: vehicle_leaving
     name: "Vehicle leaving"
@@ -76,7 +73,6 @@ number:
     id: ${id_prefix}_target_distance_measurement
     type: target_distance_measurement
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Vehicle distance target"
     mode: box
     unit_of_measurement: "mm"
@@ -84,7 +80,6 @@ number:
     id: ${id_prefix}_closing_delay
     type: closing_delay
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Closing Delay"
     unit_of_measurement: "s"
 
@@ -93,7 +88,6 @@ output:
     pin: GPIO33
     id: ${id_prefix}_ledc
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_beeper
     type: beeper
     rtttl: ${id_prefix}_rtttl
@@ -105,14 +99,12 @@ rtttl:
 
 switch:
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_led
     type: led
     pin: GPIO2
     name: "LED"
     entity_category: config
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_laser
     type: led
     pin: GPIO23
@@ -127,7 +119,6 @@ sensor:
     id: ${id_prefix}_vehicle_distance_actual
     type: distance
     name: "Vehicle distance actual"
-    ratgdo_id: ${id_prefix}
     unit_of_measurement: "mm"
     internal: true
     filters:

--- a/static/v32disco_secplusv1.yaml
+++ b/static/v32disco_secplusv1.yaml
@@ -57,17 +57,14 @@ logger:
 
 binary_sensor:
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_vehicle_detected
     type: vehicle_detected
     name: "Vehicle detected"
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_vehicle_arriving
     type: vehicle_arriving
     name: "Vehicle arriving"
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_vehicle_leaving
     type: vehicle_leaving
     name: "Vehicle leaving"
@@ -77,7 +74,6 @@ number:
     id: ${id_prefix}_target_distance_measurement
     type: target_distance_measurement
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Vehicle distance target"
     mode: box
     unit_of_measurement: "mm"
@@ -85,7 +81,6 @@ number:
     id: ${id_prefix}_closing_delay
     type: closing_delay
     entity_category: config
-    ratgdo_id: ${id_prefix}
     name: "Closing Delay"
     unit_of_measurement: "s"
 
@@ -94,7 +89,6 @@ output:
     pin: GPIO33
     id: ${id_prefix}_ledc
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_beeper
     type: beeper
     rtttl: ${id_prefix}_rtttl
@@ -106,14 +100,12 @@ rtttl:
 
 switch:
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_led
     type: led
     pin: GPIO2
     name: "LED"
     entity_category: config
   - platform: ratgdo
-    ratgdo_id: ${id_prefix}
     id: ${id_prefix}_laser
     type: led
     pin: GPIO23
@@ -128,7 +120,6 @@ sensor:
     id: ${id_prefix}_vehicle_distance_actual
     type: distance
     name: "Vehicle distance actual"
-    ratgdo_id: ${id_prefix}
     unit_of_measurement: "mm"
     internal: true
     filters:


### PR DESCRIPTION
In configurations with only one instance of the 'ratgdo' component (nearly all of them), there is no need for the entity configurations to specify the ID of the component, as the schema can auto-detect it.