### PR TITLE
Rename on_open to on_opened for ESPHome 2026.2.0

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -240,7 +240,7 @@ cover:
     name: "Door"
     on_closed:
       - switch.turn_off: ${id_prefix}_status_door
-    on_open:
+    on_opened:
       - switch.turn_on: ${id_prefix}_status_door
 
 light:

--- a/base_secplusv1.yaml
+++ b/base_secplusv1.yaml
@@ -196,7 +196,7 @@ cover:
     name: "Door"
     on_closed:
       - switch.turn_off: ${id_prefix}_status_door
-    on_open:
+    on_opened:
       - switch.turn_on: ${id_prefix}_status_door
 
 light:


### PR DESCRIPTION
## Summary
- Renames deprecated `on_open` cover trigger to `on_opened` in `base.yaml` and `base_secplusv1.yaml`
- Required by ESPHome 2026.2.0 breaking change; old name will be removed in 2026.8.0

Fixes #551