### PR TITLE
Fix ESP32 v2.5 obstruction logic; add obst_sleep_low config

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -27,6 +27,7 @@ ratgdo:
   input_gdo_pin: ${uart_rx_pin}
   output_gdo_pin: ${uart_tx_pin}
   input_obst_pin: ${input_obst_pin}
+  obst_sleep_level: ${obst_sleep_level}
   on_sync_failed:
     then:
       - homeassistant.service:

--- a/base.yaml
+++ b/base.yaml
@@ -1,4 +1,8 @@
 ---
+substitutions:
+  # Default Value(s)
+  obst_sleep_level: high
+
 esphome:
   min_version: 2025.7.0
 

--- a/base.yaml
+++ b/base.yaml
@@ -1,7 +1,7 @@
 ---
 substitutions:
   # Default Value(s)
-  obst_sleep_level: high
+  obst_sleep_low: false
 
 esphome:
   min_version: 2025.7.0
@@ -31,7 +31,7 @@ ratgdo:
   input_gdo_pin: ${uart_rx_pin}
   output_gdo_pin: ${uart_tx_pin}
   input_obst_pin: ${input_obst_pin}
-  obst_sleep_level: ${obst_sleep_level}
+  obst_sleep_low: ${obst_sleep_low}
   on_sync_failed:
     then:
       - homeassistant.service:

--- a/components/ratgdo/__init__.py
+++ b/components/ratgdo/__init__.py
@@ -84,9 +84,7 @@ CONFIG_SCHEMA = cv.All(
                 cv.none, pins.gpio_input_pin_schema
             ),
             cv.Optional(CONF_OBST_SLEEP_LVL, default=DEFAULT_OBST_SLEEP_LVL): cv.one_of(
-                OBST_SLEEP_LEVEL_LOW,
-                OBST_SLEEP_LEVEL_HIGH,
-                lower=True
+                OBST_SLEEP_LEVEL_LOW, OBST_SLEEP_LEVEL_HIGH, lower=True
             ),
             cv.Optional(CONF_DISCRETE_OPEN_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_DISCRETE_CLOSE_PIN): pins.gpio_output_pin_schema,

--- a/components/ratgdo/__init__.py
+++ b/components/ratgdo/__init__.py
@@ -26,6 +26,11 @@ DEFAULT_INPUT_GDO = (
 CONF_INPUT_OBST = "input_obst_pin"
 DEFAULT_INPUT_OBST = "D7"  # D7 black obstruction sensor terminal
 
+CONF_OBST_SLEEP_LVL = "obst_sleep_level"
+OBST_SLEEP_LEVEL_LOW = "low"
+OBST_SLEEP_LEVEL_HIGH = "high"
+DEFAULT_OBST_SLEEP_LVL = OBST_SLEEP_LEVEL_HIGH
+
 CONF_DISCRETE_OPEN_PIN = "discrete_open_pin"
 CONF_DISCRETE_CLOSE_PIN = "discrete_close_pin"
 
@@ -78,6 +83,11 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_INPUT_OBST, default=DEFAULT_INPUT_OBST): cv.Any(
                 cv.none, pins.gpio_input_pin_schema
             ),
