### PR TITLE
Switch from isort/black to ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,11 +16,9 @@ repos:
      - "c"
      - "cuda"
     args: [-style=Webkit, -i]
-- repo: https://github.com/PyCQA/isort
-  rev: 8.0.1
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.15.6
   hooks:
-    - id: isort
-- repo: https://github.com/psf/black-pre-commit-mirror
-  rev: 26.3.1
-  hooks:
-    - id: black
+    - id: ruff
+      args: [--fix]
+    - id: ruff-format

--- a/components/ratgdo/__init__.py
+++ b/components/ratgdo/__init__.py
@@ -1,9 +1,9 @@
-import esphome.codegen as cg
-import esphome.config_validation as cv
-import voluptuous as vol
 from esphome import automation, pins
+import esphome.codegen as cg
 from esphome.components import binary_sensor
+import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_TRIGGER_ID
+import voluptuous as vol
 
 DEPENDENCIES = ["preferences"]
 MULTI_CONF = True

--- a/components/ratgdo/binary_sensor/__init__.py
+++ b/components/ratgdo/binary_sensor/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import binary_sensor
+import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
 from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child

--- a/components/ratgdo/cover/__init__.py
+++ b/components/ratgdo/cover/__init__.py
@@ -1,7 +1,7 @@
-import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome import automation
+import esphome.codegen as cg
 from esphome.components import cover
+import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_TRIGGER_ID
 
 from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child

--- a/components/ratgdo/light/__init__.py
+++ b/components/ratgdo/light/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import light
+import esphome.config_validation as cv
 from esphome.const import CONF_OUTPUT_ID  # New in 2023.5
 
 from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child

--- a/components/ratgdo/lock/__init__.py
+++ b/components/ratgdo/lock/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import lock
+import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
 from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child

--- a/components/ratgdo/number/__init__.py
+++ b/components/ratgdo/number/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import number
+import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
 from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child

--- a/components/ratgdo/output/__init__.py
+++ b/components/ratgdo/output/__init__.py
@@ -1,13 +1,12 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import rtttl
+import esphome.config_validation as cv
 from esphome.const import CONF_ID
+
+from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child
 
 CONF_RTTTL = "rtttl"
 CONF_SONG = "song"
-
-
-from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child
 
 DEPENDENCIES = ["esp32", "ratgdo", "rtttl"]
 

--- a/components/ratgdo/sensor/__init__.py
+++ b/components/ratgdo/sensor/__init__.py
@@ -1,11 +1,11 @@
 import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome.components import sensor
+import esphome.config_validation as cv
 from esphome.const import CONF_ID
 
-CONF_DISTANCE = "distance"
-
 from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child
+
+CONF_DISTANCE = "distance"
 
 DEPENDENCIES = ["ratgdo"]
 

--- a/components/ratgdo/switch/__init__.py
+++ b/components/ratgdo/switch/__init__.py
@@ -1,7 +1,7 @@
-import esphome.codegen as cg
-import esphome.config_validation as cv
 from esphome import pins
+import esphome.codegen as cg
 from esphome.components import switch
+import esphome.config_validation as cv
 from esphome.const import CONF_ID, CONF_PIN
 
 from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.ruff]
+required-version = ">=0.5.0"
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+  "E",    # pycodestyle
+  "F",    # pyflakes/autoflake
+  "FURB", # refurb
+  "I",    # isort
+  "PERF", # performance
+  "PL",   # pylint
+  "SIM",  # flake8-simplify
+  "RET",  # flake8-ret
+  "UP",   # pyupgrade
+]
+
+ignore = [
+  "E501", # line too long
+  "PLC0415", # `import` should be at the top-level of a file
+  "PLR0911", # Too many return statements ({returns} > {max_returns})
+  "PLR0912", # Too many branches ({branches} > {max_branches})
+  "PLR0913", # Too many arguments to function call ({c_args} > {max_args})
+  "PLR0915", # Too many statements ({statements} > {max_statements})
+  "PLW1641", # Object does not implement `__hash__` method
+  "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
+  "PLW2901", # Outer {outer_kind} variable {name} overwritten by inner {inner_kind} target
+]
+
+[tool.ruff.lint.isort]
+force-sort-within-sections = true
+combine-as-imports = true
+split-on-trailing-comma = false

--- a/scripts/update_refs_for_ci.py
+++ b/scripts/update_refs_for_ci.py
@@ -3,15 +3,14 @@
 
 import json
 import os
+from pathlib import Path
 import re
 import sys
-from pathlib import Path
-from typing import Optional, Tuple
 
 RATGDO_REPO = "ratgdo/esphome-ratgdo"
 
 
