### PR TITLE
Migrate from get_object_id_hash() to make_entity_preference()

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -1,6 +1,6 @@
 ---
 esphome:
-  min_version: 2026.1.4
+  min_version: 2026.2.0
 
 external_components:
   - source:

--- a/base_drycontact.yaml
+++ b/base_drycontact.yaml
@@ -1,6 +1,6 @@
 ---
 esphome:
-  min_version: 2026.1.4
+  min_version: 2026.2.0
 
 external_components:
   - source:

--- a/base_secplusv1.yaml
+++ b/base_secplusv1.yaml
@@ -1,6 +1,6 @@
 ---
 esphome:
-  min_version: 2026.1.4
+  min_version: 2026.2.0
 
 external_components:
   - source:

--- a/components/ratgdo/number/ratgdo_number.cpp
+++ b/components/ratgdo/number/ratgdo_number.cpp
@@ -53,7 +53,7 @@ namespace ratgdo {
     void RATGDONumber::setup()
     {
         float value;
-        this->pref_ = global_preferences->make_preference<float>(this->get_object_id_hash());
+        this->pref_ = this->make_entity_preference<float>();
         if (!this->pref_.load(&value)) {
             if (this->number_type_ == RATGDO_CLIENT_ID) {
                 value = ((random_uint32() + 1) % 0x7FF) << 12 | 0x539; // max size limited to be precisely convertible to float

--- a/static/v25board_esp32_d1_mini.yaml
+++ b/static/v25board_esp32_d1_mini.yaml
@@ -17,7 +17,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2025.12.0
+  min_version: 2026.2.0
   project:
     name: ratgdo.v25board_esp32_secplus2
     version: "2.5"

--- a/static/v25board_esp32_d1_mini_secplusv1.yaml
+++ b/static/v25board_esp32_d1_mini_secplusv1.yaml
@@ -17,7 +17,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2025.12.0
+  min_version: 2026.2.0
   project:
     name: ratgdo.v25board_esp32_secplusv1
     version: "2.5"

--- a/static/v2board_esp32_d1_mini.yaml
+++ b/static/v2board_esp32_d1_mini.yaml
@@ -17,7 +17,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2025.12.0
+  min_version: 2026.2.0
   project:
     name: ratgdo.v2board_esp32_d1_mini
     version: "2.0"

--- a/static/v32board.yaml
+++ b/static/v32board.yaml
@@ -18,7 +18,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2025.12.0
+  min_version: 2026.2.0
   project:
     name: ratgdo.v32board_secplus2
     version: "32.0"

--- a/static/v32board_drycontact.yaml
+++ b/static/v32board_drycontact.yaml
@@ -17,7 +17,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2025.12.0
+  min_version: 2026.2.0
   project:
     name: ratgdo.v32board_drycontact
     version: "32.0"

--- a/static/v32board_secplusv1.yaml
+++ b/static/v32board_secplusv1.yaml
@@ -18,7 +18,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2025.12.0
+  min_version: 2026.2.0
   project:
     name: ratgdo.v32board_secplusv1
     version: "32.0"

--- a/static/v32disco.yaml
+++ b/static/v32disco.yaml
@@ -19,7 +19,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2025.12.0
+  min_version: 2026.2.0
   project:
     name: ratgdo.v32disco_secplus2
     version: "32disco"

--- a/static/v32disco_drycontact.yaml
+++ b/static/v32disco_drycontact.yaml
@@ -18,7 +18,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2025.12.0
+  min_version: 2026.2.0
   project:
     name: ratgdo.v32disco_drycontact
     version: "32disco"

--- a/static/v32disco_secplusv1.yaml
+++ b/static/v32disco_secplusv1.yaml
@@ -19,7 +19,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2025.12.0
+  min_version: 2026.2.0
   project:
     name: ratgdo.v32disco_secplusv1
     version: "32disco"


### PR DESCRIPTION
## Summary
- Replace `global_preferences->make_preference<float>(get_object_id_hash())` with the new `make_entity_preference<float>()` API which encapsulates preference creation and handles automatic preference migration when the hash algorithm is updated to fix collisions
- Bump `min_version` to `2026.2.0` across all configs

## Test plan
- [x] Verify preferences are correctly loaded/saved after migration
- [x] Confirm min_version enforcement works with ESPHome 2026.2.0

Closes #543