### PR TITLE
Fix secplus1 emulation noise issue

### DIFF
--- a/components/ratgdo/secplus1.cpp
+++ b/components/ratgdo/secplus1.cpp
@@ -313,10 +313,11 @@ namespace ratgdo {
 
         void Secplus1::handle_command(const RxCommand& cmd)
         {
-            if (this->wall_panel_emulation_state_ == WallPanelEmulationState::WAITING && (cmd.req == CommandType::TOGGLE_DOOR_RELEASE || cmd.resp == 0x31)) {
-                ESP_LOGD(TAG, "wall panel is starting");
-                this->flags_.wall_panel_starting = true;
-
+            if (cmd.req == CommandType::TOGGLE_DOOR_RELEASE || cmd.resp == 0x31) {
+                if (this->wall_panel_emulation_state_ == WallPanelEmulationState::WAITING) {
+                    ESP_LOGD(TAG, "wall panel is starting");
+                    this->flags_.wall_panel_starting = true;
+                }
             } else if (cmd.req == CommandType::QUERY_DOOR_STATUS) {
                 DoorState door_state;
                 auto val = cmd.resp & 0x7;


### PR DESCRIPTION
Fixes an issue that causes secplus1 analog panels to randomly exit emulation mode an stop functioning until reboot.

See https://github.com/ratgdo/esphome-ratgdo/issues/530#issuecomment-3916395313 for more details.

The fix works by only exiting emulation mode if a release command is received during the warming phase (35secs). After emulation mode is up and running, it should stay running. 