### PR TITLE
fix: rate limit collision detected log message

### DIFF
--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -467,12 +467,8 @@ namespace ratgdo {
                         this->flags_.transmit_pending = true;
                         this->transmit_pending_start_ = millis();
                         ESP_LOGD(TAG, "Collision detected, waiting to send packet");
-                    } else {
-                        if (millis() - this->transmit_pending_start_ < 5000) {
-                            ESP_LOGD(TAG, "Collision detected, waiting to send packet");
-                        } else {
-                            this->transmit_pending_start_ = 0; // to indicate GDO not connected state
-                        }
+                    } else if (millis() - this->transmit_pending_start_ >= 5000) {
+                        this->transmit_pending_start_ = 0; // to indicate GDO not connected state
                     }
                     return false;
                 }


### PR DESCRIPTION
## Summary
The "Collision detected, waiting to send packet" message was logged every loop iteration (~10ms) while waiting for the line to clear, causing massive log spam.

## Change
Now logs once when collision is first detected, then silently waits up to 5 seconds.

## Before
```
[13:22:09.848][D][ratgdo_secplus2:472]: Collision detected, waiting to send packet
[13:22:09.854][D][ratgdo_secplus2:472]: Collision detected, waiting to send packet
[13:22:09.860][D][ratgdo_secplus2:472]: Collision detected, waiting to send packet
... (100+ times)
```

## After
```
[13:22:09.848][D][ratgdo_secplus2:469]: Collision detected, waiting to send packet
```