+            cv.Optional(CONF_OBST_SLEEP_LVL, default=DEFAULT_OBST_SLEEP_LVL): cv.one_of(
+                OBST_SLEEP_LEVEL_LOW,
+                OBST_SLEEP_LEVEL_HIGH,
+                lower=True
+            ),
             cv.Optional(CONF_DISCRETE_OPEN_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_DISCRETE_CLOSE_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_ON_SYNC_FAILED): automation.validate_automation(
@@ -123,6 +133,11 @@ async def to_code(config):
     if config.get(CONF_INPUT_OBST):
         pin = await cg.gpio_pin_expression(config[CONF_INPUT_OBST])
         cg.add(var.set_input_obst_pin(pin))
+
+    if config.get(CONF_OBST_SLEEP_LVL):
+        level = config[CONF_OBST_SLEEP_LVL]
+        if level == OBST_SLEEP_LEVEL_LOW:
+            cg.add_build_flag("-DRATGDO_OBST_SLEEP_LOW")
 
     if config.get(CONF_DRY_CONTACT_OPEN_SENSOR):
         dry_contact_open_sensor = await cg.get_variable(

--- a/components/ratgdo/__init__.py
+++ b/components/ratgdo/__init__.py
@@ -26,10 +26,7 @@ DEFAULT_INPUT_GDO = (
 CONF_INPUT_OBST = "input_obst_pin"
 DEFAULT_INPUT_OBST = "D7"  # D7 black obstruction sensor terminal
 
-CONF_OBST_SLEEP_LEVEL = "obst_sleep_level"
-OBST_SLEEP_LEVEL_LOW = "low"
-OBST_SLEEP_LEVEL_HIGH = "high"
-DEFAULT_OBST_SLEEP_LEVEL = OBST_SLEEP_LEVEL_HIGH
+CONF_OBST_SLEEP_LOW = "obst_sleep_low"
 
 CONF_DISCRETE_OPEN_PIN = "discrete_open_pin"
 CONF_DISCRETE_CLOSE_PIN = "discrete_close_pin"
@@ -83,9 +80,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_INPUT_OBST, default=DEFAULT_INPUT_OBST): cv.Any(
                 cv.none, pins.gpio_input_pin_schema
             ),
-            cv.Optional(
-                CONF_OBST_SLEEP_LEVEL, default=DEFAULT_OBST_SLEEP_LEVEL
-            ): cv.one_of(OBST_SLEEP_LEVEL_LOW, OBST_SLEEP_LEVEL_HIGH, lower=True),
+            cv.Optional(CONF_OBST_SLEEP_LOW, default=False): cv.boolean,
             cv.Optional(CONF_DISCRETE_OPEN_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_DISCRETE_CLOSE_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_ON_SYNC_FAILED): automation.validate_automation(
@@ -132,8 +127,7 @@ async def to_code(config):
         pin = await cg.gpio_pin_expression(config[CONF_INPUT_OBST])
         cg.add(var.set_input_obst_pin(pin))
 
-    if config[CONF_OBST_SLEEP_LEVEL] == OBST_SLEEP_LEVEL_LOW:
-        cg.add(var.set_obst_sleep_low(True))
+    cg.add(var.set_obst_sleep_low(config[CONF_OBST_SLEEP_LOW]))
 
     if config.get(CONF_DRY_CONTACT_OPEN_SENSOR):
         dry_contact_open_sensor = await cg.get_variable(

--- a/components/ratgdo/__init__.py
+++ b/components/ratgdo/__init__.py
@@ -26,10 +26,10 @@ DEFAULT_INPUT_GDO = (
 CONF_INPUT_OBST = "input_obst_pin"
 DEFAULT_INPUT_OBST = "D7"  # D7 black obstruction sensor terminal
 
-CONF_OBST_SLEEP_LVL = "obst_sleep_level"
+CONF_OBST_SLEEP_LEVEL = "obst_sleep_level"
 OBST_SLEEP_LEVEL_LOW = "low"
 OBST_SLEEP_LEVEL_HIGH = "high"
-DEFAULT_OBST_SLEEP_LVL = OBST_SLEEP_LEVEL_HIGH
+DEFAULT_OBST_SLEEP_LEVEL = OBST_SLEEP_LEVEL_HIGH
 
 CONF_DISCRETE_OPEN_PIN = "discrete_open_pin"
 CONF_DISCRETE_CLOSE_PIN = "discrete_close_pin"
@@ -83,9 +83,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_INPUT_OBST, default=DEFAULT_INPUT_OBST): cv.Any(
                 cv.none, pins.gpio_input_pin_schema
             ),
-            cv.Optional(CONF_OBST_SLEEP_LVL, default=DEFAULT_OBST_SLEEP_LVL): cv.one_of(
-                OBST_SLEEP_LEVEL_LOW, OBST_SLEEP_LEVEL_HIGH, lower=True
-            ),
+            cv.Optional(
+                CONF_OBST_SLEEP_LEVEL, default=DEFAULT_OBST_SLEEP_LEVEL
+            ): cv.one_of(OBST_SLEEP_LEVEL_LOW, OBST_SLEEP_LEVEL_HIGH, lower=True),
             cv.Optional(CONF_DISCRETE_OPEN_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_DISCRETE_CLOSE_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_ON_SYNC_FAILED): automation.validate_automation(
@@ -132,10 +132,8 @@ async def to_code(config):
         pin = await cg.gpio_pin_expression(config[CONF_INPUT_OBST])
         cg.add(var.set_input_obst_pin(pin))
 
-    if config.get(CONF_OBST_SLEEP_LVL):
-        level = config[CONF_OBST_SLEEP_LVL]
-        if level == OBST_SLEEP_LEVEL_LOW:
-            cg.add_build_flag("-DRATGDO_OBST_SLEEP_LOW")
+    if config[CONF_OBST_SLEEP_LEVEL] == OBST_SLEEP_LEVEL_LOW:
+        cg.add(var.set_obst_sleep_low(True))
 
     if config.get(CONF_DRY_CONTACT_OPEN_SENSOR):
         dry_contact_open_sensor = await cg.get_variable(

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -477,7 +477,11 @@ namespace ratgdo {
                 this->flags_.obstruction_sensor_detected = true;
             } else if (this->isr_store_.obstruction_low_count == 0) {
                 // if there have been no pulses the line is steady high or low
+<<<<<<< Updated upstream
 #ifdef USE_ESP32
+=======
+#if defined(USE_ESP32) && !defined(RATGDO_OBST_SLEEP_LOW)
+>>>>>>> Stashed changes
                 if (this->input_obst_pin_->digital_read()) {
 #else
                 if (!this->input_obst_pin_->digital_read()) {

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -477,11 +477,7 @@ namespace ratgdo {
                 this->flags_.obstruction_sensor_detected = true;
             } else if (this->isr_store_.obstruction_low_count == 0) {
                 // if there have been no pulses the line is steady high or low
-<<<<<<< Updated upstream
-#ifdef USE_ESP32
-=======
 #if defined(USE_ESP32) && !defined(RATGDO_OBST_SLEEP_LOW)
->>>>>>> Stashed changes
                 if (this->input_obst_pin_->digital_read()) {
 #else
                 if (!this->input_obst_pin_->digital_read()) {

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -477,7 +477,7 @@ namespace ratgdo {
                 this->flags_.obstruction_sensor_detected = true;
             } else if (this->isr_store_.obstruction_low_count == 0) {
                 // if there have been no pulses the line is steady high or low
-#ifdef USE_ESP32
+#if defined(USE_ESP32) && !defined(RATGDO_LEGACY_OBSTRUCTION_SLEEP)
                 if (this->input_obst_pin_->digital_read()) {
 #else
                 if (!this->input_obst_pin_->digital_read()) {

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -477,11 +477,7 @@ namespace ratgdo {
                 this->flags_.obstruction_sensor_detected = true;
             } else if (this->isr_store_.obstruction_low_count == 0) {
                 // if there have been no pulses the line is steady high or low
-#if defined(USE_ESP32) && !defined(RATGDO_LEGACY_OBSTRUCTION_SLEEP)
-                if (this->input_obst_pin_->digital_read()) {
-#else
-                if (!this->input_obst_pin_->digital_read()) {
-#endif
+                if (this->input_obst_pin_->digital_read() != this->flags_.obst_sleep_low) {
                     // asleep
                     last_asleep = current_millis;
                 } else {

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -113,6 +113,7 @@ namespace ratgdo {
         void set_output_gdo_pin(InternalGPIOPin* pin) { this->output_gdo_pin_ = pin; }
         void set_input_gdo_pin(InternalGPIOPin* pin) { this->input_gdo_pin_ = pin; }
         void set_input_obst_pin(InternalGPIOPin* pin) { this->input_obst_pin_ = pin; }
+        void set_obst_sleep_low(bool low) { this->flags_.obst_sleep_low = low; }
 
         // dry contact methods
         void set_dry_contact_open_sensor(esphome::binary_sensor::BinarySensor* dry_contact_open_sensor_);
@@ -233,11 +234,12 @@ namespace ratgdo {
         // Bool members packed into bitfield
         struct {
             uint8_t obstruction_sensor_detected : 1;
+            uint8_t obst_sleep_low : 1;
 #ifdef RATGDO_USE_VEHICLE_SENSORS
             uint8_t presence_detect_window_active : 1;
-            uint8_t reserved : 6; // Reserved for future use
+            uint8_t reserved : 5; // Reserved for future use
 #else
-            uint8_t reserved : 7; // Reserved for future use
+            uint8_t reserved : 6; // Reserved for future use
 #endif
         } flags_ { 0 };
     }; // RATGDOComponent

--- a/static/v25board_esp32_d1_mini.yaml
+++ b/static/v25board_esp32_d1_mini.yaml
@@ -5,6 +5,7 @@ substitutions:
   uart_tx_pin: D1
   uart_rx_pin: D2
   input_obst_pin: D7
+  obst_sleep_lvl: low
   status_door_pin: D0
   status_obstruction_pin: D8
   dry_contact_open_pin: D5

--- a/static/v25board_esp32_d1_mini.yaml
+++ b/static/v25board_esp32_d1_mini.yaml
@@ -5,7 +5,7 @@ substitutions:
   uart_tx_pin: D1
   uart_rx_pin: D2
   input_obst_pin: D7
-  obst_sleep_level: low
+  obst_sleep_low: true
   status_door_pin: D0
   status_obstruction_pin: D8
   dry_contact_open_pin: D5

--- a/static/v25board_esp32_d1_mini.yaml
+++ b/static/v25board_esp32_d1_mini.yaml
@@ -5,7 +5,7 @@ substitutions:
   uart_tx_pin: D1
   uart_rx_pin: D2
   input_obst_pin: D7
-  obst_sleep_lvl: low
+  obst_sleep_level: low
   status_door_pin: D0
   status_obstruction_pin: D8
   dry_contact_open_pin: D5


### PR DESCRIPTION
### Fix ESP32 obstruction logic on v2.5 boards; add `obst_sleep_low` config option

Some v2.5 boards using ESP32 D1 Mini controllers were reporting spurious obstruction events due to the ESP32 "asleep" logic being inverted from earlier versions. This behavior appears to have been introduced in commit **[f68d126](https://github.com/ratgdo/esphome-ratgdo/commit/f68d126)** (ratgdo32 work).

This PR adds a runtime boolean config option:

```yaml
ratgdo:
  obst_sleep_low: true
```

When `true`, the obstruction sensor treats LOW as the "asleep" state (original v2.5 behavior). The default is platform-aware via `cv.SplitDefault`:

- **ESP32**: `false` (HIGH = asleep) — preserves current behavior
- **ESP8266**: `true` (LOW = asleep) — preserves current behavior

The `v25board_esp32_d1_mini.yaml` board config sets `obst_sleep_low: true` to fix the false obstruction issue on those boards.

This option is intentionally **not** exposed as a substitution in `base.yaml`. Using a substitution would require a single default value, bypassing `SplitDefault` and breaking the per-platform default for one platform. Instead, boards that need to override the default add a `ratgdo:` block with a matching `id`. Users can do the same in their own config:

```yaml
# Example: override in user config for an ESP32 v2.5 board
ratgdo:
  id: ratgdov25
  obst_sleep_low: true
```

#### Changes

- Replace compile-time `#ifdef USE_ESP32` with a runtime check against `flags_.obst_sleep_low`
- Add `obst_sleep_low` boolean config option with `cv.SplitDefault` for per-platform defaults
- Add `set_obst_sleep_low()` setter and bitfield flag to `RATGDOComponent`
- Set `obst_sleep_low: true` in `v25board_esp32_d1_mini.yaml` via a `ratgdo:` block with matching `id`

Tested on two ESP32 v2.5 boards where this resolves the false obstruction issue.