### PR TITLE
fix: increase vehicle_arriving defer names to 4

### DIFF
--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -45,7 +45,7 @@ namespace ratgdo {
 #endif
 #ifdef RATGDO_USE_VEHICLE_SENSORS
     static const char* const DEFER_VEHICLE_DETECTED[] = { "vd0" }; // 1 caller
-    static const char* const DEFER_VEHICLE_ARRIVING[] = { "va0", "va1", "va2" }; // 3 callers
+    static const char* const DEFER_VEHICLE_ARRIVING[] = { "va0", "va1", "va2", "va3" }; // 4 callers
     static const char* const DEFER_VEHICLE_LEAVING[] = { "vl0" }; // 1 caller
 #endif
 


### PR DESCRIPTION
## Summary
LED switches subscribe to `vehicle_arriving` to flash when a vehicle arrives. Configs with multiple LED switches + binary_sensor + beeper output exceed the previous limit of 3.

## Change
```cpp
// Before
static const char* const DEFER_VEHICLE_ARRIVING[] = { "va0", "va1", "va2" }; // 3 callers

// After
static const char* const DEFER_VEHICLE_ARRIVING[] = { "va0", "va1", "va2", "va3" }; // 4 callers
```

## Callers
1. `binary_sensor` (type: vehicle_arriving)
2. `output` (beeper)
3. `switch` (LED 1)
4. `switch` (LED 2)