### PR TITLE
Move wipe_devices lambda string dispatch to C++ to save ESP8266 RAM

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -42,17 +42,7 @@ api:
       devices_to_wipe: string
     then:
       - lambda: !lambda |-
-          if(devices_to_wipe.compare("all") == 0) {
-            id($id_prefix).clear_paired_devices(ratgdo::PairedDevice::ALL);
-          } else if (devices_to_wipe.compare("remote") == 0) {
-            id($id_prefix).clear_paired_devices(ratgdo::PairedDevice::REMOTE);
-          } else if (devices_to_wipe.compare("keypad") == 0) {
-            id($id_prefix).clear_paired_devices(ratgdo::PairedDevice::KEYPAD);
-          } else if (devices_to_wipe.compare("wall") == 0)  {
-            id($id_prefix).clear_paired_devices(ratgdo::PairedDevice::WALL_CONTROL);
-          } else if (devices_to_wipe.compare("accessory")  == 0) {
-            id($id_prefix).clear_paired_devices(ratgdo::PairedDevice::ACCESSORY);
-          }
+          id($id_prefix).clear_paired_devices(devices_to_wipe);
 
 ota:
   - platform: esphome

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -182,6 +182,30 @@ namespace ratgdo {
         void query_paired_devices(PairedDevice kind);
         void clear_paired_devices(PairedDevice kind);
 
+        // Uses length + first character instead of string comparisons to avoid
+        // string literals in RODATA which consume RAM on ESP8266.
+        // Valid values: "all" (3,a), "remote" (6,r), "keypad" (6,k), "wall" (4,w), "accessory" (9,a)
+        // Template so it works with std::string, StringRef, or any type with length() and operator[].
+        template <typename StringT>
+        void clear_paired_devices(const StringT& kind)
+        {
+            PairedDevice device;
+            if (kind.length() == 3 && kind[0] == 'a') {
+                device = PairedDevice::ALL;
+            } else if (kind.length() == 6 && kind[0] == 'r') {
+                device = PairedDevice::REMOTE;
+            } else if (kind.length() == 6 && kind[0] == 'k') {
+                device = PairedDevice::KEYPAD;
+            } else if (kind.length() == 4 && kind[0] == 'w') {
+                device = PairedDevice::WALL_CONTROL;
+            } else if (kind.length() == 9 && kind[0] == 'a') {
+                device = PairedDevice::ACCESSORY;
+            } else {
+                return;
+            }
+            this->clear_paired_devices(device);
+        }
+
         // button functionality
         void query_status();
         void query_openings();


### PR DESCRIPTION
## Summary
- Moves the string-to-`PairedDevice` mapping from the YAML lambda into a C++ template method on `RATGDOComponent`
- The YAML lambda had 5 string literals that ended up in RODATA (RAM on ESP8266)
- The new implementation uses length + first character checks, avoiding any string data in RAM
- Template works with both `std::string` and `StringRef` (or any type with `length()` and `operator[]`)
- Functionally the same — all valid inputs (`all`, `remote`, `keypad`, `wall`, `accessory`) map to the same enum values, just slightly more permissive since it checks length and first character rather than exact equality