### PR TITLE
Fix implicit optional to bool conversion in secplus1

### DIFF
--- a/components/ratgdo/secplus1.cpp
+++ b/components/ratgdo/secplus1.cpp
@@ -409,7 +409,7 @@ namespace ratgdo {
                 this->enqueue_command_pair(cmd.value());
                 this->transmit_byte(static_cast<uint32_t>(cmd.value()));
             }
-            return cmd;
+            return cmd.has_value();
         }
 
         void Secplus1::enqueue_command_pair(CommandType cmd)


### PR DESCRIPTION
## Summary
- `do_transmit_if_pending()` returns `bool` but was returning a `std::optional<CommandType>` directly, which fails to compile on stricter compilers
- Use explicit `has_value()` to convert the optional to bool

## Test plan
- [x] Verify compilation succeeds on target platform