-def get_pr_info() -> Tuple[str, Optional[str]]:
+def get_pr_info() -> tuple[str, str | None]:
     """Get PR branch and repository info from GitHub environment."""
     # For PRs, check GITHUB_REF first
     github_ref = os.environ.get("GITHUB_REF", "")
@@ -56,7 +55,7 @@ def main():
 
     # Process all YAML files in the project root
     for yaml_file in project_root.glob("*.yaml"):
-        with open(yaml_file, "r") as f:
+        with open(yaml_file) as f:
             content = f.read()
 
         original = content

--- a/tests/scripts/test_update_refs_for_ci.py
+++ b/tests/scripts/test_update_refs_for_ci.py
@@ -3,9 +3,8 @@
 
 import json
 import os
-import sys
-import tempfile
 from pathlib import Path
+import sys
 from unittest import mock
 
 import pytest
@@ -130,9 +129,11 @@ external_components:
 
         # Mock the project root to be tmp_path
         os.chdir(tmp_path)
-        with mock.patch.object(Path, "absolute", return_value=tmp_path):
-            with mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/test-branch"}):
-                update_refs_for_ci.main()
+        with (
+            mock.patch.object(Path, "absolute", return_value=tmp_path),
+            mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/test-branch"}),
+        ):
+            update_refs_for_ci.main()
 
         updated_content = yaml_file.read_text()
         assert "type: local" in updated_content
@@ -155,9 +156,11 @@ packages:
         yaml_file.write_text(yaml_content)
 
         os.chdir(tmp_path)
-        with mock.patch.object(Path, "absolute", return_value=tmp_path):
-            with mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/test-branch"}):
-                update_refs_for_ci.main()
+        with (
+            mock.patch.object(Path, "absolute", return_value=tmp_path),
+            mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/test-branch"}),
+        ):
+            update_refs_for_ci.main()
 
         updated_content = yaml_file.read_text()
         assert "packages:" in updated_content
@@ -176,9 +179,11 @@ dashboard_import:
         yaml_file.write_text(yaml_content)
 
         os.chdir(tmp_path)
-        with mock.patch.object(Path, "absolute", return_value=tmp_path):
-            with mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/test-branch"}):
-                update_refs_for_ci.main()
+        with (
+            mock.patch.object(Path, "absolute", return_value=tmp_path),
+            mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/test-branch"}),
+        ):
+            update_refs_for_ci.main()
 
         updated_content = yaml_file.read_text()
         assert "dashboard_import:" not in updated_content
@@ -208,9 +213,11 @@ packages:
         yaml_file.write_text(yaml_content)
 
         os.chdir(tmp_path)
-        with mock.patch.object(Path, "absolute", return_value=tmp_path):
-            with mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/test-mixed"}):
-                update_refs_for_ci.main()
+        with (
+            mock.patch.object(Path, "absolute", return_value=tmp_path),
+            mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/test-mixed"}),
+        ):
+            update_refs_for_ci.main()
 
         updated_content = yaml_file.read_text()
         # Check external_components
@@ -247,11 +254,11 @@ button:
         yaml_file.write_text(yaml_content)
 
         os.chdir(tmp_path)
-        with mock.patch.object(Path, "absolute", return_value=tmp_path):
-            with mock.patch.dict(
-                os.environ, {"GITHUB_REF": "refs/heads/preserve-tags"}
-            ):
-                update_refs_for_ci.main()
+        with (
+            mock.patch.object(Path, "absolute", return_value=tmp_path),
+            mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/preserve-tags"}),
+        ):
+            update_refs_for_ci.main()
 
         updated_content = yaml_file.read_text()
         assert "type: local" in updated_content
@@ -271,9 +278,11 @@ packages:
         original_mtime = yaml_file.stat().st_mtime
 
         os.chdir(tmp_path)
-        with mock.patch.object(Path, "absolute", return_value=tmp_path):
-            with mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/no-changes"}):
-                update_refs_for_ci.main()
+        with (
+            mock.patch.object(Path, "absolute", return_value=tmp_path),
+            mock.patch.dict(os.environ, {"GITHUB_REF": "refs/heads/no-changes"}),
+        ):
+            update_refs_for_ci.main()
 
         # File should not be modified
         assert yaml_file.stat().st_mtime == original_mtime


### PR DESCRIPTION
## Summary
- Replace isort and black pre-commit hooks with ruff linter and ruff-format
- Add pyproject.toml with ruff configuration matching the esphome project rules
- Fix all existing lint violations across the codebase

## Test plan
- [x] Verify `ruff check .` passes cleanly
- [x] Verify `ruff format --check .` passes cleanly
- [x] Verify pre-commit hooks run successfully