### PR TITLE
Update ratgdo_lock.cpp

### DIFF
--- a/components/ratgdo/lock/ratgdo_lock.cpp
+++ b/components/ratgdo/lock/ratgdo_lock.cpp
@@ -35,7 +35,7 @@ namespace ratgdo {
         } else if (state == LockState::UNLOCKED) {
             call.set_state(lock::LockState::LOCK_STATE_UNLOCKED);
         }
-        this->control(call);
+        this->publish_state(*call.get_state());
     }
 
     void RATGDOLock::control(const lock::LockCall& call)


### PR DESCRIPTION
This PR is intended to fix issue #425 

Previously ratgdo would receive a lock status update from the GDO and then send the same exact lock status command back to the GDO, which is unnecessary.

On top of that, if a bad packet is sent which is interpreted as the door lock status being flipped, ratgdo would actually command the door to change it's lock status.