### PR TITLE
Enable ESP32 Improv WiFi provisioning (requires ESPHome 2025.10.0+)

### DIFF
--- a/static/v25board_esp32_d1_mini.yaml
+++ b/static/v25board_esp32_d1_mini.yaml
@@ -17,6 +17,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
+  min_version: 2025.10.0
   project:
     name: ratgdo.esphome
     version: "2.5"
@@ -44,6 +45,9 @@ api:
   id: api_server
 
 improv_serial:
+
+esp32_improv:
+  authorizer: none
 
 wifi:
   ap:

--- a/static/v25board_esp32_d1_mini_secplusv1.yaml
+++ b/static/v25board_esp32_d1_mini_secplusv1.yaml
@@ -17,6 +17,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
+  min_version: 2025.10.0
   project:
     name: ratgdo.esphome
     version: "2.5"
@@ -44,6 +45,9 @@ api:
   id: api_server
 
 improv_serial:
+
+esp32_improv:
+  authorizer: none
 
 wifi:
   ap:

--- a/static/v2board_esp32_d1_mini.yaml
+++ b/static/v2board_esp32_d1_mini.yaml
@@ -17,6 +17,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
+  min_version: 2025.10.0
   project:
     name: ratgdo.esphome
     version: "2.0"
@@ -44,6 +45,9 @@ api:
   id: api_server
 
 improv_serial:
+
+esp32_improv:
+  authorizer: none
 
 wifi:
   ap:

--- a/static/v2board_esp32_lolin_s2_mini.yaml
+++ b/static/v2board_esp32_lolin_s2_mini.yaml
@@ -17,6 +17,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
+  min_version: 2025.10.0
   project:
     name: ratgdo.esphome
     version: "2.0"
@@ -44,6 +45,9 @@ api:
   id: api_server
 
 improv_serial:
+
+esp32_improv:
+  authorizer: none
 
 wifi:
   ap:

--- a/static/v32board.yaml
+++ b/static/v32board.yaml
@@ -18,6 +18,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
+  min_version: 2025.10.0
   project:
     name: ratgdo.esphome
     version: "32.0"
@@ -61,6 +62,9 @@ api:
   id: api_server
 
 improv_serial:
+
+esp32_improv:
+  authorizer: none
 
 wifi:
   ap:

--- a/static/v32board_drycontact.yaml
+++ b/static/v32board_drycontact.yaml
@@ -17,6 +17,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
+  min_version: 2025.10.0
   project:
     name: ratgdo.esphome
     version: "32.0"
@@ -60,6 +61,9 @@ api:
   id: api_server
 
 improv_serial:
+
+esp32_improv:
+  authorizer: none
 
 wifi:
   ap:

--- a/static/v32board_secplusv1.yaml
+++ b/static/v32board_secplusv1.yaml
@@ -18,6 +18,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
+  min_version: 2025.10.0
   project:
     name: ratgdo.esphome
     version: "32.0"
@@ -61,6 +62,9 @@ api:
   id: api_server
 
 improv_serial:
+
+esp32_improv:
+  authorizer: none
 
 wifi:
   ap:

--- a/static/v32disco.yaml
+++ b/static/v32disco.yaml
@@ -19,6 +19,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
+  min_version: 2025.10.0
   project:
     name: ratgdo.esphome
     version: "32disco"
@@ -49,6 +50,9 @@ api:
   id: api_server
 
 improv_serial:
+
+esp32_improv:
+  authorizer: none
 
 wifi:
   ap:

--- a/static/v32disco_drycontact.yaml
+++ b/static/v32disco_drycontact.yaml
@@ -18,6 +18,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
+  min_version: 2025.10.0
   project:
     name: ratgdo.esphome
     version: "32disco"
@@ -48,6 +49,9 @@ api:
   id: api_server
 
 improv_serial:
+
+esp32_improv:
+  authorizer: none
 
 wifi:
   ap:

--- a/static/v32disco_secplusv1.yaml
+++ b/static/v32disco_secplusv1.yaml
@@ -19,6 +19,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
+  min_version: 2025.10.0
   project:
     name: ratgdo.esphome
     version: "32disco"
@@ -49,6 +50,9 @@ api:
   id: api_server
 
 improv_serial:
+
+esp32_improv:
+  authorizer: none
 
 wifi:
   ap:


### PR DESCRIPTION
## Summary
- Adds `esp32_improv` component to all ESP32 board configurations for Improv WiFi provisioning via Bluetooth
- Adds `min_version: 2025.10.0` requirement to ensure sufficient RAM availability
- This change is required for [Made for ESPHome](https://esphome.io/guides/made_for_esphome/) certification

## Background
ESPHome 2025.10.0 includes significant memory optimizations for ESP32 Arduino builds:

**Major RAM improvements:**
- Arduino as ESP-IDF component ([esphome/esphome#10647](https://github.com/esphome/esphome/pull/10647)): **20-30KB RAM savings**
- Native ESP-IDF web server ([esphome/esphome#10991](https://github.com/esphome/esphome/pull/10991)): **~8KB RAM savings**

**BLE Server optimizations:**
- Vector-based service storage ([esphome/esphome#10894](https://github.com/esphome/esphome/pull/10894)): **1KB flash savings + 26x faster lookups**
- Vector-based client storage ([esphome/esphome#10897](https://github.com/esphome/esphome/pull/10897)): **16 bytes static + ~70-77 bytes per client RAM + 658 bytes flash savings**
- Conditional automation compilation ([esphome/esphome#10910](https://github.com/esphome/esphome/pull/10910)): **88 bytes RAM + 4.4KB flash savings**
- Direct callback storage ([esphome/esphome#10946](https://github.com/esphome/esphome/pull/10946)): **~124 bytes RAM + 2.1KB flash savings** (specifically for Improv)

These optimizations free up **~30-38KB total RAM**, which is more than sufficient to run the BLE server + Improv components that were previously causing memory issues on ESP32 devices.

## Made for ESPHome Requirements
This PR fulfills the Wi-Fi project requirements for Made for ESPHome certification:
- ✅ `esp32_improv` for Bluetooth-based WiFi provisioning
- ✅ `improv_serial` for USB-based provisioning (already present)

## Test plan
- [ ] Verify configurations compile with ESPHome 2025.10.0+
- [ ] Test Improv WiFi provisioning on ESP32 devices via Bluetooth
- [ ] Confirm minimum version check prevents building with older ESPHome versions
- [ ] Verify sufficient free RAM after compilation

**Note: This PR cannot be merged until ESPHome 2025.10.0 is released on October 15, 2025**
