### PR TITLE
Improve debounce

### DIFF
--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -403,7 +403,7 @@ namespace ratgdo {
         if (percent >= PRESENCE_DETECTION_ON_THRESHOLD)
             this->vehicle_detected_state = VehicleDetectedState::YES;
 
-        if (percent == 0) {
+        if (percent == 0 && *this->vehicle_detected_state == VehicleDetectedState::YES) {
             off_counter++;
             ESP_LOGD(TAG, "Off counter: %d", off_counter);
 


### PR DESCRIPTION
adds a separate PRESENCE_DETECTION_OFF_THRESHOLD which requires the entire bitset to be false for X iterations before switching VehicleDetectedState

@dkerr64 FYI