### PR TITLE
Use C++17 nested namespace syntax

### DIFF
--- a/components/ratgdo/automation.h
+++ b/components/ratgdo/automation.h
@@ -5,19 +5,17 @@
 #include "esphome/core/component.h"
 #include "ratgdo.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    class SyncFailed : public Trigger<> {
-    public:
-        explicit SyncFailed(RATGDOComponent* parent)
-        {
-            parent->subscribe_sync_failed([this](bool state) {
-                if (state)
-                    this->trigger();
-            });
-        }
-    };
+class SyncFailed : public Trigger<> {
+public:
+    explicit SyncFailed(RATGDOComponent* parent)
+    {
+        parent->subscribe_sync_failed([this](bool state) {
+            if (state)
+                this->trigger();
+        });
+    }
+};
 
-}
-}
+} // namespace esphome::ratgdo

--- a/components/ratgdo/binary_sensor/ratgdo_binary_sensor.cpp
+++ b/components/ratgdo/binary_sensor/ratgdo_binary_sensor.cpp
@@ -2,93 +2,91 @@
 #include "../ratgdo_state.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    static const char* const TAG = "ratgdo.binary_sensor";
+static const char* const TAG = "ratgdo.binary_sensor";
 
-    void RATGDOBinarySensor::setup()
-    {
-        // Initialize all sensors to false except motor (which doesn't set initial state)
-        if (this->binary_sensor_type_ != SensorType::RATGDO_SENSOR_MOTOR) {
-            this->publish_initial_state(false);
-        }
-
-        switch (this->binary_sensor_type_) {
-        case SensorType::RATGDO_SENSOR_MOTION:
-            this->parent_->subscribe_motion_state([this](MotionState state) {
-                this->publish_state(state == MotionState::DETECTED);
-            });
-            break;
-        case SensorType::RATGDO_SENSOR_OBSTRUCTION:
-            this->parent_->subscribe_obstruction_state([this](ObstructionState state) {
-                this->publish_state(state == ObstructionState::OBSTRUCTED);
-            });
-            break;
-        case SensorType::RATGDO_SENSOR_MOTOR:
-            this->parent_->subscribe_motor_state([this](MotorState state) {
-                this->publish_state(state == MotorState::ON);
-            });
-            break;
-        case SensorType::RATGDO_SENSOR_BUTTON:
-            this->parent_->subscribe_button_state([this](ButtonState state) {
-                this->publish_state(state == ButtonState::PRESSED);
-            });
-            break;
-#ifdef RATGDO_USE_VEHICLE_SENSORS
-        case SensorType::RATGDO_SENSOR_VEHICLE_DETECTED:
-            this->parent_->subscribe_vehicle_detected_state([this](VehicleDetectedState state) {
-                this->publish_state(state == VehicleDetectedState::YES);
-                this->parent_->presence_change(state == VehicleDetectedState::YES);
-            });
-            break;
-        case SensorType::RATGDO_SENSOR_VEHICLE_ARRIVING:
-            this->parent_->subscribe_vehicle_arriving_state([this](VehicleArrivingState state) {
-                this->publish_state(state == VehicleArrivingState::YES);
-            });
-            break;
-        case SensorType::RATGDO_SENSOR_VEHICLE_LEAVING:
-            this->parent_->subscribe_vehicle_leaving_state([this](VehicleLeavingState state) {
-                this->publish_state(state == VehicleLeavingState::YES);
-            });
-            break;
-#endif
-        default:
-            break;
-        }
+void RATGDOBinarySensor::setup()
+{
+    // Initialize all sensors to false except motor (which doesn't set initial state)
+    if (this->binary_sensor_type_ != SensorType::RATGDO_SENSOR_MOTOR) {
+        this->publish_initial_state(false);
     }
 
-    void RATGDOBinarySensor::dump_config()
-    {
-        LOG_BINARY_SENSOR("", "RATGDO BinarySensor", this);
-        switch (this->binary_sensor_type_) {
-        case SensorType::RATGDO_SENSOR_MOTION:
-            ESP_LOGCONFIG(TAG, "  Type: Motion");
-            break;
-        case SensorType::RATGDO_SENSOR_OBSTRUCTION:
-            ESP_LOGCONFIG(TAG, "  Type: Obstruction");
-            break;
-        case SensorType::RATGDO_SENSOR_MOTOR:
-            ESP_LOGCONFIG(TAG, "  Type: Motor");
-            break;
-        case SensorType::RATGDO_SENSOR_BUTTON:
-            ESP_LOGCONFIG(TAG, "  Type: Button");
-            break;
+    switch (this->binary_sensor_type_) {
+    case SensorType::RATGDO_SENSOR_MOTION:
+        this->parent_->subscribe_motion_state([this](MotionState state) {
+            this->publish_state(state == MotionState::DETECTED);
+        });
+        break;
+    case SensorType::RATGDO_SENSOR_OBSTRUCTION:
+        this->parent_->subscribe_obstruction_state([this](ObstructionState state) {
+            this->publish_state(state == ObstructionState::OBSTRUCTED);
+        });
+        break;
+    case SensorType::RATGDO_SENSOR_MOTOR:
+        this->parent_->subscribe_motor_state([this](MotorState state) {
+            this->publish_state(state == MotorState::ON);
+        });
+        break;
+    case SensorType::RATGDO_SENSOR_BUTTON:
+        this->parent_->subscribe_button_state([this](ButtonState state) {
+            this->publish_state(state == ButtonState::PRESSED);
+        });
+        break;
 #ifdef RATGDO_USE_VEHICLE_SENSORS
-        case SensorType::RATGDO_SENSOR_VEHICLE_DETECTED:
-            ESP_LOGCONFIG(TAG, "  Type: VehicleDetected");
-            break;
-        case SensorType::RATGDO_SENSOR_VEHICLE_ARRIVING:
-            ESP_LOGCONFIG(TAG, "  Type: VehicleArriving");
-            break;
-        case SensorType::RATGDO_SENSOR_VEHICLE_LEAVING:
-            ESP_LOGCONFIG(TAG, "  Type: VehicleLeaving");
-            break;
+    case SensorType::RATGDO_SENSOR_VEHICLE_DETECTED:
+        this->parent_->subscribe_vehicle_detected_state([this](VehicleDetectedState state) {
+            this->publish_state(state == VehicleDetectedState::YES);
+            this->parent_->presence_change(state == VehicleDetectedState::YES);
+        });
+        break;
+    case SensorType::RATGDO_SENSOR_VEHICLE_ARRIVING:
+        this->parent_->subscribe_vehicle_arriving_state([this](VehicleArrivingState state) {
+            this->publish_state(state == VehicleArrivingState::YES);
+        });
+        break;
+    case SensorType::RATGDO_SENSOR_VEHICLE_LEAVING:
+        this->parent_->subscribe_vehicle_leaving_state([this](VehicleLeavingState state) {
+            this->publish_state(state == VehicleLeavingState::YES);
+        });
+        break;
 #endif
-        default:
-            break;
-        }
+    default:
+        break;
     }
+}
 
-} // namespace ratgdo
-} // namespace esphome
+void RATGDOBinarySensor::dump_config()
+{
+    LOG_BINARY_SENSOR("", "RATGDO BinarySensor", this);
+    switch (this->binary_sensor_type_) {
+    case SensorType::RATGDO_SENSOR_MOTION:
+        ESP_LOGCONFIG(TAG, "  Type: Motion");
+        break;
+    case SensorType::RATGDO_SENSOR_OBSTRUCTION:
+        ESP_LOGCONFIG(TAG, "  Type: Obstruction");
+        break;
+    case SensorType::RATGDO_SENSOR_MOTOR:
+        ESP_LOGCONFIG(TAG, "  Type: Motor");
+        break;
+    case SensorType::RATGDO_SENSOR_BUTTON:
+        ESP_LOGCONFIG(TAG, "  Type: Button");
+        break;
+#ifdef RATGDO_USE_VEHICLE_SENSORS
+    case SensorType::RATGDO_SENSOR_VEHICLE_DETECTED:
+        ESP_LOGCONFIG(TAG, "  Type: VehicleDetected");
+        break;
+    case SensorType::RATGDO_SENSOR_VEHICLE_ARRIVING:
+        ESP_LOGCONFIG(TAG, "  Type: VehicleArriving");
+        break;
+    case SensorType::RATGDO_SENSOR_VEHICLE_LEAVING:
+        ESP_LOGCONFIG(TAG, "  Type: VehicleLeaving");
+        break;
+#endif
+    default:
+        break;
+    }
+}
+
+} // namespace esphome::ratgdo

--- a/components/ratgdo/binary_sensor/ratgdo_binary_sensor.h
+++ b/components/ratgdo/binary_sensor/ratgdo_binary_sensor.h
@@ -6,30 +6,28 @@
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    enum SensorType : uint8_t {
-        RATGDO_SENSOR_MOTION,
-        RATGDO_SENSOR_OBSTRUCTION,
-        RATGDO_SENSOR_MOTOR,
-        RATGDO_SENSOR_BUTTON,
+enum SensorType : uint8_t {
+    RATGDO_SENSOR_MOTION,
+    RATGDO_SENSOR_OBSTRUCTION,
+    RATGDO_SENSOR_MOTOR,
+    RATGDO_SENSOR_BUTTON,
 #ifdef RATGDO_USE_VEHICLE_SENSORS
-        RATGDO_SENSOR_VEHICLE_DETECTED,
-        RATGDO_SENSOR_VEHICLE_ARRIVING,
-        RATGDO_SENSOR_VEHICLE_LEAVING,
+    RATGDO_SENSOR_VEHICLE_DETECTED,
+    RATGDO_SENSOR_VEHICLE_ARRIVING,
+    RATGDO_SENSOR_VEHICLE_LEAVING,
 #endif
-    };
+};
 
-    class RATGDOBinarySensor : public binary_sensor::BinarySensor, public RATGDOClient, public Component {
-    public:
-        void setup() override;
-        void dump_config() override;
-        void set_binary_sensor_type(SensorType binary_sensor_type) { this->binary_sensor_type_ = binary_sensor_type; }
+class RATGDOBinarySensor : public binary_sensor::BinarySensor, public RATGDOClient, public Component {
+public:
+    void setup() override;
+    void dump_config() override;
+    void set_binary_sensor_type(SensorType binary_sensor_type) { this->binary_sensor_type_ = binary_sensor_type; }
 
-    protected:
-        SensorType binary_sensor_type_;
-    };
+protected:
+    SensorType binary_sensor_type_;
+};
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/callbacks.h
+++ b/components/ratgdo/callbacks.h
@@ -4,28 +4,26 @@
 #include <utility>
 #include <vector>
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    template <typename... X>
-    class OnceCallbacks;
+template <typename... X>
+class OnceCallbacks;
 
-    template <typename... Ts>
-    class OnceCallbacks<void(Ts...)> {
-    public:
-        template <typename Callback>
-        void operator()(Callback&& callback) { this->callbacks_.push_back(std::forward<Callback>(callback)); }
+template <typename... Ts>
+class OnceCallbacks<void(Ts...)> {
+public:
+    template <typename Callback>
+    void operator()(Callback&& callback) { this->callbacks_.push_back(std::forward<Callback>(callback)); }
 
-        void trigger(Ts... args)
-        {
-            for (auto& cb : this->callbacks_)
-                cb(args...);
-            this->callbacks_.clear();
-        }
+    void trigger(Ts... args)
+    {
+        for (auto& cb : this->callbacks_)
+            cb(args...);
+        this->callbacks_.clear();
+    }
 
-    protected:
-        std::vector<std::function<void(Ts...)>> callbacks_;
-    };
+protected:
+    std::vector<std::function<void(Ts...)>> callbacks_;
+};
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/cover/automation.h
+++ b/components/ratgdo/cover/automation.h
@@ -4,42 +4,40 @@
 #include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    class CoverOpeningTrigger : public Trigger<> {
-    public:
-        CoverOpeningTrigger(cover::Cover* a_cover)
-        {
-            a_cover->add_on_state_callback([this, a_cover]() {
-                if (a_cover->current_operation == cover::COVER_OPERATION_OPENING) {
-                    this->trigger();
-                }
-            });
-        }
-    };
-
-    class CoverClosingTrigger : public Trigger<> {
-    public:
-        CoverClosingTrigger(cover::Cover* a_cover)
-        {
-            a_cover->add_on_state_callback([this, a_cover]() {
-                if (a_cover->current_operation == cover::COVER_OPERATION_CLOSING) {
-                    this->trigger();
-                }
-            });
-        }
-    };
-
-    class CoverStateTrigger : public Trigger<> {
-    public:
-        CoverStateTrigger(cover::Cover* a_cover)
-        {
-            a_cover->add_on_state_callback([this, a_cover]() {
+class CoverOpeningTrigger : public Trigger<> {
+public:
+    CoverOpeningTrigger(cover::Cover* a_cover)
+    {
+        a_cover->add_on_state_callback([this, a_cover]() {
+            if (a_cover->current_operation == cover::COVER_OPERATION_OPENING) {
                 this->trigger();
-            });
-        }
-    };
+            }
+        });
+    }
+};
 
-} // namespace ratgdo
-} // namespace esphome
+class CoverClosingTrigger : public Trigger<> {
+public:
+    CoverClosingTrigger(cover::Cover* a_cover)
+    {
+        a_cover->add_on_state_callback([this, a_cover]() {
+            if (a_cover->current_operation == cover::COVER_OPERATION_CLOSING) {
+                this->trigger();
+            }
+        });
+    }
+};
+
+class CoverStateTrigger : public Trigger<> {
+public:
+    CoverStateTrigger(cover::Cover* a_cover)
+    {
+        a_cover->add_on_state_callback([this, a_cover]() {
+            this->trigger();
+        });
+    }
+};
+
+} // namespace esphome::ratgdo

--- a/components/ratgdo/cover/ratgdo_cover.cpp
+++ b/components/ratgdo/cover/ratgdo_cover.cpp
@@ -2,94 +2,92 @@
 #include "../ratgdo_state.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    using namespace esphome::cover;
+using namespace esphome::cover;
 
-    static const char* const TAG = "ratgdo.cover";
+static const char* const TAG = "ratgdo.cover";
 
-    void RATGDOCover::dump_config()
-    {
-        LOG_COVER("", "RATGDO Cover", this);
+void RATGDOCover::dump_config()
+{
+    LOG_COVER("", "RATGDO Cover", this);
+}
+
+void RATGDOCover::setup()
+{
+    auto state = this->restore_state_();
+    if (state.has_value()) {
+        this->parent_->set_door_position(state.value().position);
+    }
+    this->parent_->subscribe_door_state([this](DoorState state, float position) {
+        this->on_door_state(state, position);
+    });
+}
+
+void RATGDOCover::on_door_state(DoorState state, float position)
+{
+    // ESP_LOGD("ON_DOOR_STATE", "%s %f", LOG_STR_ARG(DoorState_to_string(state)), position);
+    bool save_to_flash = true;
+    switch (state) {
+    case DoorState::OPEN:
+        this->position = COVER_OPEN;
+        this->current_operation = COVER_OPERATION_IDLE;
+        break;
+    case DoorState::CLOSED:
+        this->position = COVER_CLOSED;
+        this->current_operation = COVER_OPERATION_IDLE;
+        break;
+    case DoorState::OPENING:
+        this->current_operation = COVER_OPERATION_OPENING;
+        this->position = position;
+        save_to_flash = false;
+        break;
+    case DoorState::CLOSING:
+        this->current_operation = COVER_OPERATION_CLOSING;
+        this->position = position;
+        save_to_flash = false;
+        break;
+    case DoorState::STOPPED:
+        this->current_operation = COVER_OPERATION_IDLE;
+        this->position = position;
+    case DoorState::UNKNOWN:
+    default:
+        this->current_operation = COVER_OPERATION_IDLE;
+        this->position = position;
+
+        break;
     }
 
-    void RATGDOCover::setup()
-    {
-        auto state = this->restore_state_();
-        if (state.has_value()) {
-            this->parent_->set_door_position(state.value().position);
-        }
-        this->parent_->subscribe_door_state([this](DoorState state, float position) {
-            this->on_door_state(state, position);
-        });
+    this->publish_state(save_to_flash);
+}
+
+CoverTraits RATGDOCover::get_traits()
+{
+    auto traits = CoverTraits();
+    traits.set_supports_stop(true);
+    traits.set_supports_toggle(true);
+    traits.set_supports_position(true);
+    return traits;
+}
+
+void RATGDOCover::control(const CoverCall& call)
+{
+    if (call.get_stop()) {
+        this->parent_->door_stop();
     }
-
-    void RATGDOCover::on_door_state(DoorState state, float position)
-    {
-        // ESP_LOGD("ON_DOOR_STATE", "%s %f", LOG_STR_ARG(DoorState_to_string(state)), position);
-        bool save_to_flash = true;
-        switch (state) {
-        case DoorState::OPEN:
-            this->position = COVER_OPEN;
-            this->current_operation = COVER_OPERATION_IDLE;
-            break;
-        case DoorState::CLOSED:
-            this->position = COVER_CLOSED;
-            this->current_operation = COVER_OPERATION_IDLE;
-            break;
-        case DoorState::OPENING:
-            this->current_operation = COVER_OPERATION_OPENING;
-            this->position = position;
-            save_to_flash = false;
-            break;
-        case DoorState::CLOSING:
-            this->current_operation = COVER_OPERATION_CLOSING;
-            this->position = position;
-            save_to_flash = false;
-            break;
-        case DoorState::STOPPED:
-            this->current_operation = COVER_OPERATION_IDLE;
-            this->position = position;
-        case DoorState::UNKNOWN:
-        default:
-            this->current_operation = COVER_OPERATION_IDLE;
-            this->position = position;
-
-            break;
-        }
-
-        this->publish_state(save_to_flash);
+    if (call.get_toggle()) {
+        this->parent_->door_toggle();
     }
-
-    CoverTraits RATGDOCover::get_traits()
-    {
-        auto traits = CoverTraits();
-        traits.set_supports_stop(true);
-        traits.set_supports_toggle(true);
-        traits.set_supports_position(true);
-        return traits;
-    }
-
-    void RATGDOCover::control(const CoverCall& call)
-    {
-        if (call.get_stop()) {
-            this->parent_->door_stop();
-        }
-        if (call.get_toggle()) {
-            this->parent_->door_toggle();
-        }
-        if (call.get_position().has_value()) {
-            auto pos = *call.get_position();
-            if (pos == COVER_OPEN) {
-                this->parent_->door_open();
-            } else if (pos == COVER_CLOSED) {
-                this->parent_->door_close();
-            } else {
-                this->parent_->door_move_to_position(pos);
-            }
+    if (call.get_position().has_value()) {
+        auto pos = *call.get_position();
+        if (pos == COVER_OPEN) {
+            this->parent_->door_open();
+        } else if (pos == COVER_CLOSED) {
+            this->parent_->door_close();
+        } else {
+            this->parent_->door_move_to_position(pos);
         }
     }
+}
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/cover/ratgdo_cover.h
+++ b/components/ratgdo/cover/ratgdo_cover.h
@@ -5,20 +5,18 @@
 #include "esphome/components/cover/cover.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    class RATGDOCover : public cover::Cover, public RATGDOClient, public Component {
-    public:
-        void dump_config() override;
-        void setup() override;
+class RATGDOCover : public cover::Cover, public RATGDOClient, public Component {
+public:
+    void dump_config() override;
+    void setup() override;
 
-        cover::CoverTraits get_traits() override;
-        void on_door_state(DoorState state, float position);
+    cover::CoverTraits get_traits() override;
+    void on_door_state(DoorState state, float position);
 
-    protected:
-        void control(const cover::CoverCall& call) override;
-    };
+protected:
+    void control(const cover::CoverCall& call) override;
+};
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/dry_contact.cpp
+++ b/components/ratgdo/dry_contact.cpp
@@ -7,129 +7,127 @@
 #include "esphome/core/scheduler.h"
 #include "ratgdo.h"
 
-namespace esphome {
-namespace ratgdo {
-    namespace dry_contact {
+namespace esphome::ratgdo {
+namespace dry_contact {
 
-        static const char* const TAG = "ratgdo_dry_contact";
+    static const char* const TAG = "ratgdo_dry_contact";
 
-        void DryContact::setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin)
-        {
-            this->ratgdo_ = ratgdo;
-            this->scheduler_ = scheduler;
-            this->tx_pin_ = tx_pin;
-            this->rx_pin_ = rx_pin;
+    void DryContact::setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin)
+    {
+        this->ratgdo_ = ratgdo;
+        this->scheduler_ = scheduler;
+        this->tx_pin_ = tx_pin;
+        this->rx_pin_ = rx_pin;
 
-            this->limits_.open_limit_reached = 0;
-            this->limits_.last_open_limit = 0;
-            this->limits_.close_limit_reached = 0;
-            this->limits_.last_close_limit = 0;
-            this->door_state_ = DoorState::UNKNOWN;
-        }
+        this->limits_.open_limit_reached = 0;
+        this->limits_.last_open_limit = 0;
+        this->limits_.close_limit_reached = 0;
+        this->limits_.last_close_limit = 0;
+        this->door_state_ = DoorState::UNKNOWN;
+    }
 
-        void DryContact::loop()
-        {
-        }
+    void DryContact::loop()
+    {
+    }
 
-        void DryContact::dump_config()
-        {
-            ESP_LOGCONFIG(TAG, "  Protocol: dry contact");
-        }
+    void DryContact::dump_config()
+    {
+        ESP_LOGCONFIG(TAG, "  Protocol: dry contact");
+    }
 
-        void DryContact::sync()
-        {
-            ESP_LOG1(TAG, "Ignoring sync action");
-        }
+    void DryContact::sync()
+    {
+        ESP_LOG1(TAG, "Ignoring sync action");
+    }
 
-        void DryContact::set_open_limit(bool state)
-        {
-            ESP_LOGD(TAG, "Set open_limit_reached to %d", state);
-            this->limits_.last_open_limit = this->limits_.open_limit_reached;
-            this->limits_.last_close_limit = false;
-            this->limits_.open_limit_reached = state;
-            this->send_door_state();
-        }
+    void DryContact::set_open_limit(bool state)
+    {
+        ESP_LOGD(TAG, "Set open_limit_reached to %d", state);
+        this->limits_.last_open_limit = this->limits_.open_limit_reached;
+        this->limits_.last_close_limit = false;
+        this->limits_.open_limit_reached = state;
+        this->send_door_state();
+    }
 
-        void DryContact::set_close_limit(bool state)
-        {
-            ESP_LOGD(TAG, "Set close_limit_reached to %d", state);
-            this->limits_.last_close_limit = this->limits_.close_limit_reached;
-            this->limits_.last_open_limit = false;
-            this->limits_.close_limit_reached = state;
-            this->send_door_state();
-        }
+    void DryContact::set_close_limit(bool state)
+    {
+        ESP_LOGD(TAG, "Set close_limit_reached to %d", state);
+        this->limits_.last_close_limit = this->limits_.close_limit_reached;
+        this->limits_.last_open_limit = false;
+        this->limits_.close_limit_reached = state;
+        this->send_door_state();
+    }
 
-        void DryContact::send_door_state()
-        {
-            if (this->limits_.open_limit_reached) {
-                this->door_state_ = DoorState::OPEN;
-            } else if (this->limits_.close_limit_reached) {
-                this->door_state_ = DoorState::CLOSED;
-            } else if (!this->limits_.close_limit_reached && !this->limits_.open_limit_reached) {
-                if (this->limits_.last_close_limit) {
-                    this->door_state_ = DoorState::OPENING;
-                }
-
-                if (this->limits_.last_open_limit) {
-                    this->door_state_ = DoorState::CLOSING;
-                }
+    void DryContact::send_door_state()
+    {
+        if (this->limits_.open_limit_reached) {
+            this->door_state_ = DoorState::OPEN;
+        } else if (this->limits_.close_limit_reached) {
+            this->door_state_ = DoorState::CLOSED;
+        } else if (!this->limits_.close_limit_reached && !this->limits_.open_limit_reached) {
+            if (this->limits_.last_close_limit) {
+                this->door_state_ = DoorState::OPENING;
             }
 
-            this->ratgdo_->received(this->door_state_);
+            if (this->limits_.last_open_limit) {
+                this->door_state_ = DoorState::CLOSING;
+            }
         }
 
-        void DryContact::light_action(LightAction action)
-        {
-            ESP_LOG1(TAG, "Ignoring light action: %s", LOG_STR_ARG(LightAction_to_string(action)));
+        this->ratgdo_->received(this->door_state_);
+    }
+
+    void DryContact::light_action(LightAction action)
+    {
+        ESP_LOG1(TAG, "Ignoring light action: %s", LOG_STR_ARG(LightAction_to_string(action)));
+        return;
+    }
+
+    void DryContact::lock_action(LockAction action)
+    {
+        ESP_LOG1(TAG, "Ignoring lock action: %s", LOG_STR_ARG(LockAction_to_string(action)));
+        return;
+    }
+
+    void DryContact::door_action(DoorAction action)
+    {
+        if (action == DoorAction::OPEN && this->limits_.open_limit_reached) {
+            ESP_LOGW(TAG, "The door is already fully open. Ignoring door action: %s", LOG_STR_ARG(DoorAction_to_string(action)));
+            return;
+        }
+        if (action == DoorAction::CLOSE && this->limits_.close_limit_reached) {
+            ESP_LOGW(TAG, "The door is already fully closed. Ignoring door action: %s", LOG_STR_ARG(DoorAction_to_string(action)));
             return;
         }
 
-        void DryContact::lock_action(LockAction action)
-        {
-            ESP_LOG1(TAG, "Ignoring lock action: %s", LOG_STR_ARG(LockAction_to_string(action)));
-            return;
-        }
+        ESP_LOG1(TAG, "Door action: %s", LOG_STR_ARG(DoorAction_to_string(action)));
 
-        void DryContact::door_action(DoorAction action)
-        {
-            if (action == DoorAction::OPEN && this->limits_.open_limit_reached) {
-                ESP_LOGW(TAG, "The door is already fully open. Ignoring door action: %s", LOG_STR_ARG(DoorAction_to_string(action)));
-                return;
-            }
-            if (action == DoorAction::CLOSE && this->limits_.close_limit_reached) {
-                ESP_LOGW(TAG, "The door is already fully closed. Ignoring door action: %s", LOG_STR_ARG(DoorAction_to_string(action)));
-                return;
-            }
-
-            ESP_LOG1(TAG, "Door action: %s", LOG_STR_ARG(DoorAction_to_string(action)));
-
-            if (action == DoorAction::OPEN) {
-                this->discrete_open_pin_->digital_write(1);
-                this->scheduler_->set_timeout(this->ratgdo_, "", 500, [this] {
-                    this->discrete_open_pin_->digital_write(0);
-                });
-            }
-
-            if (action == DoorAction::CLOSE) {
-                this->discrete_close_pin_->digital_write(1);
-                this->scheduler_->set_timeout(this->ratgdo_, "", 500, [this] {
-                    this->discrete_close_pin_->digital_write(0);
-                });
-            }
-
-            this->tx_pin_->digital_write(1); // Single button control
+        if (action == DoorAction::OPEN) {
+            this->discrete_open_pin_->digital_write(1);
             this->scheduler_->set_timeout(this->ratgdo_, "", 500, [this] {
-                this->tx_pin_->digital_write(0);
+                this->discrete_open_pin_->digital_write(0);
             });
         }
 
-        Result DryContact::call(Args args)
-        {
-            return { };
+        if (action == DoorAction::CLOSE) {
+            this->discrete_close_pin_->digital_write(1);
+            this->scheduler_->set_timeout(this->ratgdo_, "", 500, [this] {
+                this->discrete_close_pin_->digital_write(0);
+            });
         }
 
-    } // namespace dry_contact
-} // namespace ratgdo
-} // namespace esphome
+        this->tx_pin_->digital_write(1); // Single button control
+        this->scheduler_->set_timeout(this->ratgdo_, "", 500, [this] {
+            this->tx_pin_->digital_write(0);
+        });
+    }
+
+    Result DryContact::call(Args args)
+    {
+        return { };
+    }
+
+} // namespace dry_contact
+} // namespace esphome::ratgdo
 
 #endif // PROTOCOL_DRYCONTACT

--- a/components/ratgdo/dry_contact.h
+++ b/components/ratgdo/dry_contact.h
@@ -18,70 +18,71 @@ namespace esphome {
 class Scheduler;
 class InternalGPIOPin;
 
-namespace ratgdo {
-    namespace dry_contact {
-
-        using namespace esphome::ratgdo::protocol;
-        using namespace esphome::gpio;
-
-        class DryContact : public Protocol {
-        public:
-            void setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin);
-            void loop();
-            void dump_config();
-
-            void sync();
-
-            void light_action(LightAction action);
-            void lock_action(LockAction action);
-            void door_action(DoorAction action);
-            void set_open_limit(bool state);
-            void set_close_limit(bool state);
-            void send_door_state();
-
-            void set_discrete_open_pin(InternalGPIOPin* pin)
-            {
-                this->discrete_open_pin_ = pin;
-                this->discrete_open_pin_->setup();
-                this->discrete_open_pin_->pin_mode(gpio::FLAG_OUTPUT);
-            }
-
-            void set_discrete_close_pin(InternalGPIOPin* pin)
-            {
-                this->discrete_close_pin_ = pin;
-                this->discrete_close_pin_->setup();
-                this->discrete_close_pin_->pin_mode(gpio::FLAG_OUTPUT);
-            }
-
-            Result call(Args args);
-
-            const Traits& traits() const { return this->traits_; }
-
-        protected:
-            // Pointers first (4-byte aligned)
-            InternalGPIOPin* tx_pin_;
-            InternalGPIOPin* rx_pin_;
-            InternalGPIOPin* discrete_open_pin_;
-            InternalGPIOPin* discrete_close_pin_;
-            RATGDOComponent* ratgdo_;
-            Scheduler* scheduler_;
-
-            // Traits (likely aligned structure)
-            Traits traits_;
-
-            // Small members grouped at the end
-            DoorState door_state_;
-            struct {
-                uint8_t open_limit_reached : 1;
-                uint8_t last_open_limit : 1;
-                uint8_t close_limit_reached : 1;
-                uint8_t last_close_limit : 1;
-                uint8_t reserved : 4; // Reserved for future use
-            } limits_;
-        };
-
-    } // namespace dry_contact
-} // namespace ratgdo
 } // namespace esphome
+
+namespace esphome::ratgdo {
+namespace dry_contact {
+
+    using namespace esphome::ratgdo::protocol;
+    using namespace esphome::gpio;
+
+    class DryContact : public Protocol {
+    public:
+        void setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin);
+        void loop();
+        void dump_config();
+
+        void sync();
+
+        void light_action(LightAction action);
+        void lock_action(LockAction action);
+        void door_action(DoorAction action);
+        void set_open_limit(bool state);
+        void set_close_limit(bool state);
+        void send_door_state();
+
+        void set_discrete_open_pin(InternalGPIOPin* pin)
+        {
+            this->discrete_open_pin_ = pin;
+            this->discrete_open_pin_->setup();
+            this->discrete_open_pin_->pin_mode(gpio::FLAG_OUTPUT);
+        }
+
+        void set_discrete_close_pin(InternalGPIOPin* pin)
+        {
+            this->discrete_close_pin_ = pin;
+            this->discrete_close_pin_->setup();
+            this->discrete_close_pin_->pin_mode(gpio::FLAG_OUTPUT);
+        }
+
+        Result call(Args args);
+
+        const Traits& traits() const { return this->traits_; }
+
+    protected:
+        // Pointers first (4-byte aligned)
+        InternalGPIOPin* tx_pin_;
+        InternalGPIOPin* rx_pin_;
+        InternalGPIOPin* discrete_open_pin_;
+        InternalGPIOPin* discrete_close_pin_;
+        RATGDOComponent* ratgdo_;
+        Scheduler* scheduler_;
+
+        // Traits (likely aligned structure)
+        Traits traits_;
+
+        // Small members grouped at the end
+        DoorState door_state_;
+        struct {
+            uint8_t open_limit_reached : 1;
+            uint8_t last_open_limit : 1;
+            uint8_t close_limit_reached : 1;
+            uint8_t last_close_limit : 1;
+            uint8_t reserved : 4; // Reserved for future use
+        } limits_;
+    };
+
+} // namespace dry_contact
+} // namespace esphome::ratgdo
 
 #endif // PROTOCOL_DRYCONTACT

--- a/components/ratgdo/light/ratgdo_light_output.cpp
+++ b/components/ratgdo/light/ratgdo_light_output.cpp
@@ -2,67 +2,65 @@
 #include "../ratgdo_state.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    using namespace esphome::light;
+using namespace esphome::light;
 
-    static const char* const TAG = "ratgdo.light";
+static const char* const TAG = "ratgdo.light";
 
-    void RATGDOLightOutput::dump_config()
-    {
-        ESP_LOGCONFIG(TAG, "RATGDO Light");
+void RATGDOLightOutput::dump_config()
+{
+    ESP_LOGCONFIG(TAG, "RATGDO Light");
+}
+
+void RATGDOLightOutput::setup()
+{
+    this->parent_->subscribe_light_state([this](LightState state) {
+        this->on_light_state(state);
+    });
+}
+
+void RATGDOLightOutput::on_light_state(esphome::ratgdo::LightState state)
+{
+    if (this->light_state_) {
+        this->has_initial_state_ = true;
+        set_state(state);
     }
+}
 
-    void RATGDOLightOutput::setup()
-    {
-        this->parent_->subscribe_light_state([this](LightState state) {
-            this->on_light_state(state);
-        });
+void RATGDOLightOutput::set_state(esphome::ratgdo::LightState state)
+{
+    bool is_on = state == LightState::ON;
+    this->light_state_->current_values.set_state(is_on);
+    this->light_state_->remote_values.set_state(is_on);
+    this->light_state_->publish_state();
+}
+
+void RATGDOLightOutput::setup_state(light::LightState* light_state)
+{
+    esphome::ratgdo::LightState state = this->parent_->get_light_state();
+    this->light_state_ = light_state;
+    this->set_state(state);
+}
+
+LightTraits RATGDOLightOutput::get_traits()
+{
+    auto traits = LightTraits();
+    traits.set_supported_color_modes({ light::ColorMode::ON_OFF });
+    return traits;
+}
+
+void RATGDOLightOutput::write_state(light::LightState* state)
+{
+    if (!this->has_initial_state_)
+        return;
+    bool binary;
+    state->current_values_as_binary(&binary);
+    if (binary) {
+        this->parent_->light_on();
+    } else {
+        this->parent_->light_off();
     }
+}
 
-    void RATGDOLightOutput::on_light_state(esphome::ratgdo::LightState state)
-    {
-        if (this->light_state_) {
-            this->has_initial_state_ = true;
-            set_state(state);
-        }
-    }
-
-    void RATGDOLightOutput::set_state(esphome::ratgdo::LightState state)
-    {
-        bool is_on = state == LightState::ON;
-        this->light_state_->current_values.set_state(is_on);
-        this->light_state_->remote_values.set_state(is_on);
-        this->light_state_->publish_state();
-    }
-
-    void RATGDOLightOutput::setup_state(light::LightState* light_state)
-    {
-        esphome::ratgdo::LightState state = this->parent_->get_light_state();
-        this->light_state_ = light_state;
-        this->set_state(state);
-    }
-
-    LightTraits RATGDOLightOutput::get_traits()
-    {
-        auto traits = LightTraits();
-        traits.set_supported_color_modes({ light::ColorMode::ON_OFF });
-        return traits;
-    }
-
-    void RATGDOLightOutput::write_state(light::LightState* state)
-    {
-        if (!this->has_initial_state_)
-            return;
-        bool binary;
-        state->current_values_as_binary(&binary);
-        if (binary) {
-            this->parent_->light_on();
-        } else {
-            this->parent_->light_off();
-        }
-    }
-
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/light/ratgdo_light_output.h
+++ b/components/ratgdo/light/ratgdo_light_output.h
@@ -5,25 +5,23 @@
 #include "esphome/components/light/light_output.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    class RATGDOLightOutput : public light::LightOutput, public RATGDOClient, public Component {
-    public:
-        void dump_config() override;
-        void setup() override;
-        light::LightTraits get_traits() override;
-        void write_state(light::LightState* state) override;
-        void setup_state(light::LightState* state) override;
-        void set_state(esphome::ratgdo::LightState state);
-        light::LightState* get_state() { return this->light_state_; }
+class RATGDOLightOutput : public light::LightOutput, public RATGDOClient, public Component {
+public:
+    void dump_config() override;
+    void setup() override;
+    light::LightTraits get_traits() override;
+    void write_state(light::LightState* state) override;
+    void setup_state(light::LightState* state) override;
+    void set_state(esphome::ratgdo::LightState state);
+    light::LightState* get_state() { return this->light_state_; }
 
-        void on_light_state(esphome::ratgdo::LightState state);
+    void on_light_state(esphome::ratgdo::LightState state);
 
-    protected:
-        light::LightState* light_state_;
-        bool has_initial_state_ = false;
-    };
+protected:
+    light::LightState* light_state_;
+    bool has_initial_state_ = false;
+};
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/lock/ratgdo_lock.cpp
+++ b/components/ratgdo/lock/ratgdo_lock.cpp
@@ -2,54 +2,52 @@
 #include "../ratgdo_state.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    static const char* const TAG = "ratgdo.lock";
+static const char* const TAG = "ratgdo.lock";
 
-    void RATGDOLock::dump_config()
-    {
-        LOG_LOCK("", "RATGDO Lock", this);
-        ESP_LOGCONFIG(TAG, "  Type: Lock");
+void RATGDOLock::dump_config()
+{
+    LOG_LOCK("", "RATGDO Lock", this);
+    ESP_LOGCONFIG(TAG, "  Type: Lock");
+}
+
+void RATGDOLock::setup()
+{
+    this->parent_->subscribe_lock_state([this](LockState state) {
+        this->on_lock_state(state);
+    });
+}
+
+void RATGDOLock::on_lock_state(LockState state)
+{
+    if (state == LockState::LOCKED && this->state == lock::LockState::LOCK_STATE_LOCKED) {
+        return;
+    }
+    if (state == LockState::UNLOCKED && this->state == lock::LockState::LOCK_STATE_UNLOCKED) {
+        return;
     }
 
-    void RATGDOLock::setup()
-    {
-        this->parent_->subscribe_lock_state([this](LockState state) {
-            this->on_lock_state(state);
-        });
+    auto call = this->make_call();
+    if (state == LockState::LOCKED) {
+        call.set_state(lock::LockState::LOCK_STATE_LOCKED);
+    } else if (state == LockState::UNLOCKED) {
+        call.set_state(lock::LockState::LOCK_STATE_UNLOCKED);
+    }
+    this->publish_state(*call.get_state());
+}
+
+void RATGDOLock::control(const lock::LockCall& call)
+{
+    auto state = *call.get_state();
+
+    if (state == lock::LockState::LOCK_STATE_LOCKED) {
+        this->parent_->lock();
+    } else if (state == lock::LockState::LOCK_STATE_UNLOCKED) {
+        this->parent_->unlock();
     }
 
-    void RATGDOLock::on_lock_state(LockState state)
-    {
-        if (state == LockState::LOCKED && this->state == lock::LockState::LOCK_STATE_LOCKED) {
-            return;
-        }
-        if (state == LockState::UNLOCKED && this->state == lock::LockState::LOCK_STATE_UNLOCKED) {
-            return;
-        }
+    this->publish_state(state);
+}
 
-        auto call = this->make_call();
-        if (state == LockState::LOCKED) {
-            call.set_state(lock::LockState::LOCK_STATE_LOCKED);
-        } else if (state == LockState::UNLOCKED) {
-            call.set_state(lock::LockState::LOCK_STATE_UNLOCKED);
-        }
-        this->publish_state(*call.get_state());
-    }
-
-    void RATGDOLock::control(const lock::LockCall& call)
-    {
-        auto state = *call.get_state();
-
-        if (state == lock::LockState::LOCK_STATE_LOCKED) {
-            this->parent_->lock();
-        } else if (state == lock::LockState::LOCK_STATE_UNLOCKED) {
-            this->parent_->unlock();
-        }
-
-        this->publish_state(state);
-    }
-
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/lock/ratgdo_lock.h
+++ b/components/ratgdo/lock/ratgdo_lock.h
@@ -5,17 +5,15 @@
 #include "esphome/components/lock/lock.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    class RATGDOLock : public lock::Lock, public RATGDOClient, public Component {
-    public:
-        void dump_config() override;
-        void setup() override;
+class RATGDOLock : public lock::Lock, public RATGDOClient, public Component {
+public:
+    void dump_config() override;
+    void setup() override;
 
-        void on_lock_state(LockState state);
-        void control(const lock::LockCall& call) override;
-    };
+    void on_lock_state(LockState state);
+    void control(const lock::LockCall& call) override;
+};
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/macros.h
+++ b/components/ratgdo/macros.h
@@ -51,32 +51,30 @@
 #define COUNT_ONE0(type, name, val) +1
 #define COUNT_ONE(name, tuple) COUNT_ONE0 LPAREN name, TUPLE tuple)
 
-namespace esphome {
-namespace ratgdo {
-    namespace detail {
+namespace esphome::ratgdo {
+namespace detail {
 
-        template <size_t N>
-        struct EnumStringOffsets {
-            uint8_t data[N];
-        };
+    template <size_t N>
+    struct EnumStringOffsets {
+        uint8_t data[N];
+    };
 
-        template <size_t Count, size_t BlobSize>
-        constexpr EnumStringOffsets<Count> compute_enum_string_offsets(const char (&blob)[BlobSize])
-        {
-            EnumStringOffsets<Count> result { };
-            result.data[0] = 0;
-            size_t entry = 1;
-            for (size_t i = 0; i < BlobSize - 1 && entry < Count; ++i) {
-                if (blob[i] == '\0') {
-                    result.data[entry++] = static_cast<uint8_t>(i + 1);
-                }
+    template <size_t Count, size_t BlobSize>
+    constexpr EnumStringOffsets<Count> compute_enum_string_offsets(const char (&blob)[BlobSize])
+    {
+        EnumStringOffsets<Count> result { };
+        result.data[0] = 0;
+        size_t entry = 1;
+        for (size_t i = 0; i < BlobSize - 1 && entry < Count; ++i) {
+            if (blob[i] == '\0') {
+                result.data[entry++] = static_cast<uint8_t>(i + 1);
             }
-            return result;
         }
+        return result;
+    }
 
-    } // namespace detail
-} // namespace ratgdo
-} // namespace esphome
+} // namespace detail
+} // namespace esphome::ratgdo
 
 // Platform-specific helpers for enum string return types
 #ifdef USE_ESP8266

--- a/components/ratgdo/number/ratgdo_number.cpp
+++ b/components/ratgdo/number/ratgdo_number.cpp
@@ -2,187 +2,185 @@
 #include "../ratgdo_state.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    using protocol::SetClientID;
-    using protocol::SetRollingCodeCounter;
+using protocol::SetClientID;
+using protocol::SetRollingCodeCounter;
 
-    float normalize_client_id(float client_id)
-    {
-        uint32_t int_value = static_cast<uint32_t>(client_id);
-        if ((int_value & 0xFFF) != 0x539) {
-            client_id = ceil((client_id - 0x539) / 0x1000) * 0x1000 + 0x539;
-        }
-        return client_id;
+float normalize_client_id(float client_id)
+{
+    uint32_t int_value = static_cast<uint32_t>(client_id);
+    if ((int_value & 0xFFF) != 0x539) {
+        client_id = ceil((client_id - 0x539) / 0x1000) * 0x1000 + 0x539;
     }
+    return client_id;
+}
 
-    static const char* const TAG = "ratgdo.number";
+static const char* const TAG = "ratgdo.number";
 
-    void RATGDONumber::dump_config()
-    {
-        LOG_NUMBER("", "RATGDO Number", this);
-        switch (this->number_type_) {
-        case RATGDO_CLIENT_ID:
-            ESP_LOGCONFIG(TAG, " Type: Client ID");
-            break;
-        case RATGDO_ROLLING_CODE_COUNTER:
-            ESP_LOGCONFIG(TAG, "  Type: Rolling Code Counter");
-            break;
-        case RATGDO_OPENING_DURATION:
-            ESP_LOGCONFIG(TAG, "  Type: Opening Duration");
-            break;
-        case RATGDO_CLOSING_DURATION:
-            ESP_LOGCONFIG(TAG, "  Type: Closing Duration");
-            break;
+void RATGDONumber::dump_config()
+{
+    LOG_NUMBER("", "RATGDO Number", this);
+    switch (this->number_type_) {
+    case RATGDO_CLIENT_ID:
+        ESP_LOGCONFIG(TAG, " Type: Client ID");
+        break;
+    case RATGDO_ROLLING_CODE_COUNTER:
+        ESP_LOGCONFIG(TAG, "  Type: Rolling Code Counter");
+        break;
+    case RATGDO_OPENING_DURATION:
+        ESP_LOGCONFIG(TAG, "  Type: Opening Duration");
+        break;
+    case RATGDO_CLOSING_DURATION:
+        ESP_LOGCONFIG(TAG, "  Type: Closing Duration");
+        break;
 #ifdef RATGDO_USE_CLOSING_DELAY
-        case RATGDO_CLOSING_DELAY:
-            ESP_LOGCONFIG(TAG, "  Type: Closing Delay");
-            break;
+    case RATGDO_CLOSING_DELAY:
+        ESP_LOGCONFIG(TAG, "  Type: Closing Delay");
+        break;
 #endif
 #ifdef RATGDO_USE_DISTANCE_SENSOR
-        case RATGDO_TARGET_DISTANCE_MEASUREMENT:
-            ESP_LOGCONFIG(TAG, " Type: Target Distance Measurement");
-            break;
+    case RATGDO_TARGET_DISTANCE_MEASUREMENT:
+        ESP_LOGCONFIG(TAG, " Type: Target Distance Measurement");
+        break;
 #endif
-        default:
-            break;
-        }
+    default:
+        break;
     }
+}
 
-    void RATGDONumber::setup()
-    {
-        float value;
-        this->pref_ = this->make_entity_preference<float>();
-        if (!this->pref_.load(&value)) {
-            if (this->number_type_ == RATGDO_CLIENT_ID) {
-                value = ((random_uint32() + 1) % 0x7FF) << 12 | 0x539; // max size limited to be precisely convertible to float
-            } else {
-                value = 0;
-            }
+void RATGDONumber::setup()
+{
+    float value;
+    this->pref_ = this->make_entity_preference<float>();
+    if (!this->pref_.load(&value)) {
+        if (this->number_type_ == RATGDO_CLIENT_ID) {
+            value = ((random_uint32() + 1) % 0x7FF) << 12 | 0x539; // max size limited to be precisely convertible to float
         } else {
-            if (this->number_type_ == RATGDO_CLIENT_ID) {
-                uint32_t int_value = static_cast<uint32_t>(value);
-                if ((int_value & 0xFFF) != 0x539) {
-                    value = ((random_uint32() + 1) % 0x7FF) << 12 | 0x539; // max size limited to be precisely convertible to float
-                    this->pref_.save(&value);
-                }
+            value = 0;
+        }
+    } else {
+        if (this->number_type_ == RATGDO_CLIENT_ID) {
+            uint32_t int_value = static_cast<uint32_t>(value);
+            if ((int_value & 0xFFF) != 0x539) {
+                value = ((random_uint32() + 1) % 0x7FF) << 12 | 0x539; // max size limited to be precisely convertible to float
+                this->pref_.save(&value);
             }
         }
-        this->control(value);
+    }
+    this->control(value);
 
-        switch (this->number_type_) {
-        case RATGDO_ROLLING_CODE_COUNTER:
-            this->parent_->subscribe_rolling_code_counter([this](uint32_t value) {
-                this->update_state(value);
-            });
-            break;
-        case RATGDO_OPENING_DURATION:
-            this->parent_->subscribe_opening_duration([this](float value) {
-                this->update_state(value);
-            });
-            break;
-        case RATGDO_CLOSING_DURATION:
-            this->parent_->subscribe_closing_duration([this](float value) {
-                this->update_state(value);
-            });
-            break;
+    switch (this->number_type_) {
+    case RATGDO_ROLLING_CODE_COUNTER:
+        this->parent_->subscribe_rolling_code_counter([this](uint32_t value) {
+            this->update_state(value);
+        });
+        break;
+    case RATGDO_OPENING_DURATION:
+        this->parent_->subscribe_opening_duration([this](float value) {
+            this->update_state(value);
+        });
+        break;
+    case RATGDO_CLOSING_DURATION:
+        this->parent_->subscribe_closing_duration([this](float value) {
+            this->update_state(value);
+        });
+        break;
 #ifdef RATGDO_USE_CLOSING_DELAY
-        case RATGDO_CLOSING_DELAY:
-            this->parent_->subscribe_closing_delay([this](uint32_t value) {
-                this->update_state(value);
-            });
-            break;
+    case RATGDO_CLOSING_DELAY:
+        this->parent_->subscribe_closing_delay([this](uint32_t value) {
+            this->update_state(value);
+        });
+        break;
 #endif
 #ifdef RATGDO_USE_DISTANCE_SENSOR
-        case RATGDO_TARGET_DISTANCE_MEASUREMENT:
-            // this->parent_->subscribe_target_distance_measurement([=](float value) {
-            //     this->update_state(value);
-            // });
-            break;
+    case RATGDO_TARGET_DISTANCE_MEASUREMENT:
+        // this->parent_->subscribe_target_distance_measurement([=](float value) {
+        //     this->update_state(value);
+        // });
+        break;
 #endif
-        default:
-            break;
-        }
+    default:
+        break;
     }
+}
 
-    void RATGDONumber::set_number_type(NumberType number_type_)
-    {
-        this->number_type_ = number_type_;
-        switch (this->number_type_) {
-        case RATGDO_OPENING_DURATION:
-        case RATGDO_CLOSING_DURATION:
-            this->traits.set_step(0.1);
-            this->traits.set_min_value(0.0);
-            this->traits.set_max_value(180.0);
-            break;
+void RATGDONumber::set_number_type(NumberType number_type_)
+{
+    this->number_type_ = number_type_;
+    switch (this->number_type_) {
+    case RATGDO_OPENING_DURATION:
+    case RATGDO_CLOSING_DURATION:
+        this->traits.set_step(0.1);
+        this->traits.set_min_value(0.0);
+        this->traits.set_max_value(180.0);
+        break;
 #ifdef RATGDO_USE_CLOSING_DELAY
-        case RATGDO_CLOSING_DELAY:
-            this->traits.set_step(1);
-            this->traits.set_min_value(0.0);
-            this->traits.set_max_value(60.0);
-            break;
+    case RATGDO_CLOSING_DELAY:
+        this->traits.set_step(1);
+        this->traits.set_min_value(0.0);
+        this->traits.set_max_value(60.0);
+        break;
 #endif
-        case RATGDO_ROLLING_CODE_COUNTER:
-            this->traits.set_max_value(0xfffffff);
-            break;
-        case RATGDO_CLIENT_ID:
-            this->traits.set_step(0x1000);
-            this->traits.set_min_value(0x539);
-            this->traits.set_max_value(0x7ff539);
-            break;
+    case RATGDO_ROLLING_CODE_COUNTER:
+        this->traits.set_max_value(0xfffffff);
+        break;
+    case RATGDO_CLIENT_ID:
+        this->traits.set_step(0x1000);
+        this->traits.set_min_value(0x539);
+        this->traits.set_max_value(0x7ff539);
+        break;
 #ifdef RATGDO_USE_DISTANCE_SENSOR
-        case RATGDO_TARGET_DISTANCE_MEASUREMENT:
-            this->traits.set_step(1);
-            this->traits.set_min_value(5);
-            this->traits.set_max_value(3500);
-            break;
+    case RATGDO_TARGET_DISTANCE_MEASUREMENT:
+        this->traits.set_step(1);
+        this->traits.set_min_value(5);
+        this->traits.set_max_value(3500);
+        break;
 #endif
-        default:
-            break;
-        }
+    default:
+        break;
     }
+}
 
-    void RATGDONumber::update_state(float value)
-    {
-        if (value == this->state) {
-            return;
-        }
-        this->pref_.save(&value);
-        this->publish_state(value);
+void RATGDONumber::update_state(float value)
+{
+    if (value == this->state) {
+        return;
     }
+    this->pref_.save(&value);
+    this->publish_state(value);
+}
 
-    void RATGDONumber::control(float value)
-    {
-        switch (this->number_type_) {
-        case RATGDO_ROLLING_CODE_COUNTER:
-            this->parent_->call_protocol(SetRollingCodeCounter { static_cast<uint32_t>(value) });
-            break;
-        case RATGDO_OPENING_DURATION:
-            this->parent_->set_opening_duration(value);
-            break;
-        case RATGDO_CLOSING_DURATION:
-            this->parent_->set_closing_duration(value);
-            break;
+void RATGDONumber::control(float value)
+{
+    switch (this->number_type_) {
+    case RATGDO_ROLLING_CODE_COUNTER:
+        this->parent_->call_protocol(SetRollingCodeCounter { static_cast<uint32_t>(value) });
+        break;
+    case RATGDO_OPENING_DURATION:
+        this->parent_->set_opening_duration(value);
+        break;
+    case RATGDO_CLOSING_DURATION:
+        this->parent_->set_closing_duration(value);
+        break;
 #ifdef RATGDO_USE_CLOSING_DELAY
-        case RATGDO_CLOSING_DELAY:
-            this->parent_->set_closing_delay(value);
-            break;
+    case RATGDO_CLOSING_DELAY:
+        this->parent_->set_closing_delay(value);
+        break;
 #endif
-        case RATGDO_CLIENT_ID:
-            value = normalize_client_id(value);
-            this->parent_->call_protocol(SetClientID { static_cast<uint32_t>(value) });
-            break;
+    case RATGDO_CLIENT_ID:
+        value = normalize_client_id(value);
+        this->parent_->call_protocol(SetClientID { static_cast<uint32_t>(value) });
+        break;
 #ifdef RATGDO_USE_DISTANCE_SENSOR
-        case RATGDO_TARGET_DISTANCE_MEASUREMENT:
-            this->parent_->set_target_distance_measurement(value);
-            break;
+    case RATGDO_TARGET_DISTANCE_MEASUREMENT:
+        this->parent_->set_target_distance_measurement(value);
+        break;
 #endif
-        default:
-            break;
-        }
-        this->update_state(value);
+    default:
+        break;
     }
+    this->update_state(value);
+}
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/number/ratgdo_number.h
+++ b/components/ratgdo/number/ratgdo_number.h
@@ -6,39 +6,37 @@
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    enum NumberType {
-        RATGDO_CLIENT_ID,
-        RATGDO_ROLLING_CODE_COUNTER,
-        RATGDO_OPENING_DURATION,
-        RATGDO_CLOSING_DURATION,
+enum NumberType {
+    RATGDO_CLIENT_ID,
+    RATGDO_ROLLING_CODE_COUNTER,
+    RATGDO_OPENING_DURATION,
+    RATGDO_CLOSING_DURATION,
 #ifdef RATGDO_USE_CLOSING_DELAY
-        RATGDO_CLOSING_DELAY,
+    RATGDO_CLOSING_DELAY,
 #endif
 #ifdef RATGDO_USE_DISTANCE_SENSOR
-        RATGDO_TARGET_DISTANCE_MEASUREMENT,
+    RATGDO_TARGET_DISTANCE_MEASUREMENT,
 #endif
-    };
+};
 
-    class RATGDONumber : public number::Number, public RATGDOClient, public Component {
-    public:
-        void dump_config() override;
-        void setup() override;
-        void set_number_type(NumberType number_type);
-        // other esphome components that persist state in the flash have HARDWARE priority
-        // ensure we get initialized before them, so that the state doesn't get invalidated
-        // by components that might be added in the future
-        float get_setup_priority() const override { return setup_priority::HARDWARE + 1; }
+class RATGDONumber : public number::Number, public RATGDOClient, public Component {
+public:
+    void dump_config() override;
+    void setup() override;
+    void set_number_type(NumberType number_type);
+    // other esphome components that persist state in the flash have HARDWARE priority
+    // ensure we get initialized before them, so that the state doesn't get invalidated
+    // by components that might be added in the future
+    float get_setup_priority() const override { return setup_priority::HARDWARE + 1; }
 
-        void update_state(float value);
-        void control(float value) override;
+    void update_state(float value);
+    void control(float value) override;
 
-    protected:
-        NumberType number_type_;
-        ESPPreferenceObject pref_;
-    };
+protected:
+    NumberType number_type_;
+    ESPPreferenceObject pref_;
+};
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/observable.cpp
+++ b/components/ratgdo/observable.cpp
@@ -1,20 +1,18 @@
 #include "observable.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    static const char* const TAG = "ratgdo.observable";
+static const char* const TAG = "ratgdo.observable";
 
-    void log_multiple_subscribers()
-    {
-        ESP_LOGE(TAG, "single_observable already has a subscriber! This will overwrite the existing subscriber.");
-    }
+void log_multiple_subscribers()
+{
+    ESP_LOGE(TAG, "single_observable already has a subscriber! This will overwrite the existing subscriber.");
+}
 
-    void log_observer_overflow()
-    {
-        ESP_LOGE(TAG, "observable has too many subscribers! Ignoring new subscriber.");
-    }
+void log_observer_overflow()
+{
+    ESP_LOGE(TAG, "observable has too many subscribers! Ignoring new subscriber.");
+}
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/observable.h
+++ b/components/ratgdo/observable.h
@@ -5,165 +5,163 @@
 #include <type_traits>
 #include <utility>
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    void log_multiple_subscribers();
-    void log_observer_overflow();
+void log_multiple_subscribers();
+void log_observer_overflow();
 
-    // Lightweight type-erased callback (16 bytes on 32-bit).
-    // For small trivially-copyable callables (like [this], [this, f], or [this, f, id] lambdas),
-    // stores the callable inline — zero heap allocation.
-    // Supports up to 3 * sizeof(void*) bytes (12 bytes on 32-bit, 24 on 64-bit).
-    inline constexpr size_t CALLBACK_STORAGE_SIZE = 3 * sizeof(void*);
+// Lightweight type-erased callback (16 bytes on 32-bit).
+// For small trivially-copyable callables (like [this], [this, f], or [this, f, id] lambdas),
+// stores the callable inline — zero heap allocation.
+// Supports up to 3 * sizeof(void*) bytes (12 bytes on 32-bit, 24 on 64-bit).
+inline constexpr size_t CALLBACK_STORAGE_SIZE = 3 * sizeof(void*);
 
-    template <typename... Ts>
-    struct Callback {
-        using fn_t = void (*)(const void*, Ts...);
-        fn_t fn_ { nullptr };
-        alignas(void*) uint8_t storage_[CALLBACK_STORAGE_SIZE] { };
+template <typename... Ts>
+struct Callback {
+    using fn_t = void (*)(const void*, Ts...);
+    fn_t fn_ { nullptr };
+    alignas(void*) uint8_t storage_[CALLBACK_STORAGE_SIZE] { };
 
-        void call(Ts... args) const { this->fn_(this->storage_, args...); }
-        explicit operator bool() const { return this->fn_ != nullptr; }
+    void call(Ts... args) const { this->fn_(this->storage_, args...); }
+    explicit operator bool() const { return this->fn_ != nullptr; }
 
-        template <typename F>
-        static Callback create(F&& f)
-        {
-            Callback cb;
-            using Decay = std::decay_t<F>;
-            static_assert(!std::is_function_v<std::remove_reference_t<F>>,
-                "Pass function pointers, not function references");
-            static_assert(std::is_trivially_copyable_v<Decay>, "Observable callbacks must be trivially copyable (e.g. [this] lambdas)");
-            static_assert(sizeof(Decay) <= CALLBACK_STORAGE_SIZE, "Observable callbacks must fit in storage (capture at most 3 pointers)");
-            cb.fn_ = [](const void* storage, Ts... args) {
-                alignas(Decay) char buf[sizeof(Decay)];
-                __builtin_memcpy(buf, storage, sizeof(Decay));
-                (*std::launder(reinterpret_cast<Decay*>(buf)))(args...);
-            };
-            __builtin_memcpy(cb.storage_, &f, sizeof(Decay));
-            return cb;
+    template <typename F>
+    static Callback create(F&& f)
+    {
+        Callback cb;
+        using Decay = std::decay_t<F>;
+        static_assert(!std::is_function_v<std::remove_reference_t<F>>,
+            "Pass function pointers, not function references");
+        static_assert(std::is_trivially_copyable_v<Decay>, "Observable callbacks must be trivially copyable (e.g. [this] lambdas)");
+        static_assert(sizeof(Decay) <= CALLBACK_STORAGE_SIZE, "Observable callbacks must fit in storage (capture at most 3 pointers)");
+        cb.fn_ = [](const void* storage, Ts... args) {
+            alignas(Decay) char buf[sizeof(Decay)];
+            __builtin_memcpy(buf, storage, sizeof(Decay));
+            (*std::launder(reinterpret_cast<Decay*>(buf)))(args...);
+        };
+        __builtin_memcpy(cb.storage_, &f, sizeof(Decay));
+        return cb;
+    }
+};
+
+// Primary template for observable with subscribers.
+template <typename T, uint8_t MaxObservers>
+class observable {
+public:
+    observable(const T& value)
+        : value_(value)
+    {
+    }
+
+    template <typename U>
+    observable& operator=(U value)
+    {
+        if (value != this->value_) {
+            this->value_ = value;
+            this->notify();
         }
-    };
+        return *this;
+    }
 
-    // Primary template for observable with subscribers.
-    template <typename T, uint8_t MaxObservers>
-    class observable {
-    public:
-        observable(const T& value)
-            : value_(value)
-        {
-        }
+    T const* operator&() const { return &this->value_; }
+    T const& operator*() const { return this->value_; }
 
-        template <typename U>
-        observable& operator=(U value)
-        {
-            if (value != this->value_) {
-                this->value_ = value;
-                this->notify();
-            }
-            return *this;
-        }
-
-        T const* operator&() const { return &this->value_; }
-        T const& operator*() const { return this->value_; }
-
-        template <typename F>
-        void subscribe(F&& observer)
-        {
-            if (this->count_ >= MaxObservers) {
-                log_observer_overflow();
-                return;
-            }
-            this->observers_[this->count_++] = Callback<T>::create(std::forward<F>(observer));
-        }
-
-        void notify() const
-        {
-            for (uint8_t i = 0; i < this->count_; i++) {
-                this->observers_[i].call(this->value_);
-            }
-        }
-
-    private:
-        T value_;
-        Callback<T> observers_[MaxObservers] { };
-        uint8_t count_ { 0 };
-    };
-
-    // Specialization for zero subscribers — no array, no count, notify is a no-op.
-    template <typename T>
-    class observable<T, 0> {
-    public:
-        observable(const T& value)
-            : value_(value)
-        {
-        }
-
-        template <typename U>
-        observable& operator=(U value)
-        {
-            if (value != this->value_) {
-                this->value_ = value;
-            }
-            return *this;
-        }
-
-        T const* operator&() const { return &this->value_; }
-        T const& operator*() const { return this->value_; }
-
-        template <typename F>
-        void subscribe(F&&)
-        {
+    template <typename F>
+    void subscribe(F&& observer)
+    {
+        if (this->count_ >= MaxObservers) {
             log_observer_overflow();
+            return;
         }
+        this->observers_[this->count_++] = Callback<T>::create(std::forward<F>(observer));
+    }
 
-        void notify() const { }
-
-    private:
-        T value_;
-    };
-
-    template <typename T>
-    class single_observable {
-    public:
-        single_observable(const T& value)
-            : value_(value)
-        {
+    void notify() const
+    {
+        for (uint8_t i = 0; i < this->count_; i++) {
+            this->observers_[i].call(this->value_);
         }
+    }
 
-        template <typename U>
-        single_observable& operator=(U value)
-        {
-            if (value != this->value_) {
-                this->value_ = value;
-                this->notify();
-            }
-            return *this;
+private:
+    T value_;
+    Callback<T> observers_[MaxObservers] { };
+    uint8_t count_ { 0 };
+};
+
+// Specialization for zero subscribers — no array, no count, notify is a no-op.
+template <typename T>
+class observable<T, 0> {
+public:
+    observable(const T& value)
+        : value_(value)
+    {
+    }
+
+    template <typename U>
+    observable& operator=(U value)
+    {
+        if (value != this->value_) {
+            this->value_ = value;
         }
+        return *this;
+    }
 
-        T const* operator&() const { return &this->value_; }
-        T const& operator*() const { return this->value_; }
+    T const* operator&() const { return &this->value_; }
+    T const& operator*() const { return this->value_; }
 
-        template <typename F>
-        void subscribe(F&& observer)
-        {
-            if (this->observer_) {
-                log_multiple_subscribers();
-            }
-            this->observer_ = Callback<T>::create(std::forward<F>(observer));
+    template <typename F>
+    void subscribe(F&&)
+    {
+        log_observer_overflow();
+    }
+
+    void notify() const { }
+
+private:
+    T value_;
+};
+
+template <typename T>
+class single_observable {
+public:
+    single_observable(const T& value)
+        : value_(value)
+    {
+    }
+
+    template <typename U>
+    single_observable& operator=(U value)
+    {
+        if (value != this->value_) {
+            this->value_ = value;
+            this->notify();
         }
+        return *this;
+    }
 
-        void notify() const
-        {
-            if (this->observer_) {
-                this->observer_.call(this->value_);
-            }
+    T const* operator&() const { return &this->value_; }
+    T const& operator*() const { return this->value_; }
+
+    template <typename F>
+    void subscribe(F&& observer)
+    {
+        if (this->observer_) {
+            log_multiple_subscribers();
         }
+        this->observer_ = Callback<T>::create(std::forward<F>(observer));
+    }
 
-    private:
-        T value_;
-        Callback<T> observer_ { };
-    };
+    void notify() const
+    {
+        if (this->observer_) {
+            this->observer_.call(this->value_);
+        }
+    }
 
-} // namespace ratgdo
-} // namespace esphome
+private:
+    T value_;
+    Callback<T> observer_ { };
+};
+
+} // namespace esphome::ratgdo

--- a/components/ratgdo/output/ratgdo_output.cpp
+++ b/components/ratgdo/output/ratgdo_output.cpp
@@ -2,59 +2,57 @@
 #include "../ratgdo_state.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    static const char* TAG = "ratgdo.output";
+static const char* TAG = "ratgdo.output";
 
-    void RATGDOOutput::setup()
-    {
-        ESP_LOGD(TAG, "Output was setup");
+void RATGDOOutput::setup()
+{
+    ESP_LOGD(TAG, "Output was setup");
 
-        if (this->output_type_ == OutputType::RATGDO_BEEPER) {
-            this->beeper_->add_on_finished_playback_callback([this] { this->finished_playback(); });
+    if (this->output_type_ == OutputType::RATGDO_BEEPER) {
+        this->beeper_->add_on_finished_playback_callback([this] { this->finished_playback(); });
 
 #ifdef RATGDO_USE_VEHICLE_SENSORS
-            this->parent_->subscribe_vehicle_arriving_state([this](VehicleArrivingState state) {
-                if (state == VehicleArrivingState::YES) {
-                    this->play();
-                }
-            });
+        this->parent_->subscribe_vehicle_arriving_state([this](VehicleArrivingState state) {
+            if (state == VehicleArrivingState::YES) {
+                this->play();
+            }
+        });
 #endif
 
-            this->parent_->subscribe_door_action_delayed([this](DoorActionDelayed state) {
-                if (state == DoorActionDelayed::YES) {
-                    this->play();
-                    this->repeat_ = true;
-                } else if (state == DoorActionDelayed::NO) {
-                    this->repeat_ = false;
-                }
-            });
-        }
+        this->parent_->subscribe_door_action_delayed([this](DoorActionDelayed state) {
+            if (state == DoorActionDelayed::YES) {
+                this->play();
+                this->repeat_ = true;
+            } else if (state == DoorActionDelayed::NO) {
+                this->repeat_ = false;
+            }
+        });
     }
+}
 
-    void RATGDOOutput::play()
-    {
-        this->beeper_->play(this->rtttlSong_);
+void RATGDOOutput::play()
+{
+    this->beeper_->play(this->rtttlSong_);
+}
+
+void RATGDOOutput::finished_playback()
+{
+    if (this->repeat_)
+        this->play();
+}
+
+void RATGDOOutput::dump_config()
+{
+    if (this->output_type_ == OutputType::RATGDO_BEEPER) {
+        ESP_LOGCONFIG(TAG, "  Type: Beeper");
     }
+}
 
-    void RATGDOOutput::finished_playback()
-    {
-        if (this->repeat_)
-            this->play();
-    }
+void RATGDOOutput::set_output_type(OutputType output_type_)
+{
+    this->output_type_ = output_type_;
+}
 
-    void RATGDOOutput::dump_config()
-    {
-        if (this->output_type_ == OutputType::RATGDO_BEEPER) {
-            ESP_LOGCONFIG(TAG, "  Type: Beeper");
-        }
-    }
-
-    void RATGDOOutput::set_output_type(OutputType output_type_)
-    {
-        this->output_type_ = output_type_;
-    }
-
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/output/ratgdo_output.h
+++ b/components/ratgdo/output/ratgdo_output.h
@@ -4,29 +4,27 @@
 #include "esphome/components/rtttl/rtttl.h"
 #include "esphome/core/component.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    enum OutputType {
-        RATGDO_BEEPER
-    };
+enum OutputType {
+    RATGDO_BEEPER
+};
 
-    class RATGDOOutput : public RATGDOClient, public Component {
-    public:
-        void setup() override;
-        void play();
-        void finished_playback();
-        void dump_config() override;
-        void set_output_type(OutputType output_type);
-        void set_song(std::string rtttlSong) { this->rtttlSong_ = rtttlSong; }
-        void set_rtttl(rtttl::Rtttl* output) { this->beeper_ = output; }
+class RATGDOOutput : public RATGDOClient, public Component {
+public:
+    void setup() override;
+    void play();
+    void finished_playback();
+    void dump_config() override;
+    void set_output_type(OutputType output_type);
+    void set_song(std::string rtttlSong) { this->rtttlSong_ = rtttlSong; }
+    void set_rtttl(rtttl::Rtttl* output) { this->beeper_ = output; }
 
-    protected:
-        OutputType output_type_;
-        rtttl::Rtttl* beeper_;
-        std::string rtttlSong_;
-        bool repeat_;
-    };
+protected:
+    OutputType output_type_;
+    rtttl::Rtttl* beeper_;
+    std::string rtttlSong_;
+    bool repeat_;
+};
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/protocol.h
+++ b/components/ratgdo/protocol.h
@@ -8,116 +8,117 @@ namespace esphome {
 class Scheduler;
 class InternalGPIOPin;
 
-namespace ratgdo {
-
-    class RATGDOComponent;
-
-    namespace protocol {
-
-        const uint32_t HAS_DOOR_OPEN = 1 << 0; // has idempotent open door command
-        const uint32_t HAS_DOOR_CLOSE = 1 << 1; // has idempotent close door command
-        const uint32_t HAS_DOOR_STOP = 1 << 2; // has idempotent stop door command
-        const uint32_t HAS_DOOR_STATUS = 1 << 3;
-
-        const uint32_t HAS_LIGHT_TOGGLE = 1 << 10; // some protocols might not support this
-
-        const uint32_t HAS_LOCK_TOGGLE = 1 << 20;
-
-        class Traits {
-            uint32_t value;
-
-        public:
-            Traits()
-                : value(0)
-            {
-            }
-
-            bool has_door_open() const { return this->value & HAS_DOOR_OPEN; }
-            bool has_door_close() const { return this->value & HAS_DOOR_CLOSE; }
-            bool has_door_stop() const { return this->value & HAS_DOOR_STOP; }
-            bool has_door_status() const { return this->value & HAS_DOOR_STATUS; }
-
-            bool has_light_toggle() const { return this->value & HAS_LIGHT_TOGGLE; }
-
-            bool has_lock_toggle() const { return this->value & HAS_LOCK_TOGGLE; }
-
-            void set_features(uint32_t feature) { this->value |= feature; }
-            void clear_features(uint32_t feature) { this->value &= ~feature; }
-
-            static uint32_t all()
-            {
-                return HAS_DOOR_CLOSE | HAS_DOOR_OPEN | HAS_DOOR_STOP | HAS_DOOR_STATUS | HAS_LIGHT_TOGGLE | HAS_LOCK_TOGGLE;
-            }
-        };
-
-        struct SetRollingCodeCounter {
-            uint32_t counter;
-        };
-        struct GetRollingCodeCounter {
-        };
-        struct SetClientID {
-            uint64_t client_id;
-        };
-        struct QueryStatus {
-        };
-        struct QueryOpenings {
-        };
-        struct ActivateLearn {
-        };
-        struct InactivateLearn {
-        };
-        struct QueryPairedDevices {
-            PairedDevice kind;
-        };
-        struct QueryPairedDevicesAll {
-        };
-        struct ClearPairedDevices {
-            PairedDevice kind;
-        };
-
-        // a poor man's sum-type, because C++
-        SUM_TYPE(Args,
-            (SetRollingCodeCounter, set_rolling_code_counter),
-            (GetRollingCodeCounter, get_rolling_code_counter),
-            (SetClientID, set_client_id),
-            (QueryStatus, query_status),
-            (QueryOpenings, query_openings),
-            (ActivateLearn, activate_learn),
-            (InactivateLearn, inactivate_learn),
-            (QueryPairedDevices, query_paired_devices),
-            (QueryPairedDevicesAll, query_paired_devices_all),
-            (ClearPairedDevices, clear_paired_devices), )
-
-        struct RollingCodeCounter {
-            single_observable<uint32_t>* value;
-        };
-
-        SUM_TYPE(Result,
-            (RollingCodeCounter, rolling_code_counter), )
-
-        class Protocol {
-        public:
-            virtual void setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin);
-            virtual void loop();
-            virtual void dump_config();
-
-            virtual void sync();
-
-            // dry contact methods
-            virtual void set_open_limit(bool);
-            virtual void set_close_limit(bool);
-            virtual void set_discrete_open_pin(InternalGPIOPin* pin);
-            virtual void set_discrete_close_pin(InternalGPIOPin* pin);
-
-            virtual const Traits& traits() const;
-
-            virtual void light_action(LightAction action);
-            virtual void lock_action(LockAction action);
-            virtual void door_action(DoorAction action);
-
-            virtual protocol::Result call(protocol::Args args);
-        };
-
-    }
-} // namespace ratgdo
 } // namespace esphome
+
+namespace esphome::ratgdo {
+
+class RATGDOComponent;
+
+namespace protocol {
+
+    const uint32_t HAS_DOOR_OPEN = 1 << 0; // has idempotent open door command
+    const uint32_t HAS_DOOR_CLOSE = 1 << 1; // has idempotent close door command
+    const uint32_t HAS_DOOR_STOP = 1 << 2; // has idempotent stop door command
+    const uint32_t HAS_DOOR_STATUS = 1 << 3;
+
+    const uint32_t HAS_LIGHT_TOGGLE = 1 << 10; // some protocols might not support this
+
+    const uint32_t HAS_LOCK_TOGGLE = 1 << 20;
+
+    class Traits {
+        uint32_t value;
+
+    public:
+        Traits()
+            : value(0)
+        {
+        }
+
+        bool has_door_open() const { return this->value & HAS_DOOR_OPEN; }
+        bool has_door_close() const { return this->value & HAS_DOOR_CLOSE; }
+        bool has_door_stop() const { return this->value & HAS_DOOR_STOP; }
+        bool has_door_status() const { return this->value & HAS_DOOR_STATUS; }
+
+        bool has_light_toggle() const { return this->value & HAS_LIGHT_TOGGLE; }
+
+        bool has_lock_toggle() const { return this->value & HAS_LOCK_TOGGLE; }
+
+        void set_features(uint32_t feature) { this->value |= feature; }
+        void clear_features(uint32_t feature) { this->value &= ~feature; }
+
+        static uint32_t all()
+        {
+            return HAS_DOOR_CLOSE | HAS_DOOR_OPEN | HAS_DOOR_STOP | HAS_DOOR_STATUS | HAS_LIGHT_TOGGLE | HAS_LOCK_TOGGLE;
+        }
+    };
+
+    struct SetRollingCodeCounter {
+        uint32_t counter;
+    };
+    struct GetRollingCodeCounter {
+    };
+    struct SetClientID {
+        uint64_t client_id;
+    };
+    struct QueryStatus {
+    };
+    struct QueryOpenings {
+    };
+    struct ActivateLearn {
+    };
+    struct InactivateLearn {
+    };
+    struct QueryPairedDevices {
+        PairedDevice kind;
+    };
+    struct QueryPairedDevicesAll {
+    };
+    struct ClearPairedDevices {
+        PairedDevice kind;
+    };
+
+    // a poor man's sum-type, because C++
+    SUM_TYPE(Args,
+        (SetRollingCodeCounter, set_rolling_code_counter),
+        (GetRollingCodeCounter, get_rolling_code_counter),
+        (SetClientID, set_client_id),
+        (QueryStatus, query_status),
+        (QueryOpenings, query_openings),
+        (ActivateLearn, activate_learn),
+        (InactivateLearn, inactivate_learn),
+        (QueryPairedDevices, query_paired_devices),
+        (QueryPairedDevicesAll, query_paired_devices_all),
+        (ClearPairedDevices, clear_paired_devices), )
+
+    struct RollingCodeCounter {
+        single_observable<uint32_t>* value;
+    };
+
+    SUM_TYPE(Result,
+        (RollingCodeCounter, rolling_code_counter), )
+
+    class Protocol {
+    public:
+        virtual void setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin);
+        virtual void loop();
+        virtual void dump_config();
+
+        virtual void sync();
+
+        // dry contact methods
+        virtual void set_open_limit(bool);
+        virtual void set_close_limit(bool);
+        virtual void set_discrete_open_pin(InternalGPIOPin* pin);
+        virtual void set_discrete_close_pin(InternalGPIOPin* pin);
+
+        virtual const Traits& traits() const;
+
+        virtual void light_action(LightAction action);
+        virtual void lock_action(LockAction action);
+        virtual void door_action(DoorAction action);
+
+        virtual protocol::Result call(protocol::Args args);
+    };
+
+}
+} // namespace esphome::ratgdo

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -29,727 +29,725 @@
 #include "esphome/core/gpio.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    using namespace protocol;
+using namespace protocol;
 
-    static const char* const TAG = "ratgdo";
-    static const int SYNC_DELAY = 1000;
+static const char* const TAG = "ratgdo";
+static const int SYNC_DELAY = 1000;
 
-    using namespace defer_ids;
+using namespace defer_ids;
 
-    void log_subscriber_overflow(const LogString* observable_name, uint32_t max)
-    {
-        ESP_LOGE(TAG, "Too many subscribers for %s (max %d)", LOG_STR_ARG(observable_name), (int)max);
-    }
+void log_subscriber_overflow(const LogString* observable_name, uint32_t max)
+{
+    ESP_LOGE(TAG, "Too many subscribers for %s (max %d)", LOG_STR_ARG(observable_name), (int)max);
+}
 
 #ifdef RATGDO_USE_VEHICLE_SENSORS
-    static const int CLEAR_PRESENCE = 60000; // how long to keep arriving/leaving active
-    static const int PRESENCE_DETECT_WINDOW = 300000; // how long to calculate presence after door state change
+static const int CLEAR_PRESENCE = 60000; // how long to keep arriving/leaving active
+static const int PRESENCE_DETECT_WINDOW = 300000; // how long to calculate presence after door state change
 
-    // increasing these values increases reliability but also increases detection time
-    static constexpr int PRESENCE_DETECTION_ON_THRESHOLD = 5; // Minimum percentage of valid bitset::in_range samples required to detect vehicle
-    static constexpr int PRESENCE_DETECTION_OFF_DEBOUNCE = 2; // The number of consecutive bitset::in_range iterations that must be 0 before clearing vehicle detected state
+// increasing these values increases reliability but also increases detection time
+static constexpr int PRESENCE_DETECTION_ON_THRESHOLD = 5; // Minimum percentage of valid bitset::in_range samples required to detect vehicle
+static constexpr int PRESENCE_DETECTION_OFF_DEBOUNCE = 2; // The number of consecutive bitset::in_range iterations that must be 0 before clearing vehicle detected state
 #endif
 
-    void RATGDOComponent::setup()
-    {
-        this->output_gdo_pin_->setup();
-        this->output_gdo_pin_->pin_mode(gpio::FLAG_OUTPUT);
+void RATGDOComponent::setup()
+{
+    this->output_gdo_pin_->setup();
+    this->output_gdo_pin_->pin_mode(gpio::FLAG_OUTPUT);
 
-        this->input_gdo_pin_->setup();
-        this->input_gdo_pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
+    this->input_gdo_pin_->setup();
+    this->input_gdo_pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
 
-        this->input_obst_pin_->setup();
+    this->input_obst_pin_->setup();
 #ifdef USE_ESP32
-        this->input_obst_pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
+    this->input_obst_pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
 #else
-        this->input_obst_pin_->pin_mode(gpio::FLAG_INPUT);
+    this->input_obst_pin_->pin_mode(gpio::FLAG_INPUT);
 #endif
-        this->input_obst_pin_->attach_interrupt(RATGDOStore::isr_obstruction, &this->isr_store_, gpio::INTERRUPT_FALLING_EDGE);
+    this->input_obst_pin_->attach_interrupt(RATGDOStore::isr_obstruction, &this->isr_store_, gpio::INTERRUPT_FALLING_EDGE);
 
-        this->protocol_->setup(this, &App.scheduler, this->input_gdo_pin_, this->output_gdo_pin_);
+    this->protocol_->setup(this, &App.scheduler, this->input_gdo_pin_, this->output_gdo_pin_);
 
-        // many things happening at startup, use some delay for sync
-        set_timeout(SYNC_DELAY, [this] { this->sync(); });
-        ESP_LOGD(TAG, " _____ _____ _____ _____ ____  _____ ");
-        ESP_LOGD(TAG, "| __  |  _  |_   _|   __|    \\|     |");
-        ESP_LOGD(TAG, "|    -|     | | | |  |  |  |  |  |  |");
-        ESP_LOGD(TAG, "|__|__|__|__| |_| |_____|____/|_____|");
-        ESP_LOGD(TAG, "https://paulwieland.github.io/ratgdo/");
+    // many things happening at startup, use some delay for sync
+    set_timeout(SYNC_DELAY, [this] { this->sync(); });
+    ESP_LOGD(TAG, " _____ _____ _____ _____ ____  _____ ");
+    ESP_LOGD(TAG, "| __  |  _  |_   _|   __|    \\|     |");
+    ESP_LOGD(TAG, "|    -|     | | | |  |  |  |  |  |  |");
+    ESP_LOGD(TAG, "|__|__|__|__| |_| |_____|____/|_____|");
+    ESP_LOGD(TAG, "https://paulwieland.github.io/ratgdo/");
 
-        this->subscribe_door_state([this](DoorState state, float position) {
-            static DoorState lastState = DoorState::UNKNOWN;
+    this->subscribe_door_state([this](DoorState state, float position) {
+        static DoorState lastState = DoorState::UNKNOWN;
 
 #ifdef RATGDO_USE_VEHICLE_SENSORS
-            if (lastState != DoorState::UNKNOWN && state != DoorState::CLOSED && !this->flags_.presence_detect_window_active) {
-                this->flags_.presence_detect_window_active = true;
-                set_timeout("presence_detect_window", PRESENCE_DETECT_WINDOW, [this] {
-                    this->flags_.presence_detect_window_active = false;
-                });
-            }
-
-            if (state == DoorState::CLOSED) {
+        if (lastState != DoorState::UNKNOWN && state != DoorState::CLOSED && !this->flags_.presence_detect_window_active) {
+            this->flags_.presence_detect_window_active = true;
+            set_timeout("presence_detect_window", PRESENCE_DETECT_WINDOW, [this] {
                 this->flags_.presence_detect_window_active = false;
-                cancel_timeout("presence_detect_window");
-            }
+            });
+        }
+
+        if (state == DoorState::CLOSED) {
+            this->flags_.presence_detect_window_active = false;
+            cancel_timeout("presence_detect_window");
+        }
 #endif
 
-            lastState = state;
-        });
-    }
+        lastState = state;
+    });
+}
 
-    // initializing protocol, this gets called before setup() because
-    // its children components might require that
-    void RATGDOComponent::init_protocol()
-    {
+// initializing protocol, this gets called before setup() because
+// its children components might require that
+void RATGDOComponent::init_protocol()
+{
 #ifdef PROTOCOL_SECPLUSV2
-        this->protocol_ = new secplus2::Secplus2();
+    this->protocol_ = new secplus2::Secplus2();
 #endif
 #ifdef PROTOCOL_SECPLUSV1
-        this->protocol_ = new secplus1::Secplus1();
+    this->protocol_ = new secplus1::Secplus1();
 #endif
 #ifdef PROTOCOL_DRYCONTACT
-        this->protocol_ = new dry_contact::DryContact();
+    this->protocol_ = new dry_contact::DryContact();
 #endif
+}
+
+void RATGDOComponent::loop()
+{
+    this->obstruction_loop();
+    this->protocol_->loop();
+}
+
+void RATGDOComponent::dump_config()
+{
+    ESP_LOGCONFIG(TAG, "Setting up RATGDO...");
+    LOG_PIN("  Output GDO Pin: ", this->output_gdo_pin_);
+    LOG_PIN("  Input GDO Pin: ", this->input_gdo_pin_);
+    LOG_PIN("  Input Obstruction Pin: ", this->input_obst_pin_);
+    this->protocol_->dump_config();
+}
+
+void RATGDOComponent::received(const DoorState door_state)
+{
+    ESP_LOGD(TAG, "Door state=%s", LOG_STR_ARG(DoorState_to_string(door_state)));
+
+    auto prev_door_state = *this->door_state;
+
+    if (prev_door_state == door_state) {
+        return;
     }
 
-    void RATGDOComponent::loop()
-    {
-        this->obstruction_loop();
-        this->protocol_->loop();
+    // opening duration calibration
+    if (*this->opening_duration == 0) {
+        if (door_state == DoorState::OPENING && prev_door_state == DoorState::CLOSED) {
+            this->start_opening = millis();
+        }
+        if (door_state == DoorState::OPEN && prev_door_state == DoorState::OPENING && this->start_opening > 0) {
+            auto duration = (millis() - this->start_opening) / 1000;
+            this->set_opening_duration(round(duration * 10) / 10);
+        }
+        if (door_state == DoorState::STOPPED) {
+            this->start_opening = -1;
+        }
+    }
+    // closing duration calibration
+    if (*this->closing_duration == 0) {
+        if (door_state == DoorState::CLOSING && prev_door_state == DoorState::OPEN) {
+            this->start_closing = millis();
+        }
+        if (door_state == DoorState::CLOSED && prev_door_state == DoorState::CLOSING && this->start_closing > 0) {
+            auto duration = (millis() - this->start_closing) / 1000;
+            this->set_closing_duration(round(duration * 10) / 10);
+        }
+        if (door_state == DoorState::STOPPED) {
+            this->start_closing = -1;
+        }
     }
 
-    void RATGDOComponent::dump_config()
-    {
-        ESP_LOGCONFIG(TAG, "Setting up RATGDO...");
-        LOG_PIN("  Output GDO Pin: ", this->output_gdo_pin_);
-        LOG_PIN("  Input GDO Pin: ", this->input_gdo_pin_);
-        LOG_PIN("  Input Obstruction Pin: ", this->input_obst_pin_);
-        this->protocol_->dump_config();
-    }
-
-    void RATGDOComponent::received(const DoorState door_state)
-    {
-        ESP_LOGD(TAG, "Door state=%s", LOG_STR_ARG(DoorState_to_string(door_state)));
-
-        auto prev_door_state = *this->door_state;
-
-        if (prev_door_state == door_state) {
-            return;
-        }
-
-        // opening duration calibration
-        if (*this->opening_duration == 0) {
-            if (door_state == DoorState::OPENING && prev_door_state == DoorState::CLOSED) {
-                this->start_opening = millis();
-            }
-            if (door_state == DoorState::OPEN && prev_door_state == DoorState::OPENING && this->start_opening > 0) {
-                auto duration = (millis() - this->start_opening) / 1000;
-                this->set_opening_duration(round(duration * 10) / 10);
-            }
-            if (door_state == DoorState::STOPPED) {
-                this->start_opening = -1;
-            }
-        }
-        // closing duration calibration
-        if (*this->closing_duration == 0) {
-            if (door_state == DoorState::CLOSING && prev_door_state == DoorState::OPEN) {
-                this->start_closing = millis();
-            }
-            if (door_state == DoorState::CLOSED && prev_door_state == DoorState::CLOSING && this->start_closing > 0) {
-                auto duration = (millis() - this->start_closing) / 1000;
-                this->set_closing_duration(round(duration * 10) / 10);
-            }
-            if (door_state == DoorState::STOPPED) {
-                this->start_closing = -1;
-            }
-        }
-
-        if (door_state == DoorState::OPENING) {
-            // door started opening
-            if (prev_door_state == DoorState::CLOSING) {
-                this->door_position_update();
-                this->cancel_position_sync_callbacks();
-                this->door_move_delta = DOOR_DELTA_UNKNOWN;
-            }
-            this->door_start_moving = millis();
-            this->door_start_position = *this->door_position;
-            if (this->door_move_delta == DOOR_DELTA_UNKNOWN) {
-                this->door_move_delta = 1.0 - this->door_start_position;
-            }
-            if (*this->opening_duration != 0) {
-                this->schedule_door_position_sync();
-            }
-        } else if (door_state == DoorState::CLOSING) {
-            // door started closing
-            if (prev_door_state == DoorState::OPENING) {
-                this->door_position_update();
-                this->cancel_position_sync_callbacks();
-                this->door_move_delta = DOOR_DELTA_UNKNOWN;
-            }
-            this->door_start_moving = millis();
-            this->door_start_position = *this->door_position;
-            if (this->door_move_delta == DOOR_DELTA_UNKNOWN) {
-                this->door_move_delta = 0.0 - this->door_start_position;
-            }
-            if (*this->closing_duration != 0) {
-                this->schedule_door_position_sync();
-            }
-        } else if (door_state == DoorState::STOPPED) {
+    if (door_state == DoorState::OPENING) {
+        // door started opening
+        if (prev_door_state == DoorState::CLOSING) {
             this->door_position_update();
-            if (*this->door_position == DOOR_POSITION_UNKNOWN) {
-                this->door_position = 0.5; // best guess
-            }
             this->cancel_position_sync_callbacks();
-            cancel_timeout("door_query_state");
-        } else if (door_state == DoorState::OPEN) {
-            this->door_position = 1.0;
+            this->door_move_delta = DOOR_DELTA_UNKNOWN;
+        }
+        this->door_start_moving = millis();
+        this->door_start_position = *this->door_position;
+        if (this->door_move_delta == DOOR_DELTA_UNKNOWN) {
+            this->door_move_delta = 1.0 - this->door_start_position;
+        }
+        if (*this->opening_duration != 0) {
+            this->schedule_door_position_sync();
+        }
+    } else if (door_state == DoorState::CLOSING) {
+        // door started closing
+        if (prev_door_state == DoorState::OPENING) {
+            this->door_position_update();
             this->cancel_position_sync_callbacks();
-        } else if (door_state == DoorState::CLOSED) {
-            this->door_position = 0.0;
-            this->cancel_position_sync_callbacks();
+            this->door_move_delta = DOOR_DELTA_UNKNOWN;
         }
-
-        if (door_state == DoorState::OPEN || door_state == DoorState::CLOSED || door_state == DoorState::STOPPED) {
-            this->motor_state = MotorState::OFF;
+        this->door_start_moving = millis();
+        this->door_start_position = *this->door_position;
+        if (this->door_move_delta == DOOR_DELTA_UNKNOWN) {
+            this->door_move_delta = 0.0 - this->door_start_position;
         }
-
-        if (door_state == DoorState::CLOSED && door_state != prev_door_state) {
-            this->query_openings();
+        if (*this->closing_duration != 0) {
+            this->schedule_door_position_sync();
         }
-
-        this->door_state = door_state;
-        this->on_door_state_.trigger(door_state);
-    }
-
-    void RATGDOComponent::received(const LearnState learn_state)
-    {
-        ESP_LOGD(TAG, "Learn state=%s", LOG_STR_ARG(LearnState_to_string(learn_state)));
-
-        if (*this->learn_state == learn_state) {
-            return;
+    } else if (door_state == DoorState::STOPPED) {
+        this->door_position_update();
+        if (*this->door_position == DOOR_POSITION_UNKNOWN) {
+            this->door_position = 0.5; // best guess
         }
+        this->cancel_position_sync_callbacks();
+        cancel_timeout("door_query_state");
+    } else if (door_state == DoorState::OPEN) {
+        this->door_position = 1.0;
+        this->cancel_position_sync_callbacks();
+    } else if (door_state == DoorState::CLOSED) {
+        this->door_position = 0.0;
+        this->cancel_position_sync_callbacks();
+    }
 
-        if (learn_state == LearnState::INACTIVE) {
-            this->query_paired_devices();
+    if (door_state == DoorState::OPEN || door_state == DoorState::CLOSED || door_state == DoorState::STOPPED) {
+        this->motor_state = MotorState::OFF;
+    }
+
+    if (door_state == DoorState::CLOSED && door_state != prev_door_state) {
+        this->query_openings();
+    }
+
+    this->door_state = door_state;
+    this->on_door_state_.trigger(door_state);
+}
+
+void RATGDOComponent::received(const LearnState learn_state)
+{
+    ESP_LOGD(TAG, "Learn state=%s", LOG_STR_ARG(LearnState_to_string(learn_state)));
+
+    if (*this->learn_state == learn_state) {
+        return;
+    }
+
+    if (learn_state == LearnState::INACTIVE) {
+        this->query_paired_devices();
+    }
+
+    this->learn_state = learn_state;
+}
+
+void RATGDOComponent::received(const LightState light_state)
+{
+    ESP_LOGD(TAG, "Light state=%s", LOG_STR_ARG(LightState_to_string(light_state)));
+    this->light_state = light_state;
+}
+
+void RATGDOComponent::received(const LockState lock_state)
+{
+    ESP_LOGD(TAG, "Lock state=%s", LOG_STR_ARG(LockState_to_string(lock_state)));
+    this->lock_state = lock_state;
+}
+
+void RATGDOComponent::received(const ObstructionState obstruction_state)
+{
+    if (!this->flags_.obstruction_sensor_detected) {
+        ESP_LOGD(TAG, "Obstruction: state=%s", LOG_STR_ARG(ObstructionState_to_string(*this->obstruction_state)));
+
+        this->obstruction_state = obstruction_state;
+        // This isn't very fast to update, but its still better
+        // than nothing in the case the obstruction sensor is not
+        // wired up.
+    }
+}
+
+void RATGDOComponent::received(const MotorState motor_state)
+{
+    ESP_LOGD(TAG, "Motor: state=%s", LOG_STR_ARG(MotorState_to_string(*this->motor_state)));
+    this->motor_state = motor_state;
+}
+
+void RATGDOComponent::received(const ButtonState button_state)
+{
+    ESP_LOGD(TAG, "Button state=%s", LOG_STR_ARG(ButtonState_to_string(*this->button_state)));
+    this->button_state = button_state;
+}
+
+void RATGDOComponent::received(const MotionState motion_state)
+{
+    ESP_LOGD(TAG, "Motion: %s", LOG_STR_ARG(MotionState_to_string(*this->motion_state)));
+    this->motion_state = motion_state;
+    if (motion_state == MotionState::DETECTED) {
+        this->set_timeout("clear_motion", 3000, [this] {
+            this->motion_state = MotionState::CLEAR;
+        });
+        if (*this->light_state == LightState::OFF) {
+            this->query_status();
         }
-
-        this->learn_state = learn_state;
     }
+}
 
-    void RATGDOComponent::received(const LightState light_state)
-    {
-        ESP_LOGD(TAG, "Light state=%s", LOG_STR_ARG(LightState_to_string(light_state)));
-        this->light_state = light_state;
+void RATGDOComponent::received(const LightAction light_action)
+{
+    ESP_LOGD(TAG, "Light cmd=%s state=%s",
+        LOG_STR_ARG(LightAction_to_string(light_action)),
+        LOG_STR_ARG(LightState_to_string(*this->light_state)));
+    if (light_action == LightAction::OFF) {
+        this->light_state = LightState::OFF;
+    } else if (light_action == LightAction::ON) {
+        this->light_state = LightState::ON;
+    } else if (light_action == LightAction::TOGGLE) {
+        this->light_state = light_state_toggle(*this->light_state);
     }
+}
 
-    void RATGDOComponent::received(const LockState lock_state)
-    {
-        ESP_LOGD(TAG, "Lock state=%s", LOG_STR_ARG(LockState_to_string(lock_state)));
-        this->lock_state = lock_state;
+void RATGDOComponent::received(const Openings openings)
+{
+    if (openings.flag == 0 || *this->openings != 0) {
+        this->openings = openings.count;
+        ESP_LOGD(TAG, "Openings: %d", *this->openings);
+    } else {
+        ESP_LOGD(TAG, "Ignoring openings, not from our request");
     }
+}
 
-    void RATGDOComponent::received(const ObstructionState obstruction_state)
-    {
-        if (!this->flags_.obstruction_sensor_detected) {
-            ESP_LOGD(TAG, "Obstruction: state=%s", LOG_STR_ARG(ObstructionState_to_string(*this->obstruction_state)));
+void RATGDOComponent::received(const PairedDeviceCount pdc)
+{
+    ESP_LOGD(TAG, "Paired device count, kind=%s count=%d", LOG_STR_ARG(PairedDevice_to_string(pdc.kind)), pdc.count);
 
-            this->obstruction_state = obstruction_state;
-            // This isn't very fast to update, but its still better
-            // than nothing in the case the obstruction sensor is not
-            // wired up.
+    if (pdc.kind == PairedDevice::ALL) {
+        this->paired_total = pdc.count;
+    } else if (pdc.kind == PairedDevice::REMOTE) {
+        this->paired_remotes = pdc.count;
+    } else if (pdc.kind == PairedDevice::KEYPAD) {
+        this->paired_keypads = pdc.count;
+    } else if (pdc.kind == PairedDevice::WALL_CONTROL) {
+        this->paired_wall_controls = pdc.count;
+    } else if (pdc.kind == PairedDevice::ACCESSORY) {
+        this->paired_accessories = pdc.count;
+    }
+}
+
+void RATGDOComponent::received(const TimeToClose ttc)
+{
+    ESP_LOGD(TAG, "Time to close (TTC): %ds", ttc.seconds);
+}
+
+void RATGDOComponent::received(const BatteryState battery_state)
+{
+    ESP_LOGD(TAG, "Battery state=%s", LOG_STR_ARG(BatteryState_to_string(battery_state)));
+}
+
+void RATGDOComponent::schedule_door_position_sync(float update_period)
+{
+    ESP_LOG1(TAG, "Schedule position sync: delta %f, start position: %f, start moving: %d",
+        this->door_move_delta, this->door_start_position, this->door_start_moving);
+    auto duration = this->door_move_delta > 0 ? *this->opening_duration : *this->closing_duration;
+    if (duration == 0) {
+        return;
+    }
+    this->position_sync_remaining_ = std::max(static_cast<uint16_t>(1000 * duration / update_period), static_cast<uint16_t>(1));
+    set_interval(INTERVAL_POSITION_SYNC, static_cast<uint32_t>(update_period), [this]() {
+        this->door_position_update();
+        if (--this->position_sync_remaining_ == 0) {
+            cancel_interval(INTERVAL_POSITION_SYNC);
+        }
+    });
+}
+
+void RATGDOComponent::door_position_update()
+{
+    if (this->door_start_moving == 0 || this->door_start_position == DOOR_POSITION_UNKNOWN || this->door_move_delta == DOOR_DELTA_UNKNOWN) {
+        return;
+    }
+    auto now = millis();
+    auto duration = this->door_move_delta > 0 ? *this->opening_duration : -*this->closing_duration;
+    if (duration == 0) {
+        return;
+    }
+    auto position = this->door_start_position + (now - this->door_start_moving) / (1000 * duration);
+    ESP_LOG2(TAG, "[%d] Position update: %f", now, position);
+    this->door_position = clamp(position, 0.0f, 1.0f);
+}
+
+void RATGDOComponent::set_opening_duration(float duration)
+{
+    ESP_LOGD(TAG, "Set opening duration: %.1fs", duration);
+    this->opening_duration = duration;
+}
+
+void RATGDOComponent::set_closing_duration(float duration)
+{
+    ESP_LOGD(TAG, "Set closing duration: %.1fs", duration);
+    this->closing_duration = duration;
+}
+
+#ifdef RATGDO_USE_DISTANCE_SENSOR
+void RATGDOComponent::set_target_distance_measurement(int16_t distance)
+{
+    this->target_distance_measurement = distance;
+}
+
+void RATGDOComponent::set_distance_measurement(int16_t distance)
+{
+    this->last_distance_measurement = distance;
+
+#ifdef RATGDO_USE_VEHICLE_SENSORS
+    this->in_range <<= 1;
+    this->in_range.set(0, distance <= *this->target_distance_measurement);
+    this->calculate_presence();
+#endif
+}
+#endif
+
+#ifdef RATGDO_USE_VEHICLE_SENSORS
+void RATGDOComponent::calculate_presence()
+{
+    int percent = this->in_range.count() * 100 / this->in_range.size();
+    static int last_percent = -1;
+    static int off_counter = 0;
+
+    if (percent >= PRESENCE_DETECTION_ON_THRESHOLD)
+        this->vehicle_detected_state = VehicleDetectedState::YES;
+
+    if (percent == 0 && *this->vehicle_detected_state == VehicleDetectedState::YES) {
+        off_counter++;
+        ESP_LOGD(TAG, "Off counter: %d", off_counter);
+
+        if (off_counter / this->in_range.size() >= PRESENCE_DETECTION_OFF_DEBOUNCE) {
+            off_counter = 0;
+            this->vehicle_detected_state = VehicleDetectedState::NO;
         }
     }
 
-    void RATGDOComponent::received(const MotorState motor_state)
-    {
-        ESP_LOGD(TAG, "Motor: state=%s", LOG_STR_ARG(MotorState_to_string(*this->motor_state)));
-        this->motor_state = motor_state;
+    if (percent != last_percent) {
+        ESP_LOGD(TAG, "pct_in_range: %d", percent);
+        last_percent = percent;
+        off_counter = 0;
     }
+    // ESP_LOGD(TAG, "in_range: %s", this->in_range.to_string().c_str());
+}
+#endif
 
-    void RATGDOComponent::received(const ButtonState button_state)
-    {
-        ESP_LOGD(TAG, "Button state=%s", LOG_STR_ARG(ButtonState_to_string(*this->button_state)));
-        this->button_state = button_state;
-    }
-
-    void RATGDOComponent::received(const MotionState motion_state)
-    {
-        ESP_LOGD(TAG, "Motion: %s", LOG_STR_ARG(MotionState_to_string(*this->motion_state)));
-        this->motion_state = motion_state;
-        if (motion_state == MotionState::DETECTED) {
-            this->set_timeout("clear_motion", 3000, [this] {
-                this->motion_state = MotionState::CLEAR;
+#ifdef RATGDO_USE_VEHICLE_SENSORS
+void RATGDOComponent::presence_change(bool sensor_value)
+{
+    if (this->flags_.presence_detect_window_active) {
+        if (sensor_value) {
+            this->vehicle_arriving_state = VehicleArrivingState::YES;
+            this->vehicle_leaving_state = VehicleLeavingState::NO;
+            set_timeout(CLEAR_PRESENCE, [this] {
+                this->vehicle_arriving_state = VehicleArrivingState::NO;
             });
-            if (*this->light_state == LightState::OFF) {
-                this->query_status();
+        } else {
+            this->vehicle_arriving_state = VehicleArrivingState::NO;
+            this->vehicle_leaving_state = VehicleLeavingState::YES;
+            set_timeout(CLEAR_PRESENCE, [this] {
+                this->vehicle_leaving_state = VehicleLeavingState::NO;
+            });
+        }
+    }
+}
+#endif
+
+Result RATGDOComponent::call_protocol(Args args)
+{
+    return this->protocol_->call(args);
+}
+
+/*************************** OBSTRUCTION DETECTION ***************************/
+
+void RATGDOComponent::obstruction_loop()
+{
+    long current_millis = millis();
+    static unsigned long last_millis = 0;
+    static unsigned long last_asleep = 0;
+
+    // the obstruction sensor has 3 states: clear (HIGH with LOW pulse every 7ms), obstructed (HIGH), asleep (LOW)
+    // the transitions between awake and asleep are tricky because the voltage drops slowly when falling asleep
+    // and is high without pulses when waking up
+
+    // If at least 3 low pulses are counted within 50ms, the door is awake, not obstructed and we don't have to check anything else
+
+    const long CHECK_PERIOD = 50;
+    const long PULSES_LOWER_LIMIT = 3;
+
+    if (current_millis - last_millis > CHECK_PERIOD) {
+        // ESP_LOGD(TAG, "%ld: Obstruction count: %d, expected: %d, since asleep: %ld",
+        //     current_millis, this->isr_store_.obstruction_low_count, PULSES_LOWER_LIMIT,
+        //     current_millis - last_asleep
+        // );
+
+        // check to see if we got more then PULSES_LOWER_LIMIT pulses
+        if (this->isr_store_.obstruction_low_count > PULSES_LOWER_LIMIT) {
+            this->obstruction_state = ObstructionState::CLEAR;
+            this->flags_.obstruction_sensor_detected = true;
+        } else if (this->isr_store_.obstruction_low_count == 0) {
+            // if there have been no pulses the line is steady high or low
+#ifdef USE_ESP32
+            if (this->input_obst_pin_->digital_read()) {
+#else
+            if (!this->input_obst_pin_->digital_read()) {
+#endif
+                // asleep
+                last_asleep = current_millis;
+            } else {
+                // if the line is high and was last asleep more than 700ms ago, then there is an obstruction present
+                if (current_millis - last_asleep > 700) {
+                    this->obstruction_state = ObstructionState::OBSTRUCTED;
+                }
             }
         }
+        last_millis = current_millis;
+        this->isr_store_.obstruction_low_count = 0;
+    }
+}
+
+void RATGDOComponent::query_status()
+{
+    this->protocol_->call(QueryStatus { });
+}
+
+void RATGDOComponent::query_openings()
+{
+    this->protocol_->call(QueryOpenings { });
+}
+
+void RATGDOComponent::query_paired_devices()
+{
+    this->protocol_->call(QueryPairedDevicesAll { });
+}
+
+void RATGDOComponent::query_paired_devices(PairedDevice kind)
+{
+    this->protocol_->call(QueryPairedDevices { kind });
+}
+
+void RATGDOComponent::clear_paired_devices(PairedDevice kind)
+{
+    this->protocol_->call(ClearPairedDevices { kind });
+}
+
+void RATGDOComponent::sync()
+{
+    this->protocol_->sync();
+
+    // dry contact protocol:
+    // needed to trigger the intial state of the limit switch sensors
+    // ideally this would be in drycontact::sync
+#ifdef PROTOCOL_DRYCONTACT
+    this->protocol_->set_open_limit(this->dry_contact_open_sensor_->state);
+    this->protocol_->set_close_limit(this->dry_contact_close_sensor_->state);
+#endif
+}
+
+void RATGDOComponent::door_open()
+{
+    if (*this->door_state == DoorState::OPENING) {
+        return; // gets ignored by opener
     }
 
-    void RATGDOComponent::received(const LightAction light_action)
-    {
-        ESP_LOGD(TAG, "Light cmd=%s state=%s",
-            LOG_STR_ARG(LightAction_to_string(light_action)),
-            LOG_STR_ARG(LightState_to_string(*this->light_state)));
-        if (light_action == LightAction::OFF) {
-            this->light_state = LightState::OFF;
-        } else if (light_action == LightAction::ON) {
-            this->light_state = LightState::ON;
-        } else if (light_action == LightAction::TOGGLE) {
-            this->light_state = light_state_toggle(*this->light_state);
-        }
-    }
+    this->door_action(DoorAction::OPEN);
 
-    void RATGDOComponent::received(const Openings openings)
-    {
-        if (openings.flag == 0 || *this->openings != 0) {
-            this->openings = openings.count;
-            ESP_LOGD(TAG, "Openings: %d", *this->openings);
-        } else {
-            ESP_LOGD(TAG, "Ignoring openings, not from our request");
-        }
-    }
-
-    void RATGDOComponent::received(const PairedDeviceCount pdc)
-    {
-        ESP_LOGD(TAG, "Paired device count, kind=%s count=%d", LOG_STR_ARG(PairedDevice_to_string(pdc.kind)), pdc.count);
-
-        if (pdc.kind == PairedDevice::ALL) {
-            this->paired_total = pdc.count;
-        } else if (pdc.kind == PairedDevice::REMOTE) {
-            this->paired_remotes = pdc.count;
-        } else if (pdc.kind == PairedDevice::KEYPAD) {
-            this->paired_keypads = pdc.count;
-        } else if (pdc.kind == PairedDevice::WALL_CONTROL) {
-            this->paired_wall_controls = pdc.count;
-        } else if (pdc.kind == PairedDevice::ACCESSORY) {
-            this->paired_accessories = pdc.count;
-        }
-    }
-
-    void RATGDOComponent::received(const TimeToClose ttc)
-    {
-        ESP_LOGD(TAG, "Time to close (TTC): %ds", ttc.seconds);
-    }
-
-    void RATGDOComponent::received(const BatteryState battery_state)
-    {
-        ESP_LOGD(TAG, "Battery state=%s", LOG_STR_ARG(BatteryState_to_string(battery_state)));
-    }
-
-    void RATGDOComponent::schedule_door_position_sync(float update_period)
-    {
-        ESP_LOG1(TAG, "Schedule position sync: delta %f, start position: %f, start moving: %d",
-            this->door_move_delta, this->door_start_position, this->door_start_moving);
-        auto duration = this->door_move_delta > 0 ? *this->opening_duration : *this->closing_duration;
-        if (duration == 0) {
-            return;
-        }
-        this->position_sync_remaining_ = std::max(static_cast<uint16_t>(1000 * duration / update_period), static_cast<uint16_t>(1));
-        set_interval(INTERVAL_POSITION_SYNC, static_cast<uint32_t>(update_period), [this]() {
-            this->door_position_update();
-            if (--this->position_sync_remaining_ == 0) {
-                cancel_interval(INTERVAL_POSITION_SYNC);
+    if (*this->opening_duration > 0) {
+        // query state in case we don't get a status message
+        set_timeout("door_query_state", (*this->opening_duration + 2) * 1000, [this]() {
+            if (*this->door_state != DoorState::OPEN && *this->door_state != DoorState::STOPPED) {
+                this->received(DoorState::OPEN); // probably missed a status mesage, assume it's open
+                this->query_status(); // query in case we're wrong and it's stopped
             }
         });
     }
+}
 
-    void RATGDOComponent::door_position_update()
-    {
-        if (this->door_start_moving == 0 || this->door_start_position == DOOR_POSITION_UNKNOWN || this->door_move_delta == DOOR_DELTA_UNKNOWN) {
-            return;
-        }
-        auto now = millis();
-        auto duration = this->door_move_delta > 0 ? *this->opening_duration : -*this->closing_duration;
-        if (duration == 0) {
-            return;
-        }
-        auto position = this->door_start_position + (now - this->door_start_moving) / (1000 * duration);
-        ESP_LOG2(TAG, "[%d] Position update: %f", now, position);
-        this->door_position = clamp(position, 0.0f, 1.0f);
+void RATGDOComponent::door_close()
+{
+    if (*this->door_state == DoorState::CLOSING) {
+        return; // gets ignored by opener
     }
 
-    void RATGDOComponent::set_opening_duration(float duration)
-    {
-        ESP_LOGD(TAG, "Set opening duration: %.1fs", duration);
-        this->opening_duration = duration;
-    }
-
-    void RATGDOComponent::set_closing_duration(float duration)
-    {
-        ESP_LOGD(TAG, "Set closing duration: %.1fs", duration);
-        this->closing_duration = duration;
-    }
-
-#ifdef RATGDO_USE_DISTANCE_SENSOR
-    void RATGDOComponent::set_target_distance_measurement(int16_t distance)
-    {
-        this->target_distance_measurement = distance;
-    }
-
-    void RATGDOComponent::set_distance_measurement(int16_t distance)
-    {
-        this->last_distance_measurement = distance;
-
-#ifdef RATGDO_USE_VEHICLE_SENSORS
-        this->in_range <<= 1;
-        this->in_range.set(0, distance <= *this->target_distance_measurement);
-        this->calculate_presence();
-#endif
-    }
-#endif
-
-#ifdef RATGDO_USE_VEHICLE_SENSORS
-    void RATGDOComponent::calculate_presence()
-    {
-        int percent = this->in_range.count() * 100 / this->in_range.size();
-        static int last_percent = -1;
-        static int off_counter = 0;
-
-        if (percent >= PRESENCE_DETECTION_ON_THRESHOLD)
-            this->vehicle_detected_state = VehicleDetectedState::YES;
-
-        if (percent == 0 && *this->vehicle_detected_state == VehicleDetectedState::YES) {
-            off_counter++;
-            ESP_LOGD(TAG, "Off counter: %d", off_counter);
-
-            if (off_counter / this->in_range.size() >= PRESENCE_DETECTION_OFF_DEBOUNCE) {
-                off_counter = 0;
-                this->vehicle_detected_state = VehicleDetectedState::NO;
-            }
-        }
-
-        if (percent != last_percent) {
-            ESP_LOGD(TAG, "pct_in_range: %d", percent);
-            last_percent = percent;
-            off_counter = 0;
-        }
-        // ESP_LOGD(TAG, "in_range: %s", this->in_range.to_string().c_str());
-    }
-#endif
-
-#ifdef RATGDO_USE_VEHICLE_SENSORS
-    void RATGDOComponent::presence_change(bool sensor_value)
-    {
-        if (this->flags_.presence_detect_window_active) {
-            if (sensor_value) {
-                this->vehicle_arriving_state = VehicleArrivingState::YES;
-                this->vehicle_leaving_state = VehicleLeavingState::NO;
-                set_timeout(CLEAR_PRESENCE, [this] {
-                    this->vehicle_arriving_state = VehicleArrivingState::NO;
-                });
-            } else {
-                this->vehicle_arriving_state = VehicleArrivingState::NO;
-                this->vehicle_leaving_state = VehicleLeavingState::YES;
-                set_timeout(CLEAR_PRESENCE, [this] {
-                    this->vehicle_leaving_state = VehicleLeavingState::NO;
-                });
-            }
-        }
-    }
-#endif
-
-    Result RATGDOComponent::call_protocol(Args args)
-    {
-        return this->protocol_->call(args);
-    }
-
-    /*************************** OBSTRUCTION DETECTION ***************************/
-
-    void RATGDOComponent::obstruction_loop()
-    {
-        long current_millis = millis();
-        static unsigned long last_millis = 0;
-        static unsigned long last_asleep = 0;
-
-        // the obstruction sensor has 3 states: clear (HIGH with LOW pulse every 7ms), obstructed (HIGH), asleep (LOW)
-        // the transitions between awake and asleep are tricky because the voltage drops slowly when falling asleep
-        // and is high without pulses when waking up
-
-        // If at least 3 low pulses are counted within 50ms, the door is awake, not obstructed and we don't have to check anything else
-
-        const long CHECK_PERIOD = 50;
-        const long PULSES_LOWER_LIMIT = 3;
-
-        if (current_millis - last_millis > CHECK_PERIOD) {
-            // ESP_LOGD(TAG, "%ld: Obstruction count: %d, expected: %d, since asleep: %ld",
-            //     current_millis, this->isr_store_.obstruction_low_count, PULSES_LOWER_LIMIT,
-            //     current_millis - last_asleep
-            // );
-
-            // check to see if we got more then PULSES_LOWER_LIMIT pulses
-            if (this->isr_store_.obstruction_low_count > PULSES_LOWER_LIMIT) {
-                this->obstruction_state = ObstructionState::CLEAR;
-                this->flags_.obstruction_sensor_detected = true;
-            } else if (this->isr_store_.obstruction_low_count == 0) {
-                // if there have been no pulses the line is steady high or low
-#ifdef USE_ESP32
-                if (this->input_obst_pin_->digital_read()) {
-#else
-                if (!this->input_obst_pin_->digital_read()) {
-#endif
-                    // asleep
-                    last_asleep = current_millis;
-                } else {
-                    // if the line is high and was last asleep more than 700ms ago, then there is an obstruction present
-                    if (current_millis - last_asleep > 700) {
-                        this->obstruction_state = ObstructionState::OBSTRUCTED;
-                    }
-                }
-            }
-            last_millis = current_millis;
-            this->isr_store_.obstruction_low_count = 0;
-        }
-    }
-
-    void RATGDOComponent::query_status()
-    {
-        this->protocol_->call(QueryStatus { });
-    }
-
-    void RATGDOComponent::query_openings()
-    {
-        this->protocol_->call(QueryOpenings { });
-    }
-
-    void RATGDOComponent::query_paired_devices()
-    {
-        this->protocol_->call(QueryPairedDevicesAll { });
-    }
-
-    void RATGDOComponent::query_paired_devices(PairedDevice kind)
-    {
-        this->protocol_->call(QueryPairedDevices { kind });
-    }
-
-    void RATGDOComponent::clear_paired_devices(PairedDevice kind)
-    {
-        this->protocol_->call(ClearPairedDevices { kind });
-    }
-
-    void RATGDOComponent::sync()
-    {
-        this->protocol_->sync();
-
-        // dry contact protocol:
-        // needed to trigger the intial state of the limit switch sensors
-        // ideally this would be in drycontact::sync
-#ifdef PROTOCOL_DRYCONTACT
-        this->protocol_->set_open_limit(this->dry_contact_open_sensor_->state);
-        this->protocol_->set_close_limit(this->dry_contact_close_sensor_->state);
-#endif
-    }
-
-    void RATGDOComponent::door_open()
-    {
-        if (*this->door_state == DoorState::OPENING) {
-            return; // gets ignored by opener
-        }
-
-        this->door_action(DoorAction::OPEN);
-
-        if (*this->opening_duration > 0) {
-            // query state in case we don't get a status message
-            set_timeout("door_query_state", (*this->opening_duration + 2) * 1000, [this]() {
-                if (*this->door_state != DoorState::OPEN && *this->door_state != DoorState::STOPPED) {
-                    this->received(DoorState::OPEN); // probably missed a status mesage, assume it's open
-                    this->query_status(); // query in case we're wrong and it's stopped
-                }
-            });
-        }
-    }
-
-    void RATGDOComponent::door_close()
-    {
-        if (*this->door_state == DoorState::CLOSING) {
-            return; // gets ignored by opener
-        }
-
-        if (*this->door_state == DoorState::OPENING) {
-            // have to stop door first, otherwise close command is ignored
-            this->door_action(DoorAction::STOP);
-            this->on_door_state_([this](DoorState s) {
-                if (s == DoorState::STOPPED) {
-                    this->door_action(DoorAction::CLOSE);
-                } else {
-                    ESP_LOGW(TAG, "Door did not stop, ignoring close command");
-                }
-            });
-            return;
-        }
-
-        if (this->flags_.obstruction_sensor_detected) {
-            this->door_action(DoorAction::CLOSE);
-        } else if (*this->door_state == DoorState::OPEN) {
-            ESP_LOGD(TAG, "No obstruction sensors detected. Close using TOGGLE.");
-            this->door_action(DoorAction::TOGGLE);
-        }
-
-        if (*this->closing_duration > 0) {
-            // query state in case we don't get a status message
-            set_timeout("door_query_state", (*this->closing_duration + 2) * 1000, [this]() {
-                if (*this->door_state != DoorState::CLOSED && *this->door_state != DoorState::STOPPED) {
-                    this->received(DoorState::CLOSED); // probably missed a status mesage, assume it's closed
-                    this->query_status(); // query in case we're wrong and it's stopped
-                }
-            });
-        }
-    }
-
-    void RATGDOComponent::door_stop()
-    {
-        if (*this->door_state != DoorState::OPENING && *this->door_state != DoorState::CLOSING) {
-            ESP_LOGW(TAG, "The door is not moving.");
-            return;
-        }
+    if (*this->door_state == DoorState::OPENING) {
+        // have to stop door first, otherwise close command is ignored
         this->door_action(DoorAction::STOP);
+        this->on_door_state_([this](DoorState s) {
+            if (s == DoorState::STOPPED) {
+                this->door_action(DoorAction::CLOSE);
+            } else {
+                ESP_LOGW(TAG, "Door did not stop, ignoring close command");
+            }
+        });
+        return;
     }
 
-    void RATGDOComponent::door_toggle()
-    {
+    if (this->flags_.obstruction_sensor_detected) {
+        this->door_action(DoorAction::CLOSE);
+    } else if (*this->door_state == DoorState::OPEN) {
+        ESP_LOGD(TAG, "No obstruction sensors detected. Close using TOGGLE.");
         this->door_action(DoorAction::TOGGLE);
     }
 
-    void RATGDOComponent::door_action(DoorAction action)
-    {
+    if (*this->closing_duration > 0) {
+        // query state in case we don't get a status message
+        set_timeout("door_query_state", (*this->closing_duration + 2) * 1000, [this]() {
+            if (*this->door_state != DoorState::CLOSED && *this->door_state != DoorState::STOPPED) {
+                this->received(DoorState::CLOSED); // probably missed a status mesage, assume it's closed
+                this->query_status(); // query in case we're wrong and it's stopped
+            }
+        });
+    }
+}
+
+void RATGDOComponent::door_stop()
+{
+    if (*this->door_state != DoorState::OPENING && *this->door_state != DoorState::CLOSING) {
+        ESP_LOGW(TAG, "The door is not moving.");
+        return;
+    }
+    this->door_action(DoorAction::STOP);
+}
+
+void RATGDOComponent::door_toggle()
+{
+    this->door_action(DoorAction::TOGGLE);
+}
+
+void RATGDOComponent::door_action(DoorAction action)
+{
 #ifdef RATGDO_USE_CLOSING_DELAY
-        if (*this->closing_delay > 0 && (action == DoorAction::CLOSE || (action == DoorAction::TOGGLE && *this->door_state != DoorState::CLOSED))) {
-            this->door_action_delayed = DoorActionDelayed::YES;
-            set_timeout("door_action", *this->closing_delay * 1000, [this] {
-                this->door_action_delayed = DoorActionDelayed::NO;
-                this->protocol_->door_action(DoorAction::CLOSE);
-            });
-        } else {
-            this->protocol_->door_action(action);
-        }
-#else
+    if (*this->closing_delay > 0 && (action == DoorAction::CLOSE || (action == DoorAction::TOGGLE && *this->door_state != DoorState::CLOSED))) {
+        this->door_action_delayed = DoorActionDelayed::YES;
+        set_timeout("door_action", *this->closing_delay * 1000, [this] {
+            this->door_action_delayed = DoorActionDelayed::NO;
+            this->protocol_->door_action(DoorAction::CLOSE);
+        });
+    } else {
         this->protocol_->door_action(action);
+    }
+#else
+    this->protocol_->door_action(action);
 #endif
-    }
+}
 
-    void RATGDOComponent::door_move_to_position(float position)
-    {
-        if (*this->door_state == DoorState::OPENING || *this->door_state == DoorState::CLOSING) {
-            this->door_action(DoorAction::STOP);
-            this->on_door_state_([this, position](DoorState s) {
-                if (s == DoorState::STOPPED) {
-                    this->door_move_to_position(position);
-                }
-            });
-            return;
-        }
-
-        auto delta = position - *this->door_position;
-        if (delta == 0) {
-            ESP_LOGD(TAG, "Door is already at position %.2f", position);
-            return;
-        }
-
-        auto duration = delta > 0 ? *this->opening_duration : -*this->closing_duration;
-        if (duration == 0) {
-            ESP_LOGW(TAG, "I don't know duration, ignoring move to position");
-            return;
-        }
-
-        auto operation_time = 1000 * duration * delta;
-        this->door_move_delta = delta;
-        ESP_LOGD(TAG, "Moving to position %.2f in %.1fs", position, operation_time / 1000.0);
-
-        this->door_action(delta > 0 ? DoorAction::OPEN : DoorAction::CLOSE);
-        set_timeout("move_to_position", operation_time, [this] {
-            this->door_action(DoorAction::STOP);
+void RATGDOComponent::door_move_to_position(float position)
+{
+    if (*this->door_state == DoorState::OPENING || *this->door_state == DoorState::CLOSING) {
+        this->door_action(DoorAction::STOP);
+        this->on_door_state_([this, position](DoorState s) {
+            if (s == DoorState::STOPPED) {
+                this->door_move_to_position(position);
+            }
         });
+        return;
     }
 
-    void RATGDOComponent::cancel_position_sync_callbacks()
-    {
-        if (this->door_start_moving != 0) {
-            ESP_LOGD(TAG, "Cancelling position callbacks");
-            cancel_timeout("move_to_position");
-            cancel_interval(INTERVAL_POSITION_SYNC);
-
-            this->door_start_moving = 0;
-            this->door_start_position = DOOR_POSITION_UNKNOWN;
-            this->door_move_delta = DOOR_DELTA_UNKNOWN;
-        }
+    auto delta = position - *this->door_position;
+    if (delta == 0) {
+        ESP_LOGD(TAG, "Door is already at position %.2f", position);
+        return;
     }
 
-    void RATGDOComponent::light_on()
-    {
-        this->light_state = LightState::ON;
-        this->protocol_->light_action(LightAction::ON);
+    auto duration = delta > 0 ? *this->opening_duration : -*this->closing_duration;
+    if (duration == 0) {
+        ESP_LOGW(TAG, "I don't know duration, ignoring move to position");
+        return;
     }
 
-    void RATGDOComponent::light_off()
-    {
-        this->light_state = LightState::OFF;
-        this->protocol_->light_action(LightAction::OFF);
+    auto operation_time = 1000 * duration * delta;
+    this->door_move_delta = delta;
+    ESP_LOGD(TAG, "Moving to position %.2f in %.1fs", position, operation_time / 1000.0);
+
+    this->door_action(delta > 0 ? DoorAction::OPEN : DoorAction::CLOSE);
+    set_timeout("move_to_position", operation_time, [this] {
+        this->door_action(DoorAction::STOP);
+    });
+}
+
+void RATGDOComponent::cancel_position_sync_callbacks()
+{
+    if (this->door_start_moving != 0) {
+        ESP_LOGD(TAG, "Cancelling position callbacks");
+        cancel_timeout("move_to_position");
+        cancel_interval(INTERVAL_POSITION_SYNC);
+
+        this->door_start_moving = 0;
+        this->door_start_position = DOOR_POSITION_UNKNOWN;
+        this->door_move_delta = DOOR_DELTA_UNKNOWN;
     }
+}
 
-    void RATGDOComponent::light_toggle()
-    {
-        this->light_state = light_state_toggle(*this->light_state);
-        this->protocol_->light_action(LightAction::TOGGLE);
-    }
+void RATGDOComponent::light_on()
+{
+    this->light_state = LightState::ON;
+    this->protocol_->light_action(LightAction::ON);
+}
 
-    LightState RATGDOComponent::get_light_state() const
-    {
-        return *this->light_state;
-    }
+void RATGDOComponent::light_off()
+{
+    this->light_state = LightState::OFF;
+    this->protocol_->light_action(LightAction::OFF);
+}
 
-    // Lock functions
-    void RATGDOComponent::lock()
-    {
-        this->lock_state = LockState::LOCKED;
-        this->protocol_->lock_action(LockAction::LOCK);
-    }
+void RATGDOComponent::light_toggle()
+{
+    this->light_state = light_state_toggle(*this->light_state);
+    this->protocol_->light_action(LightAction::TOGGLE);
+}
 
-    void RATGDOComponent::unlock()
-    {
-        this->lock_state = LockState::UNLOCKED;
-        this->protocol_->lock_action(LockAction::UNLOCK);
-    }
+LightState RATGDOComponent::get_light_state() const
+{
+    return *this->light_state;
+}
 
-    void RATGDOComponent::lock_toggle()
-    {
-        this->lock_state = lock_state_toggle(*this->lock_state);
-        this->protocol_->lock_action(LockAction::TOGGLE);
-    }
+// Lock functions
+void RATGDOComponent::lock()
+{
+    this->lock_state = LockState::LOCKED;
+    this->protocol_->lock_action(LockAction::LOCK);
+}
 
-    // Learn functions
-    void RATGDOComponent::activate_learn()
-    {
-        this->protocol_->call(ActivateLearn { });
-    }
+void RATGDOComponent::unlock()
+{
+    this->lock_state = LockState::UNLOCKED;
+    this->protocol_->lock_action(LockAction::UNLOCK);
+}
 
-    void RATGDOComponent::inactivate_learn()
-    {
-        this->protocol_->call(InactivateLearn { });
-    }
+void RATGDOComponent::lock_toggle()
+{
+    this->lock_state = lock_state_toggle(*this->lock_state);
+    this->protocol_->lock_action(LockAction::TOGGLE);
+}
 
-    // Subscribe implementations are now templates in ratgdo.h
+// Learn functions
+void RATGDOComponent::activate_learn()
+{
+    this->protocol_->call(ActivateLearn { });
+}
 
-    // dry contact methods
-    void RATGDOComponent::set_dry_contact_open_sensor(esphome::binary_sensor::BinarySensor* dry_contact_open_sensor)
-    {
-        dry_contact_open_sensor_ = dry_contact_open_sensor;
-        dry_contact_open_sensor_->add_on_state_callback([this](bool sensor_value) {
-            this->protocol_->set_open_limit(sensor_value);
-            this->door_position = 1.0;
-        });
-    }
+void RATGDOComponent::inactivate_learn()
+{
+    this->protocol_->call(InactivateLearn { });
+}
 
-    void RATGDOComponent::set_dry_contact_close_sensor(esphome::binary_sensor::BinarySensor* dry_contact_close_sensor)
-    {
-        dry_contact_close_sensor_ = dry_contact_close_sensor;
-        dry_contact_close_sensor_->add_on_state_callback([this](bool sensor_value) {
-            this->protocol_->set_close_limit(sensor_value);
-            this->door_position = 0.0;
-        });
-    }
+// Subscribe implementations are now templates in ratgdo.h
 
-} // namespace ratgdo
-} // namespace esphome
+// dry contact methods
+void RATGDOComponent::set_dry_contact_open_sensor(esphome::binary_sensor::BinarySensor* dry_contact_open_sensor)
+{
+    dry_contact_open_sensor_ = dry_contact_open_sensor;
+    dry_contact_open_sensor_->add_on_state_callback([this](bool sensor_value) {
+        this->protocol_->set_open_limit(sensor_value);
+        this->door_position = 1.0;
+    });
+}
+
+void RATGDOComponent::set_dry_contact_close_sensor(esphome::binary_sensor::BinarySensor* dry_contact_close_sensor)
+{
+    dry_contact_close_sensor_ = dry_contact_close_sensor;
+    dry_contact_close_sensor_->add_on_state_callback([this](bool sensor_value) {
+        this->protocol_->set_close_limit(sensor_value);
+        this->door_position = 0.0;
+    });
+}
+
+} // namespace esphome::ratgdo

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -50,572 +50,573 @@
 
 namespace esphome {
 class InternalGPIOPin;
-namespace ratgdo {
-
-    class RATGDOComponent;
-    typedef Parented<RATGDOComponent> RATGDOClient;
-
-    const float DOOR_POSITION_UNKNOWN = -1.0;
-    const float DOOR_DELTA_UNKNOWN = -2.0;
-    const uint8_t PAIRED_DEVICES_UNKNOWN = 0xFF;
-
-    struct RATGDOStore {
-        int obstruction_low_count = 0; // count obstruction low pulses
-
-        static void IRAM_ATTR HOT isr_obstruction(RATGDOStore* arg)
-        {
-            arg->obstruction_low_count++;
-        }
-    };
-
-    using protocol::Args;
-    using protocol::Result;
-
-    class RATGDOComponent : public Component {
-    public:
-        RATGDOComponent()
-        {
-        }
-
-        void setup() override;
-        void loop() override;
-        void dump_config() override;
-
-        void init_protocol();
-
-        void obstruction_loop();
-
-        float start_opening { -1 };
-        single_observable<float> opening_duration { 0 };
-        float start_closing { -1 };
-        single_observable<float> closing_duration { 0 };
-#ifdef RATGDO_USE_CLOSING_DELAY
-        single_observable<uint32_t> closing_delay { 0 };
-#endif
-
-#ifdef RATGDO_USE_DISTANCE_SENSOR
-        single_observable<int16_t> target_distance_measurement { -1 };
-        std::bitset<256> in_range; // the length of this bitset determines how many out of range readings are required for presence detection to change states
-        observable<int16_t, RATGDO_MAX_DISTANCE_SUBSCRIBERS> last_distance_measurement { 0 };
-#endif
-
-        single_observable<uint16_t> openings { 0 }; // number of times the door has been opened
-        single_observable<uint8_t> paired_total { PAIRED_DEVICES_UNKNOWN };
-        single_observable<uint8_t> paired_remotes { PAIRED_DEVICES_UNKNOWN };
-        single_observable<uint8_t> paired_keypads { PAIRED_DEVICES_UNKNOWN };
-        single_observable<uint8_t> paired_wall_controls { PAIRED_DEVICES_UNKNOWN };
-        single_observable<uint8_t> paired_accessories { PAIRED_DEVICES_UNKNOWN };
-
-        observable<DoorState, RATGDO_MAX_DOOR_STATE_SUBSCRIBERS> door_state { DoorState::UNKNOWN };
-        observable<float, RATGDO_MAX_DOOR_STATE_SUBSCRIBERS> door_position { DOOR_POSITION_UNKNOWN };
-        observable<DoorActionDelayed, RATGDO_MAX_DOOR_ACTION_DELAYED_SUBSCRIBERS> door_action_delayed { DoorActionDelayed::NO };
-
-        unsigned long door_start_moving { 0 };
-        float door_start_position { DOOR_POSITION_UNKNOWN };
-        float door_move_delta { DOOR_DELTA_UNKNOWN };
-        uint16_t position_sync_remaining_ { 0 };
-
-        single_observable<LightState> light_state { LightState::UNKNOWN };
-        single_observable<LockState> lock_state { LockState::UNKNOWN };
-        single_observable<ObstructionState> obstruction_state { ObstructionState::UNKNOWN };
-        single_observable<MotorState> motor_state { MotorState::UNKNOWN };
-        single_observable<ButtonState> button_state { ButtonState::UNKNOWN };
-        single_observable<MotionState> motion_state { MotionState::UNKNOWN };
-        single_observable<LearnState> learn_state { LearnState::UNKNOWN };
-#ifdef RATGDO_USE_VEHICLE_SENSORS
-        observable<VehicleDetectedState, RATGDO_MAX_VEHICLE_DETECTED_SUBSCRIBERS> vehicle_detected_state { VehicleDetectedState::NO };
-        observable<VehicleArrivingState, RATGDO_MAX_VEHICLE_ARRIVING_SUBSCRIBERS> vehicle_arriving_state { VehicleArrivingState::NO };
-        observable<VehicleLeavingState, RATGDO_MAX_VEHICLE_LEAVING_SUBSCRIBERS> vehicle_leaving_state { VehicleLeavingState::NO };
-#endif
-
-        OnceCallbacks<void(DoorState)> on_door_state_;
-
-        single_observable<bool> sync_failed { false };
-
-        void set_output_gdo_pin(InternalGPIOPin* pin) { this->output_gdo_pin_ = pin; }
-        void set_input_gdo_pin(InternalGPIOPin* pin) { this->input_gdo_pin_ = pin; }
-        void set_input_obst_pin(InternalGPIOPin* pin) { this->input_obst_pin_ = pin; }
-
-        // dry contact methods
-        void set_dry_contact_open_sensor(esphome::binary_sensor::BinarySensor* dry_contact_open_sensor_);
-        void set_dry_contact_close_sensor(esphome::binary_sensor::BinarySensor* dry_contact_close_sensor_);
-        void set_discrete_open_pin(InternalGPIOPin* pin) { this->protocol_->set_discrete_open_pin(pin); }
-        void set_discrete_close_pin(InternalGPIOPin* pin) { this->protocol_->set_discrete_close_pin(pin); }
-
-        Result call_protocol(Args args);
-
-        void received(const DoorState door_state);
-        void received(const LightState light_state);
-        void received(const LockState lock_state);
-        void received(const ObstructionState obstruction_state);
-        void received(const LightAction light_action);
-        void received(const MotorState motor_state);
-        void received(const ButtonState button_state);
-        void received(const MotionState motion_state);
-        void received(const LearnState light_state);
-        void received(const Openings openings);
-        void received(const TimeToClose ttc);
-        void received(const PairedDeviceCount pdc);
-        void received(const BatteryState pdc);
-
-        // door
-        void door_toggle();
-        void door_open();
-        void door_close();
-        void door_stop();
-
-        void door_action(DoorAction action);
-        void ensure_door_action(DoorAction action, uint32_t delay = 1500);
-        void door_move_to_position(float position);
-        void set_door_position(float door_position) { this->door_position = door_position; }
-        void set_opening_duration(float duration);
-        void set_closing_duration(float duration);
-#ifdef RATGDO_USE_CLOSING_DELAY
-        void set_closing_delay(uint32_t delay) { this->closing_delay = delay; }
-#endif
-        void schedule_door_position_sync(float update_period = 500);
-        void door_position_update();
-        void cancel_position_sync_callbacks();
-#ifdef RATGDO_USE_DISTANCE_SENSOR
-        void set_target_distance_measurement(int16_t distance);
-        void set_distance_measurement(int16_t distance);
-#endif
-#ifdef RATGDO_USE_VEHICLE_SENSORS
-        void calculate_presence();
-        void presence_change(bool sensor_value);
-#endif
-
-        // light
-        void light_toggle();
-        void light_on();
-        void light_off();
-        LightState get_light_state() const;
-
-        // lock
-        void lock_toggle();
-        void lock();
-        void unlock();
-
-        // Learn & Paired
-        void activate_learn();
-        void inactivate_learn();
-        void query_paired_devices();
-        void query_paired_devices(PairedDevice kind);
-        void clear_paired_devices(PairedDevice kind);
-
-        // Uses length + first character instead of string comparisons to avoid
-        // string literals in RODATA which consume RAM on ESP8266.
-        // Valid values: "all" (3,a), "remote" (6,r), "keypad" (6,k), "wall" (4,w), "accessory" (9,a)
-        // Template so it works with std::string, StringRef, or any type with length() and operator[].
-        template <typename StringT>
-        void clear_paired_devices(const StringT& kind)
-        {
-            PairedDevice device;
-            if (kind.length() == 3 && kind[0] == 'a') {
-                device = PairedDevice::ALL;
-            } else if (kind.length() == 6 && kind[0] == 'r') {
-                device = PairedDevice::REMOTE;
-            } else if (kind.length() == 6 && kind[0] == 'k') {
-                device = PairedDevice::KEYPAD;
-            } else if (kind.length() == 4 && kind[0] == 'w') {
-                device = PairedDevice::WALL_CONTROL;
-            } else if (kind.length() == 9 && kind[0] == 'a') {
-                device = PairedDevice::ACCESSORY;
-            } else {
-                return;
-            }
-            this->clear_paired_devices(device);
-        }
-
-        // button functionality
-        void query_status();
-        void query_openings();
-        void sync();
-
-        // children subscriptions — type-safe templates (no std::function)
-        // Callbacks must be trivially copyable and fit in Callback storage
-        // (3 * sizeof(void*)), e.g. [this] or [this, f] lambdas.
-        // Enforced at compile time by Callback::create().
-        template <typename F>
-        void subscribe_rolling_code_counter(F&& f);
-        template <typename F>
-        void subscribe_opening_duration(F&& f);
-        template <typename F>
-        void subscribe_closing_duration(F&& f);
-#ifdef RATGDO_USE_CLOSING_DELAY
-        template <typename F>
-        void subscribe_closing_delay(F&& f);
-#endif
-        template <typename F>
-        void subscribe_openings(F&& f);
-        template <typename F>
-        void subscribe_paired_devices_total(F&& f);
-        template <typename F>
-        void subscribe_paired_remotes(F&& f);
-        template <typename F>
-        void subscribe_paired_keypads(F&& f);
-        template <typename F>
-        void subscribe_paired_wall_controls(F&& f);
-        template <typename F>
-        void subscribe_paired_accessories(F&& f);
-        template <typename F>
-        void subscribe_door_state(F&& f);
-        template <typename F>
-        void subscribe_light_state(F&& f);
-        template <typename F>
-        void subscribe_lock_state(F&& f);
-        template <typename F>
-        void subscribe_obstruction_state(F&& f);
-        template <typename F>
-        void subscribe_motor_state(F&& f);
-        template <typename F>
-        void subscribe_button_state(F&& f);
-        template <typename F>
-        void subscribe_motion_state(F&& f);
-        template <typename F>
-        void subscribe_sync_failed(F&& f);
-        template <typename F>
-        void subscribe_learn_state(F&& f);
-        template <typename F>
-        void subscribe_door_action_delayed(F&& f);
-#ifdef RATGDO_USE_DISTANCE_SENSOR
-        template <typename F>
-        void subscribe_distance_measurement(F&& f);
-#endif
-#ifdef RATGDO_USE_VEHICLE_SENSORS
-        template <typename F>
-        void subscribe_vehicle_detected_state(F&& f);
-        template <typename F>
-        void subscribe_vehicle_arriving_state(F&& f);
-        template <typename F>
-        void subscribe_vehicle_leaving_state(F&& f);
-#endif
-
-    protected:
-        // Pointers first (4-byte aligned)
-        protocol::Protocol* protocol_;
-        InternalGPIOPin* output_gdo_pin_;
-        InternalGPIOPin* input_gdo_pin_;
-        InternalGPIOPin* input_obst_pin_;
-        esphome::binary_sensor::BinarySensor* dry_contact_open_sensor_;
-        esphome::binary_sensor::BinarySensor* dry_contact_close_sensor_;
-
-        // 4-byte members
-        RATGDOStore isr_store_ { };
-
-        // Bool members packed into bitfield
-        struct {
-            uint8_t obstruction_sensor_detected : 1;
-#ifdef RATGDO_USE_VEHICLE_SENSORS
-            uint8_t presence_detect_window_active : 1;
-            uint8_t reserved : 6; // Reserved for future use
-#else
-            uint8_t reserved : 7; // Reserved for future use
-#endif
-        } flags_ { 0 };
-
-        // Subscriber counters for defer name allocation
-        uint8_t door_state_sub_num_ { 0 };
-        uint8_t door_action_delayed_sub_num_ { 0 };
-#ifdef RATGDO_USE_DISTANCE_SENSOR
-        uint8_t distance_sub_num_ { 0 };
-#endif
-#ifdef RATGDO_USE_VEHICLE_SENSORS
-        uint8_t vehicle_detected_sub_num_ { 0 };
-        uint8_t vehicle_arriving_sub_num_ { 0 };
-        uint8_t vehicle_leaving_sub_num_ { 0 };
-#endif
-    }; // RATGDOComponent
-
-    void log_subscriber_overflow(const LogString* observable_name, uint32_t max);
-
-    inline uint32_t get_defer_id(uint32_t base, uint32_t count, uint8_t& counter, const LogString* observable_name)
-    {
-        if (count == 0) {
-            log_subscriber_overflow(observable_name, count);
-            return base;
-        }
-        if (counter >= count) {
-            log_subscriber_overflow(observable_name, count);
-            return base + count - 1; // reuse last ID to avoid collision with first subscriber
-        }
-        return base + counter++;
-    }
-
-    // Defer IDs using uint32_t ranges to avoid heap allocations
-    // Bases are auto-generated from counts to prevent ID conflicts
-    namespace defer_ids {
-        inline constexpr uint32_t INTERVAL_POSITION_SYNC = 0;
-
-        // Multi-subscriber ranges — counts derived from codegen defines
-        inline constexpr uint32_t DEFER_DOOR_STATE_COUNT = RATGDO_MAX_DOOR_STATE_SUBSCRIBERS;
-        inline constexpr uint32_t DEFER_DOOR_STATE_BASE = INTERVAL_POSITION_SYNC + 1;
-
-        inline constexpr uint32_t DEFER_DOOR_ACTION_DELAYED_COUNT = RATGDO_MAX_DOOR_ACTION_DELAYED_SUBSCRIBERS;
-        inline constexpr uint32_t DEFER_DOOR_ACTION_DELAYED_BASE = DEFER_DOOR_STATE_BASE + DEFER_DOOR_STATE_COUNT;
-
-#ifdef RATGDO_USE_DISTANCE_SENSOR
-        inline constexpr uint32_t DEFER_DISTANCE_COUNT = RATGDO_MAX_DISTANCE_SUBSCRIBERS;
-        inline constexpr uint32_t DEFER_DISTANCE_BASE = DEFER_DOOR_ACTION_DELAYED_BASE + DEFER_DOOR_ACTION_DELAYED_COUNT;
-        inline constexpr uint32_t DEFER_DISTANCE_END = DEFER_DISTANCE_BASE + DEFER_DISTANCE_COUNT;
-#else
-        inline constexpr uint32_t DEFER_DISTANCE_END = DEFER_DOOR_ACTION_DELAYED_BASE + DEFER_DOOR_ACTION_DELAYED_COUNT;
-#endif
-
-#ifdef RATGDO_USE_VEHICLE_SENSORS
-        inline constexpr uint32_t DEFER_VEHICLE_DETECTED_COUNT = RATGDO_MAX_VEHICLE_DETECTED_SUBSCRIBERS;
-        inline constexpr uint32_t DEFER_VEHICLE_DETECTED_BASE = DEFER_DISTANCE_END;
-        inline constexpr uint32_t DEFER_VEHICLE_ARRIVING_COUNT = RATGDO_MAX_VEHICLE_ARRIVING_SUBSCRIBERS;
-        inline constexpr uint32_t DEFER_VEHICLE_ARRIVING_BASE = DEFER_VEHICLE_DETECTED_BASE + DEFER_VEHICLE_DETECTED_COUNT;
-        inline constexpr uint32_t DEFER_VEHICLE_LEAVING_COUNT = RATGDO_MAX_VEHICLE_LEAVING_SUBSCRIBERS;
-        inline constexpr uint32_t DEFER_VEHICLE_LEAVING_BASE = DEFER_VEHICLE_ARRIVING_BASE + DEFER_VEHICLE_ARRIVING_COUNT;
-        inline constexpr uint32_t DEFER_VEHICLE_END = DEFER_VEHICLE_LEAVING_BASE + DEFER_VEHICLE_LEAVING_COUNT;
-#else
-        inline constexpr uint32_t DEFER_VEHICLE_END = DEFER_DISTANCE_END;
-#endif
-
-        // Single-subscriber IDs
-        enum : uint32_t {
-            DEFER_ROLLING_CODE = DEFER_VEHICLE_END,
-            DEFER_OPENING_DURATION,
-            DEFER_CLOSING_DURATION,
-            DEFER_CLOSING_DELAY,
-            DEFER_OPENINGS,
-            DEFER_PAIRED_TOTAL,
-            DEFER_PAIRED_REMOTES,
-            DEFER_PAIRED_KEYPADS,
-            DEFER_PAIRED_WALL_CONTROLS,
-            DEFER_PAIRED_ACCESSORIES,
-            DEFER_LIGHT_STATE,
-            DEFER_LOCK_STATE,
-            DEFER_OBSTRUCTION_STATE,
-            DEFER_MOTOR_STATE,
-            DEFER_BUTTON_STATE,
-            DEFER_MOTION_STATE,
-            DEFER_LEARN_STATE,
-        };
-    } // namespace defer_ids
-
-    // Template implementations for subscribe methods.
-    // Each wraps the callback in a deferred call so that if the observable
-    // fires multiple times during one loop iteration, only the last value
-    // is dispatched to the child component.
-
-    template <typename F>
-    void RATGDOComponent::subscribe_rolling_code_counter(F&& f)
-    {
-        // change update to children is defered until after component loop
-        // if multiple changes occur during component loop, only the last one is notified
-        auto counter = this->protocol_->call(protocol::GetRollingCodeCounter { });
-        if (counter.tag == protocol::Result::Tag::rolling_code_counter) {
-            counter.value.rolling_code_counter.value->subscribe([this, f](uint32_t state) {
-                defer(defer_ids::DEFER_ROLLING_CODE, [f, state] { f(state); });
-            });
-        }
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_opening_duration(F&& f)
-    {
-        this->opening_duration.subscribe([this, f](float state) {
-            defer(defer_ids::DEFER_OPENING_DURATION, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_closing_duration(F&& f)
-    {
-        this->closing_duration.subscribe([this, f](float state) {
-            defer(defer_ids::DEFER_CLOSING_DURATION, [f, state] { f(state); });
-        });
-    }
-
-#ifdef RATGDO_USE_CLOSING_DELAY
-    template <typename F>
-    void RATGDOComponent::subscribe_closing_delay(F&& f)
-    {
-        this->closing_delay.subscribe([this, f](uint32_t state) {
-            defer(defer_ids::DEFER_CLOSING_DELAY, [f, state] { f(state); });
-        });
-    }
-#endif
-
-    template <typename F>
-    void RATGDOComponent::subscribe_openings(F&& f)
-    {
-        this->openings.subscribe([this, f](uint16_t state) {
-            defer(defer_ids::DEFER_OPENINGS, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_paired_devices_total(F&& f)
-    {
-        this->paired_total.subscribe([this, f](uint8_t state) {
-            defer(defer_ids::DEFER_PAIRED_TOTAL, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_paired_remotes(F&& f)
-    {
-        this->paired_remotes.subscribe([this, f](uint8_t state) {
-            defer(defer_ids::DEFER_PAIRED_REMOTES, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_paired_keypads(F&& f)
-    {
-        this->paired_keypads.subscribe([this, f](uint8_t state) {
-            defer(defer_ids::DEFER_PAIRED_KEYPADS, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_paired_wall_controls(F&& f)
-    {
-        this->paired_wall_controls.subscribe([this, f](uint8_t state) {
-            defer(defer_ids::DEFER_PAIRED_WALL_CONTROLS, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_paired_accessories(F&& f)
-    {
-        this->paired_accessories.subscribe([this, f](uint8_t state) {
-            defer(defer_ids::DEFER_PAIRED_ACCESSORIES, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_door_state(F&& f)
-    {
-        uint32_t id = get_defer_id(defer_ids::DEFER_DOOR_STATE_BASE, defer_ids::DEFER_DOOR_STATE_COUNT,
-            this->door_state_sub_num_, LOG_STR("door_state"));
-        this->door_state.subscribe([this, f, id](DoorState state) {
-            defer(id, [this, f, state] { f(state, *this->door_position); });
-        });
-        this->door_position.subscribe([this, f, id](float position) {
-            defer(id, [this, f, position] { f(*this->door_state, position); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_light_state(F&& f)
-    {
-        this->light_state.subscribe([this, f](LightState state) {
-            defer(defer_ids::DEFER_LIGHT_STATE, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_lock_state(F&& f)
-    {
-        this->lock_state.subscribe([this, f](LockState state) {
-            defer(defer_ids::DEFER_LOCK_STATE, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_obstruction_state(F&& f)
-    {
-        this->obstruction_state.subscribe([this, f](ObstructionState state) {
-            defer(defer_ids::DEFER_OBSTRUCTION_STATE, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_motor_state(F&& f)
-    {
-        this->motor_state.subscribe([this, f](MotorState state) {
-            defer(defer_ids::DEFER_MOTOR_STATE, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_button_state(F&& f)
-    {
-        this->button_state.subscribe([this, f](ButtonState state) {
-            defer(defer_ids::DEFER_BUTTON_STATE, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_motion_state(F&& f)
-    {
-        this->motion_state.subscribe([this, f](MotionState state) {
-            defer(defer_ids::DEFER_MOTION_STATE, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_sync_failed(F&& f)
-    {
-        this->sync_failed.subscribe(std::forward<F>(f));
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_learn_state(F&& f)
-    {
-        this->learn_state.subscribe([this, f](LearnState state) {
-            defer(defer_ids::DEFER_LEARN_STATE, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_door_action_delayed(F&& f)
-    {
-        uint32_t id = get_defer_id(defer_ids::DEFER_DOOR_ACTION_DELAYED_BASE, defer_ids::DEFER_DOOR_ACTION_DELAYED_COUNT,
-            this->door_action_delayed_sub_num_, LOG_STR("door_action_delayed"));
-        this->door_action_delayed.subscribe([this, f, id](DoorActionDelayed state) {
-            defer(id, [f, state] { f(state); });
-        });
-    }
-
-#ifdef RATGDO_USE_DISTANCE_SENSOR
-    template <typename F>
-    void RATGDOComponent::subscribe_distance_measurement(F&& f)
-    {
-        uint32_t id = get_defer_id(defer_ids::DEFER_DISTANCE_BASE, defer_ids::DEFER_DISTANCE_COUNT,
-            this->distance_sub_num_, LOG_STR("distance_measurement"));
-        this->last_distance_measurement.subscribe([this, f, id](int16_t state) {
-            defer(id, [f, state] { f(state); });
-        });
-    }
-#endif
-
-#ifdef RATGDO_USE_VEHICLE_SENSORS
-    template <typename F>
-    void RATGDOComponent::subscribe_vehicle_detected_state(F&& f)
-    {
-        uint32_t id = get_defer_id(defer_ids::DEFER_VEHICLE_DETECTED_BASE, defer_ids::DEFER_VEHICLE_DETECTED_COUNT,
-            this->vehicle_detected_sub_num_, LOG_STR("vehicle_detected"));
-        this->vehicle_detected_state.subscribe([this, f, id](VehicleDetectedState state) {
-            defer(id, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_vehicle_arriving_state(F&& f)
-    {
-        uint32_t id = get_defer_id(defer_ids::DEFER_VEHICLE_ARRIVING_BASE, defer_ids::DEFER_VEHICLE_ARRIVING_COUNT,
-            this->vehicle_arriving_sub_num_, LOG_STR("vehicle_arriving"));
-        this->vehicle_arriving_state.subscribe([this, f, id](VehicleArrivingState state) {
-            defer(id, [f, state] { f(state); });
-        });
-    }
-
-    template <typename F>
-    void RATGDOComponent::subscribe_vehicle_leaving_state(F&& f)
-    {
-        uint32_t id = get_defer_id(defer_ids::DEFER_VEHICLE_LEAVING_BASE, defer_ids::DEFER_VEHICLE_LEAVING_COUNT,
-            this->vehicle_leaving_sub_num_, LOG_STR("vehicle_leaving"));
-        this->vehicle_leaving_state.subscribe([this, f, id](VehicleLeavingState state) {
-            defer(id, [f, state] { f(state); });
-        });
-    }
-#endif
-
-} // namespace ratgdo
 } // namespace esphome
+
+namespace esphome::ratgdo {
+
+class RATGDOComponent;
+typedef Parented<RATGDOComponent> RATGDOClient;
+
+const float DOOR_POSITION_UNKNOWN = -1.0;
+const float DOOR_DELTA_UNKNOWN = -2.0;
+const uint8_t PAIRED_DEVICES_UNKNOWN = 0xFF;
+
+struct RATGDOStore {
+    int obstruction_low_count = 0; // count obstruction low pulses
+
+    static void IRAM_ATTR HOT isr_obstruction(RATGDOStore* arg)
+    {
+        arg->obstruction_low_count++;
+    }
+};
+
+using protocol::Args;
+using protocol::Result;
+
+class RATGDOComponent : public Component {
+public:
+    RATGDOComponent()
+    {
+    }
+
+    void setup() override;
+    void loop() override;
+    void dump_config() override;
+
+    void init_protocol();
+
+    void obstruction_loop();
+
+    float start_opening { -1 };
+    single_observable<float> opening_duration { 0 };
+    float start_closing { -1 };
+    single_observable<float> closing_duration { 0 };
+#ifdef RATGDO_USE_CLOSING_DELAY
+    single_observable<uint32_t> closing_delay { 0 };
+#endif
+
+#ifdef RATGDO_USE_DISTANCE_SENSOR
+    single_observable<int16_t> target_distance_measurement { -1 };
+    std::bitset<256> in_range; // the length of this bitset determines how many out of range readings are required for presence detection to change states
+    observable<int16_t, RATGDO_MAX_DISTANCE_SUBSCRIBERS> last_distance_measurement { 0 };
+#endif
+
+    single_observable<uint16_t> openings { 0 }; // number of times the door has been opened
+    single_observable<uint8_t> paired_total { PAIRED_DEVICES_UNKNOWN };
+    single_observable<uint8_t> paired_remotes { PAIRED_DEVICES_UNKNOWN };
+    single_observable<uint8_t> paired_keypads { PAIRED_DEVICES_UNKNOWN };
+    single_observable<uint8_t> paired_wall_controls { PAIRED_DEVICES_UNKNOWN };
+    single_observable<uint8_t> paired_accessories { PAIRED_DEVICES_UNKNOWN };
+
+    observable<DoorState, RATGDO_MAX_DOOR_STATE_SUBSCRIBERS> door_state { DoorState::UNKNOWN };
+    observable<float, RATGDO_MAX_DOOR_STATE_SUBSCRIBERS> door_position { DOOR_POSITION_UNKNOWN };
+    observable<DoorActionDelayed, RATGDO_MAX_DOOR_ACTION_DELAYED_SUBSCRIBERS> door_action_delayed { DoorActionDelayed::NO };
+
+    unsigned long door_start_moving { 0 };
+    float door_start_position { DOOR_POSITION_UNKNOWN };
+    float door_move_delta { DOOR_DELTA_UNKNOWN };
+    uint16_t position_sync_remaining_ { 0 };
+
+    single_observable<LightState> light_state { LightState::UNKNOWN };
+    single_observable<LockState> lock_state { LockState::UNKNOWN };
+    single_observable<ObstructionState> obstruction_state { ObstructionState::UNKNOWN };
+    single_observable<MotorState> motor_state { MotorState::UNKNOWN };
+    single_observable<ButtonState> button_state { ButtonState::UNKNOWN };
+    single_observable<MotionState> motion_state { MotionState::UNKNOWN };
+    single_observable<LearnState> learn_state { LearnState::UNKNOWN };
+#ifdef RATGDO_USE_VEHICLE_SENSORS
+    observable<VehicleDetectedState, RATGDO_MAX_VEHICLE_DETECTED_SUBSCRIBERS> vehicle_detected_state { VehicleDetectedState::NO };
+    observable<VehicleArrivingState, RATGDO_MAX_VEHICLE_ARRIVING_SUBSCRIBERS> vehicle_arriving_state { VehicleArrivingState::NO };
+    observable<VehicleLeavingState, RATGDO_MAX_VEHICLE_LEAVING_SUBSCRIBERS> vehicle_leaving_state { VehicleLeavingState::NO };
+#endif
+
+    OnceCallbacks<void(DoorState)> on_door_state_;
+
+    single_observable<bool> sync_failed { false };
+
+    void set_output_gdo_pin(InternalGPIOPin* pin) { this->output_gdo_pin_ = pin; }
+    void set_input_gdo_pin(InternalGPIOPin* pin) { this->input_gdo_pin_ = pin; }
+    void set_input_obst_pin(InternalGPIOPin* pin) { this->input_obst_pin_ = pin; }
+
+    // dry contact methods
+    void set_dry_contact_open_sensor(esphome::binary_sensor::BinarySensor* dry_contact_open_sensor_);
+    void set_dry_contact_close_sensor(esphome::binary_sensor::BinarySensor* dry_contact_close_sensor_);
+    void set_discrete_open_pin(InternalGPIOPin* pin) { this->protocol_->set_discrete_open_pin(pin); }
+    void set_discrete_close_pin(InternalGPIOPin* pin) { this->protocol_->set_discrete_close_pin(pin); }
+
+    Result call_protocol(Args args);
+
+    void received(const DoorState door_state);
+    void received(const LightState light_state);
+    void received(const LockState lock_state);
+    void received(const ObstructionState obstruction_state);
+    void received(const LightAction light_action);
+    void received(const MotorState motor_state);
+    void received(const ButtonState button_state);
+    void received(const MotionState motion_state);
+    void received(const LearnState light_state);
+    void received(const Openings openings);
+    void received(const TimeToClose ttc);
+    void received(const PairedDeviceCount pdc);
+    void received(const BatteryState pdc);
+
+    // door
+    void door_toggle();
+    void door_open();
+    void door_close();
+    void door_stop();
+
+    void door_action(DoorAction action);
+    void ensure_door_action(DoorAction action, uint32_t delay = 1500);
+    void door_move_to_position(float position);
+    void set_door_position(float door_position) { this->door_position = door_position; }
+    void set_opening_duration(float duration);
+    void set_closing_duration(float duration);
+#ifdef RATGDO_USE_CLOSING_DELAY
+    void set_closing_delay(uint32_t delay) { this->closing_delay = delay; }
+#endif
+    void schedule_door_position_sync(float update_period = 500);
+    void door_position_update();
+    void cancel_position_sync_callbacks();
+#ifdef RATGDO_USE_DISTANCE_SENSOR
+    void set_target_distance_measurement(int16_t distance);
+    void set_distance_measurement(int16_t distance);
+#endif
+#ifdef RATGDO_USE_VEHICLE_SENSORS
+    void calculate_presence();
+    void presence_change(bool sensor_value);
+#endif
+
+    // light
+    void light_toggle();
+    void light_on();
+    void light_off();
+    LightState get_light_state() const;
+
+    // lock
+    void lock_toggle();
+    void lock();
+    void unlock();
+
+    // Learn & Paired
+    void activate_learn();
+    void inactivate_learn();
+    void query_paired_devices();
+    void query_paired_devices(PairedDevice kind);
+    void clear_paired_devices(PairedDevice kind);
+
+    // Uses length + first character instead of string comparisons to avoid
+    // string literals in RODATA which consume RAM on ESP8266.
+    // Valid values: "all" (3,a), "remote" (6,r), "keypad" (6,k), "wall" (4,w), "accessory" (9,a)
+    // Template so it works with std::string, StringRef, or any type with length() and operator[].
+    template <typename StringT>
+    void clear_paired_devices(const StringT& kind)
+    {
+        PairedDevice device;
+        if (kind.length() == 3 && kind[0] == 'a') {
+            device = PairedDevice::ALL;
+        } else if (kind.length() == 6 && kind[0] == 'r') {
+            device = PairedDevice::REMOTE;
+        } else if (kind.length() == 6 && kind[0] == 'k') {
+            device = PairedDevice::KEYPAD;
+        } else if (kind.length() == 4 && kind[0] == 'w') {
+            device = PairedDevice::WALL_CONTROL;
+        } else if (kind.length() == 9 && kind[0] == 'a') {
+            device = PairedDevice::ACCESSORY;
+        } else {
+            return;
+        }
+        this->clear_paired_devices(device);
+    }
+
+    // button functionality
+    void query_status();
+    void query_openings();
+    void sync();
+
+    // children subscriptions — type-safe templates (no std::function)
+    // Callbacks must be trivially copyable and fit in Callback storage
+    // (3 * sizeof(void*)), e.g. [this] or [this, f] lambdas.
+    // Enforced at compile time by Callback::create().
+    template <typename F>
+    void subscribe_rolling_code_counter(F&& f);
+    template <typename F>
+    void subscribe_opening_duration(F&& f);
+    template <typename F>
+    void subscribe_closing_duration(F&& f);
+#ifdef RATGDO_USE_CLOSING_DELAY
+    template <typename F>
+    void subscribe_closing_delay(F&& f);
+#endif
+    template <typename F>
+    void subscribe_openings(F&& f);
+    template <typename F>
+    void subscribe_paired_devices_total(F&& f);
+    template <typename F>
+    void subscribe_paired_remotes(F&& f);
+    template <typename F>
+    void subscribe_paired_keypads(F&& f);
+    template <typename F>
+    void subscribe_paired_wall_controls(F&& f);
+    template <typename F>
+    void subscribe_paired_accessories(F&& f);
+    template <typename F>
+    void subscribe_door_state(F&& f);
+    template <typename F>
+    void subscribe_light_state(F&& f);
+    template <typename F>
+    void subscribe_lock_state(F&& f);
+    template <typename F>
+    void subscribe_obstruction_state(F&& f);
+    template <typename F>
+    void subscribe_motor_state(F&& f);
+    template <typename F>
+    void subscribe_button_state(F&& f);
+    template <typename F>
+    void subscribe_motion_state(F&& f);
+    template <typename F>
+    void subscribe_sync_failed(F&& f);
+    template <typename F>
+    void subscribe_learn_state(F&& f);
+    template <typename F>
+    void subscribe_door_action_delayed(F&& f);
+#ifdef RATGDO_USE_DISTANCE_SENSOR
+    template <typename F>
+    void subscribe_distance_measurement(F&& f);
+#endif
+#ifdef RATGDO_USE_VEHICLE_SENSORS
+    template <typename F>
+    void subscribe_vehicle_detected_state(F&& f);
+    template <typename F>
+    void subscribe_vehicle_arriving_state(F&& f);
+    template <typename F>
+    void subscribe_vehicle_leaving_state(F&& f);
+#endif
+
+protected:
+    // Pointers first (4-byte aligned)
+    protocol::Protocol* protocol_;
+    InternalGPIOPin* output_gdo_pin_;
+    InternalGPIOPin* input_gdo_pin_;
+    InternalGPIOPin* input_obst_pin_;
+    esphome::binary_sensor::BinarySensor* dry_contact_open_sensor_;
+    esphome::binary_sensor::BinarySensor* dry_contact_close_sensor_;
+
+    // 4-byte members
+    RATGDOStore isr_store_ { };
+
+    // Bool members packed into bitfield
+    struct {
+        uint8_t obstruction_sensor_detected : 1;
+#ifdef RATGDO_USE_VEHICLE_SENSORS
+        uint8_t presence_detect_window_active : 1;
+        uint8_t reserved : 6; // Reserved for future use
+#else
+        uint8_t reserved : 7; // Reserved for future use
+#endif
+    } flags_ { 0 };
+
+    // Subscriber counters for defer name allocation
+    uint8_t door_state_sub_num_ { 0 };
+    uint8_t door_action_delayed_sub_num_ { 0 };
+#ifdef RATGDO_USE_DISTANCE_SENSOR
+    uint8_t distance_sub_num_ { 0 };
+#endif
+#ifdef RATGDO_USE_VEHICLE_SENSORS
+    uint8_t vehicle_detected_sub_num_ { 0 };
+    uint8_t vehicle_arriving_sub_num_ { 0 };
+    uint8_t vehicle_leaving_sub_num_ { 0 };
+#endif
+}; // RATGDOComponent
+
+void log_subscriber_overflow(const LogString* observable_name, uint32_t max);
+
+inline uint32_t get_defer_id(uint32_t base, uint32_t count, uint8_t& counter, const LogString* observable_name)
+{
+    if (count == 0) {
+        log_subscriber_overflow(observable_name, count);
+        return base;
+    }
+    if (counter >= count) {
+        log_subscriber_overflow(observable_name, count);
+        return base + count - 1; // reuse last ID to avoid collision with first subscriber
+    }
+    return base + counter++;
+}
+
+// Defer IDs using uint32_t ranges to avoid heap allocations
+// Bases are auto-generated from counts to prevent ID conflicts
+namespace defer_ids {
+    inline constexpr uint32_t INTERVAL_POSITION_SYNC = 0;
+
+    // Multi-subscriber ranges — counts derived from codegen defines
+    inline constexpr uint32_t DEFER_DOOR_STATE_COUNT = RATGDO_MAX_DOOR_STATE_SUBSCRIBERS;
+    inline constexpr uint32_t DEFER_DOOR_STATE_BASE = INTERVAL_POSITION_SYNC + 1;
+
+    inline constexpr uint32_t DEFER_DOOR_ACTION_DELAYED_COUNT = RATGDO_MAX_DOOR_ACTION_DELAYED_SUBSCRIBERS;
+    inline constexpr uint32_t DEFER_DOOR_ACTION_DELAYED_BASE = DEFER_DOOR_STATE_BASE + DEFER_DOOR_STATE_COUNT;
+
+#ifdef RATGDO_USE_DISTANCE_SENSOR
+    inline constexpr uint32_t DEFER_DISTANCE_COUNT = RATGDO_MAX_DISTANCE_SUBSCRIBERS;
+    inline constexpr uint32_t DEFER_DISTANCE_BASE = DEFER_DOOR_ACTION_DELAYED_BASE + DEFER_DOOR_ACTION_DELAYED_COUNT;
+    inline constexpr uint32_t DEFER_DISTANCE_END = DEFER_DISTANCE_BASE + DEFER_DISTANCE_COUNT;
+#else
+    inline constexpr uint32_t DEFER_DISTANCE_END = DEFER_DOOR_ACTION_DELAYED_BASE + DEFER_DOOR_ACTION_DELAYED_COUNT;
+#endif
+
+#ifdef RATGDO_USE_VEHICLE_SENSORS
+    inline constexpr uint32_t DEFER_VEHICLE_DETECTED_COUNT = RATGDO_MAX_VEHICLE_DETECTED_SUBSCRIBERS;
+    inline constexpr uint32_t DEFER_VEHICLE_DETECTED_BASE = DEFER_DISTANCE_END;
+    inline constexpr uint32_t DEFER_VEHICLE_ARRIVING_COUNT = RATGDO_MAX_VEHICLE_ARRIVING_SUBSCRIBERS;
+    inline constexpr uint32_t DEFER_VEHICLE_ARRIVING_BASE = DEFER_VEHICLE_DETECTED_BASE + DEFER_VEHICLE_DETECTED_COUNT;
+    inline constexpr uint32_t DEFER_VEHICLE_LEAVING_COUNT = RATGDO_MAX_VEHICLE_LEAVING_SUBSCRIBERS;
+    inline constexpr uint32_t DEFER_VEHICLE_LEAVING_BASE = DEFER_VEHICLE_ARRIVING_BASE + DEFER_VEHICLE_ARRIVING_COUNT;
+    inline constexpr uint32_t DEFER_VEHICLE_END = DEFER_VEHICLE_LEAVING_BASE + DEFER_VEHICLE_LEAVING_COUNT;
+#else
+    inline constexpr uint32_t DEFER_VEHICLE_END = DEFER_DISTANCE_END;
+#endif
+
+    // Single-subscriber IDs
+    enum : uint32_t {
+        DEFER_ROLLING_CODE = DEFER_VEHICLE_END,
+        DEFER_OPENING_DURATION,
+        DEFER_CLOSING_DURATION,
+        DEFER_CLOSING_DELAY,
+        DEFER_OPENINGS,
+        DEFER_PAIRED_TOTAL,
+        DEFER_PAIRED_REMOTES,
+        DEFER_PAIRED_KEYPADS,
+        DEFER_PAIRED_WALL_CONTROLS,
+        DEFER_PAIRED_ACCESSORIES,
+        DEFER_LIGHT_STATE,
+        DEFER_LOCK_STATE,
+        DEFER_OBSTRUCTION_STATE,
+        DEFER_MOTOR_STATE,
+        DEFER_BUTTON_STATE,
+        DEFER_MOTION_STATE,
+        DEFER_LEARN_STATE,
+    };
+} // namespace defer_ids
+
+// Template implementations for subscribe methods.
+// Each wraps the callback in a deferred call so that if the observable
+// fires multiple times during one loop iteration, only the last value
+// is dispatched to the child component.
+
+template <typename F>
+void RATGDOComponent::subscribe_rolling_code_counter(F&& f)
+{
+    // change update to children is defered until after component loop
+    // if multiple changes occur during component loop, only the last one is notified
+    auto counter = this->protocol_->call(protocol::GetRollingCodeCounter { });
+    if (counter.tag == protocol::Result::Tag::rolling_code_counter) {
+        counter.value.rolling_code_counter.value->subscribe([this, f](uint32_t state) {
+            defer(defer_ids::DEFER_ROLLING_CODE, [f, state] { f(state); });
+        });
+    }
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_opening_duration(F&& f)
+{
+    this->opening_duration.subscribe([this, f](float state) {
+        defer(defer_ids::DEFER_OPENING_DURATION, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_closing_duration(F&& f)
+{
+    this->closing_duration.subscribe([this, f](float state) {
+        defer(defer_ids::DEFER_CLOSING_DURATION, [f, state] { f(state); });
+    });
+}
+
+#ifdef RATGDO_USE_CLOSING_DELAY
+template <typename F>
+void RATGDOComponent::subscribe_closing_delay(F&& f)
+{
+    this->closing_delay.subscribe([this, f](uint32_t state) {
+        defer(defer_ids::DEFER_CLOSING_DELAY, [f, state] { f(state); });
+    });
+}
+#endif
+
+template <typename F>
+void RATGDOComponent::subscribe_openings(F&& f)
+{
+    this->openings.subscribe([this, f](uint16_t state) {
+        defer(defer_ids::DEFER_OPENINGS, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_paired_devices_total(F&& f)
+{
+    this->paired_total.subscribe([this, f](uint8_t state) {
+        defer(defer_ids::DEFER_PAIRED_TOTAL, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_paired_remotes(F&& f)
+{
+    this->paired_remotes.subscribe([this, f](uint8_t state) {
+        defer(defer_ids::DEFER_PAIRED_REMOTES, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_paired_keypads(F&& f)
+{
+    this->paired_keypads.subscribe([this, f](uint8_t state) {
+        defer(defer_ids::DEFER_PAIRED_KEYPADS, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_paired_wall_controls(F&& f)
+{
+    this->paired_wall_controls.subscribe([this, f](uint8_t state) {
+        defer(defer_ids::DEFER_PAIRED_WALL_CONTROLS, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_paired_accessories(F&& f)
+{
+    this->paired_accessories.subscribe([this, f](uint8_t state) {
+        defer(defer_ids::DEFER_PAIRED_ACCESSORIES, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_door_state(F&& f)
+{
+    uint32_t id = get_defer_id(defer_ids::DEFER_DOOR_STATE_BASE, defer_ids::DEFER_DOOR_STATE_COUNT,
+        this->door_state_sub_num_, LOG_STR("door_state"));
+    this->door_state.subscribe([this, f, id](DoorState state) {
+        defer(id, [this, f, state] { f(state, *this->door_position); });
+    });
+    this->door_position.subscribe([this, f, id](float position) {
+        defer(id, [this, f, position] { f(*this->door_state, position); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_light_state(F&& f)
+{
+    this->light_state.subscribe([this, f](LightState state) {
+        defer(defer_ids::DEFER_LIGHT_STATE, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_lock_state(F&& f)
+{
+    this->lock_state.subscribe([this, f](LockState state) {
+        defer(defer_ids::DEFER_LOCK_STATE, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_obstruction_state(F&& f)
+{
+    this->obstruction_state.subscribe([this, f](ObstructionState state) {
+        defer(defer_ids::DEFER_OBSTRUCTION_STATE, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_motor_state(F&& f)
+{
+    this->motor_state.subscribe([this, f](MotorState state) {
+        defer(defer_ids::DEFER_MOTOR_STATE, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_button_state(F&& f)
+{
+    this->button_state.subscribe([this, f](ButtonState state) {
+        defer(defer_ids::DEFER_BUTTON_STATE, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_motion_state(F&& f)
+{
+    this->motion_state.subscribe([this, f](MotionState state) {
+        defer(defer_ids::DEFER_MOTION_STATE, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_sync_failed(F&& f)
+{
+    this->sync_failed.subscribe(std::forward<F>(f));
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_learn_state(F&& f)
+{
+    this->learn_state.subscribe([this, f](LearnState state) {
+        defer(defer_ids::DEFER_LEARN_STATE, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_door_action_delayed(F&& f)
+{
+    uint32_t id = get_defer_id(defer_ids::DEFER_DOOR_ACTION_DELAYED_BASE, defer_ids::DEFER_DOOR_ACTION_DELAYED_COUNT,
+        this->door_action_delayed_sub_num_, LOG_STR("door_action_delayed"));
+    this->door_action_delayed.subscribe([this, f, id](DoorActionDelayed state) {
+        defer(id, [f, state] { f(state); });
+    });
+}
+
+#ifdef RATGDO_USE_DISTANCE_SENSOR
+template <typename F>
+void RATGDOComponent::subscribe_distance_measurement(F&& f)
+{
+    uint32_t id = get_defer_id(defer_ids::DEFER_DISTANCE_BASE, defer_ids::DEFER_DISTANCE_COUNT,
+        this->distance_sub_num_, LOG_STR("distance_measurement"));
+    this->last_distance_measurement.subscribe([this, f, id](int16_t state) {
+        defer(id, [f, state] { f(state); });
+    });
+}
+#endif
+
+#ifdef RATGDO_USE_VEHICLE_SENSORS
+template <typename F>
+void RATGDOComponent::subscribe_vehicle_detected_state(F&& f)
+{
+    uint32_t id = get_defer_id(defer_ids::DEFER_VEHICLE_DETECTED_BASE, defer_ids::DEFER_VEHICLE_DETECTED_COUNT,
+        this->vehicle_detected_sub_num_, LOG_STR("vehicle_detected"));
+    this->vehicle_detected_state.subscribe([this, f, id](VehicleDetectedState state) {
+        defer(id, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_vehicle_arriving_state(F&& f)
+{
+    uint32_t id = get_defer_id(defer_ids::DEFER_VEHICLE_ARRIVING_BASE, defer_ids::DEFER_VEHICLE_ARRIVING_COUNT,
+        this->vehicle_arriving_sub_num_, LOG_STR("vehicle_arriving"));
+    this->vehicle_arriving_state.subscribe([this, f, id](VehicleArrivingState state) {
+        defer(id, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_vehicle_leaving_state(F&& f)
+{
+    uint32_t id = get_defer_id(defer_ids::DEFER_VEHICLE_LEAVING_BASE, defer_ids::DEFER_VEHICLE_LEAVING_COUNT,
+        this->vehicle_leaving_sub_num_, LOG_STR("vehicle_leaving"));
+    this->vehicle_leaving_state.subscribe([this, f, id](VehicleLeavingState state) {
+        defer(id, [f, state] { f(state); });
+    });
+}
+#endif
+
+} // namespace esphome::ratgdo

--- a/components/ratgdo/ratgdo_state.cpp
+++ b/components/ratgdo/ratgdo_state.cpp
@@ -1,49 +1,47 @@
 #include "ratgdo_state.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    LightState light_state_toggle(LightState state)
-    {
-        switch (state) {
-        case LightState::OFF:
-            return LightState::ON;
-        case LightState::ON:
-            return LightState::OFF;
-            // 2 and 3 appears sometimes
-        case LightState::UNKNOWN:
-        default:
-            return LightState::UNKNOWN;
-        }
+LightState light_state_toggle(LightState state)
+{
+    switch (state) {
+    case LightState::OFF:
+        return LightState::ON;
+    case LightState::ON:
+        return LightState::OFF;
+        // 2 and 3 appears sometimes
+    case LightState::UNKNOWN:
+    default:
+        return LightState::UNKNOWN;
     }
+}
 
-    LockState lock_state_toggle(LockState state)
-    {
-        switch (state) {
-        case LockState::UNLOCKED:
-            return LockState::LOCKED;
-        case LockState::LOCKED:
-            return LockState::UNLOCKED;
-            // 2 and 3 appears sometimes
-        case LockState::UNKNOWN:
-        default:
-            return LockState::UNKNOWN;
-        }
+LockState lock_state_toggle(LockState state)
+{
+    switch (state) {
+    case LockState::UNLOCKED:
+        return LockState::LOCKED;
+    case LockState::LOCKED:
+        return LockState::UNLOCKED;
+        // 2 and 3 appears sometimes
+    case LockState::UNKNOWN:
+    default:
+        return LockState::UNKNOWN;
     }
+}
 
-    LearnState learn_state_toggle(LearnState state)
-    {
-        switch (state) {
-        case LearnState::ACTIVE:
-            return LearnState::INACTIVE;
-        case LearnState::INACTIVE:
-            return LearnState::ACTIVE;
-            // 2 and 3 appears sometimes
-        case LearnState::UNKNOWN:
-        default:
-            return LearnState::UNKNOWN;
-        }
+LearnState learn_state_toggle(LearnState state)
+{
+    switch (state) {
+    case LearnState::ACTIVE:
+        return LearnState::INACTIVE;
+    case LearnState::INACTIVE:
+        return LearnState::ACTIVE;
+        // 2 and 3 appears sometimes
+    case LearnState::UNKNOWN:
+    default:
+        return LearnState::UNKNOWN;
     }
+}
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/ratgdo_state.h
+++ b/components/ratgdo/ratgdo_state.h
@@ -16,126 +16,124 @@
 #include "macros.h"
 #include <cstdint>
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    ENUM(DoorState, uint8_t,
-        (UNKNOWN, 0),
-        (OPEN, 1),
-        (CLOSED, 2),
-        (STOPPED, 3),
-        (OPENING, 4),
-        (CLOSING, 5))
+ENUM(DoorState, uint8_t,
+    (UNKNOWN, 0),
+    (OPEN, 1),
+    (CLOSED, 2),
+    (STOPPED, 3),
+    (OPENING, 4),
+    (CLOSING, 5))
 
-    ENUM(DoorActionDelayed, uint8_t,
-        (NO, 0),
-        (YES, 1))
+ENUM(DoorActionDelayed, uint8_t,
+    (NO, 0),
+    (YES, 1))
 
-    /// Enum for all states a the light can be in.
-    ENUM(LightState, uint8_t,
-        (OFF, 0),
-        (ON, 1),
-        (UNKNOWN, 2))
-    LightState light_state_toggle(LightState state);
+/// Enum for all states a the light can be in.
+ENUM(LightState, uint8_t,
+    (OFF, 0),
+    (ON, 1),
+    (UNKNOWN, 2))
+LightState light_state_toggle(LightState state);
 
-    /// Enum for all states a the lock can be in.
-    ENUM(LockState, uint8_t,
-        (UNLOCKED, 0),
-        (LOCKED, 1),
-        (UNKNOWN, 2))
-    LockState lock_state_toggle(LockState state);
+/// Enum for all states a the lock can be in.
+ENUM(LockState, uint8_t,
+    (UNLOCKED, 0),
+    (LOCKED, 1),
+    (UNKNOWN, 2))
+LockState lock_state_toggle(LockState state);
 
-    /// MotionState for all states a the motion can be in.
-    ENUM(MotionState, uint8_t,
-        (CLEAR, 0),
-        (DETECTED, 1),
-        (UNKNOWN, 2))
+/// MotionState for all states a the motion can be in.
+ENUM(MotionState, uint8_t,
+    (CLEAR, 0),
+    (DETECTED, 1),
+    (UNKNOWN, 2))
 
-    /// Enum for all states a the obstruction can be in.
-    ENUM(ObstructionState, uint8_t,
-        (OBSTRUCTED, 0),
-        (CLEAR, 1),
-        (UNKNOWN, 2))
+/// Enum for all states a the obstruction can be in.
+ENUM(ObstructionState, uint8_t,
+    (OBSTRUCTED, 0),
+    (CLEAR, 1),
+    (UNKNOWN, 2))
 
-    /// Enum for all states a the motor can be in.
-    ENUM(MotorState, uint8_t,
-        (OFF, 0),
-        (ON, 1),
-        (UNKNOWN, 2))
+/// Enum for all states a the motor can be in.
+ENUM(MotorState, uint8_t,
+    (OFF, 0),
+    (ON, 1),
+    (UNKNOWN, 2))
 
-    /// Enum for all states the button can be in.
-    ENUM(ButtonState, uint8_t,
-        (PRESSED, 0),
-        (RELEASED, 1),
-        (UNKNOWN, 2))
+/// Enum for all states the button can be in.
+ENUM(ButtonState, uint8_t,
+    (PRESSED, 0),
+    (RELEASED, 1),
+    (UNKNOWN, 2))
 
-    ENUM_SPARSE(BatteryState, uint8_t,
-        (UNKNOWN, 0),
-        (CHARGING, 0x6),
-        (FULL, 0x8))
+ENUM_SPARSE(BatteryState, uint8_t,
+    (UNKNOWN, 0),
+    (CHARGING, 0x6),
+    (FULL, 0x8))
 
-    /// Enum for learn states.
-    ENUM(LearnState, uint8_t,
-        (INACTIVE, 0),
-        (ACTIVE, 1),
-        (UNKNOWN, 2))
-    LearnState learn_state_toggle(LearnState state);
+/// Enum for learn states.
+ENUM(LearnState, uint8_t,
+    (INACTIVE, 0),
+    (ACTIVE, 1),
+    (UNKNOWN, 2))
+LearnState learn_state_toggle(LearnState state);
 
-    ENUM(PairedDevice, uint8_t,
-        (ALL, 0),
-        (REMOTE, 1),
-        (KEYPAD, 2),
-        (WALL_CONTROL, 3),
-        (ACCESSORY, 4),
-        (UNKNOWN, 0xff))
+ENUM(PairedDevice, uint8_t,
+    (ALL, 0),
+    (REMOTE, 1),
+    (KEYPAD, 2),
+    (WALL_CONTROL, 3),
+    (ACCESSORY, 4),
+    (UNKNOWN, 0xff))
 
-    // actions
-    ENUM(LightAction, uint8_t,
-        (OFF, 0),
-        (ON, 1),
-        (TOGGLE, 2),
-        (UNKNOWN, 3))
+// actions
+ENUM(LightAction, uint8_t,
+    (OFF, 0),
+    (ON, 1),
+    (TOGGLE, 2),
+    (UNKNOWN, 3))
 
-    ENUM(LockAction, uint8_t,
-        (UNLOCK, 0),
-        (LOCK, 1),
-        (TOGGLE, 2),
-        (UNKNOWN, 3))
+ENUM(LockAction, uint8_t,
+    (UNLOCK, 0),
+    (LOCK, 1),
+    (TOGGLE, 2),
+    (UNKNOWN, 3))
 
-    ENUM(DoorAction, uint8_t,
-        (CLOSE, 0),
-        (OPEN, 1),
-        (TOGGLE, 2),
-        (STOP, 3),
-        (UNKNOWN, 4))
+ENUM(DoorAction, uint8_t,
+    (CLOSE, 0),
+    (OPEN, 1),
+    (TOGGLE, 2),
+    (STOP, 3),
+    (UNKNOWN, 4))
 
 #ifdef RATGDO_USE_VEHICLE_SENSORS
-    ENUM(VehicleDetectedState, uint8_t,
-        (NO, 0),
-        (YES, 1))
+ENUM(VehicleDetectedState, uint8_t,
+    (NO, 0),
+    (YES, 1))
 
-    ENUM(VehicleArrivingState, uint8_t,
-        (NO, 0),
-        (YES, 1))
+ENUM(VehicleArrivingState, uint8_t,
+    (NO, 0),
+    (YES, 1))
 
-    ENUM(VehicleLeavingState, uint8_t,
-        (NO, 0),
-        (YES, 1))
+ENUM(VehicleLeavingState, uint8_t,
+    (NO, 0),
+    (YES, 1))
 #endif
 
-    struct Openings {
-        uint16_t count;
-        uint8_t flag;
-    };
+struct Openings {
+    uint16_t count;
+    uint8_t flag;
+};
 
-    struct PairedDeviceCount {
-        PairedDevice kind;
-        uint8_t count;
-    };
+struct PairedDeviceCount {
+    PairedDevice kind;
+    uint8_t count;
+};
 
-    struct TimeToClose {
-        uint16_t seconds;
-    };
+struct TimeToClose {
+    uint16_t seconds;
+};
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/secplus1.cpp
+++ b/components/ratgdo/secplus1.cpp
@@ -9,466 +9,464 @@
 #include "esphome/core/log.h"
 #include "esphome/core/scheduler.h"
 
-namespace esphome {
-namespace ratgdo {
-    namespace secplus1 {
+namespace esphome::ratgdo {
+namespace secplus1 {
 
-        static const char* const TAG = "ratgdo_secplus1";
+    static const char* const TAG = "ratgdo_secplus1";
 
-        void Secplus1::setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin)
-        {
-            this->ratgdo_ = ratgdo;
-            this->scheduler_ = scheduler;
-            this->tx_pin_ = tx_pin;
-            this->rx_pin_ = rx_pin;
+    void Secplus1::setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin)
+    {
+        this->ratgdo_ = ratgdo;
+        this->scheduler_ = scheduler;
+        this->tx_pin_ = tx_pin;
+        this->rx_pin_ = rx_pin;
 
-            this->sw_serial_.begin(1200, SWSERIAL_8E1, rx_pin->get_pin(), tx_pin->get_pin(), true);
+        this->sw_serial_.begin(1200, SWSERIAL_8E1, rx_pin->get_pin(), tx_pin->get_pin(), true);
 
-            this->traits_.set_features(HAS_DOOR_STATUS | HAS_LIGHT_TOGGLE | HAS_LOCK_TOGGLE);
+        this->traits_.set_features(HAS_DOOR_STATUS | HAS_LIGHT_TOGGLE | HAS_LOCK_TOGGLE);
+    }
+
+    void Secplus1::loop()
+    {
+        auto rx_cmd = this->read_command();
+        if (rx_cmd) {
+            this->handle_command(rx_cmd.value());
         }
+        auto tx_cmd = this->pending_tx();
+        if (
+            (millis() - this->last_tx_) > 200 && // don't send twice in a period
+            (millis() - this->last_rx_) > 50 && // time to send it
+            tx_cmd && // have pending command
+            !(this->flags_.is_0x37_panel && tx_cmd.value() == CommandType::TOGGLE_LOCK_PRESS) && this->wall_panel_emulation_state_ != WallPanelEmulationState::RUNNING) {
+            this->do_transmit_if_pending();
+        }
+    }
 
-        void Secplus1::loop()
-        {
-            auto rx_cmd = this->read_command();
-            if (rx_cmd) {
-                this->handle_command(rx_cmd.value());
+    void Secplus1::dump_config()
+    {
+        ESP_LOGCONFIG(TAG, "  Protocol: SEC+ v1");
+    }
+
+    void Secplus1::sync()
+    {
+        this->wall_panel_emulation_state_ = WallPanelEmulationState::WAITING;
+        this->wall_panel_emulation_start_ = millis();
+        this->flags_.wall_panel_starting = false;
+        this->door_state = DoorState::UNKNOWN;
+        this->light_state = LightState::UNKNOWN;
+        this->scheduler_->cancel_timeout(this->ratgdo_, "wall_panel_emulation");
+        this->wall_panel_emulation();
+
+        this->scheduler_->set_timeout(this->ratgdo_, "", 45000, [this] {
+            if (this->door_state == DoorState::UNKNOWN) {
+                ESP_LOGW(TAG, "Triggering sync failed actions.");
+                this->ratgdo_->sync_failed = true;
             }
-            auto tx_cmd = this->pending_tx();
-            if (
-                (millis() - this->last_tx_) > 200 && // don't send twice in a period
-                (millis() - this->last_rx_) > 50 && // time to send it
-                tx_cmd && // have pending command
-                !(this->flags_.is_0x37_panel && tx_cmd.value() == CommandType::TOGGLE_LOCK_PRESS) && this->wall_panel_emulation_state_ != WallPanelEmulationState::RUNNING) {
-                this->do_transmit_if_pending();
-            }
-        }
+        });
+    }
 
-        void Secplus1::dump_config()
-        {
-            ESP_LOGCONFIG(TAG, "  Protocol: SEC+ v1");
-        }
-
-        void Secplus1::sync()
-        {
+    void Secplus1::wall_panel_emulation(size_t index)
+    {
+        if (this->flags_.wall_panel_starting) {
             this->wall_panel_emulation_state_ = WallPanelEmulationState::WAITING;
-            this->wall_panel_emulation_start_ = millis();
-            this->flags_.wall_panel_starting = false;
-            this->door_state = DoorState::UNKNOWN;
-            this->light_state = LightState::UNKNOWN;
-            this->scheduler_->cancel_timeout(this->ratgdo_, "wall_panel_emulation");
-            this->wall_panel_emulation();
+        } else if (this->wall_panel_emulation_state_ == WallPanelEmulationState::WAITING) {
+            ESP_LOGD(TAG, "Looking for security+ 1.0 wall panel...");
 
-            this->scheduler_->set_timeout(this->ratgdo_, "", 45000, [this] {
-                if (this->door_state == DoorState::UNKNOWN) {
-                    ESP_LOGW(TAG, "Triggering sync failed actions.");
-                    this->ratgdo_->sync_failed = true;
+            if (this->door_state != DoorState::UNKNOWN || this->light_state != LightState::UNKNOWN) {
+                ESP_LOG1(TAG, "Wall panel detected");
+                return;
+            }
+            if (millis() - this->wall_panel_emulation_start_ > 35000 && !this->flags_.wall_panel_starting) {
+                ESP_LOGD(TAG, "No wall panel detected. Switching to emulation mode.");
+                this->wall_panel_emulation_state_ = WallPanelEmulationState::RUNNING;
+            }
+            this->scheduler_->set_timeout(this->ratgdo_, "wall_panel_emulation", 2000, [this] {
+                this->wall_panel_emulation();
+            });
+            return;
+        } else if (this->wall_panel_emulation_state_ == WallPanelEmulationState::RUNNING) {
+#ifdef USE_ESP8266
+            // ESP_LOG2(TAG, "[Wall panel emulation] Sending byte: [%02X]", progmem_read_byte(&secplus1_states[index]));
+#else
+            // ESP_LOG2(TAG, "[Wall panel emulation] Sending byte: [%02X]", secplus1_states[index]);
+#endif
+
+            if (index < 15 || !this->do_transmit_if_pending()) {
+#ifdef USE_ESP8266
+                this->transmit_byte(progmem_read_byte(&secplus1_states[index]));
+#else
+                this->transmit_byte(secplus1_states[index]);
+#endif
+                // gdo response simulation for testing
+#ifdef USE_ESP8266
+                // auto resp = progmem_read_byte(&secplus1_states[index]) == 0x39 ? 0x00 :
+                //             progmem_read_byte(&secplus1_states[index]) == 0x3A ? 0x5C :
+                //             progmem_read_byte(&secplus1_states[index]) == 0x38 ? 0x52 : 0xFF;
+#else
+                // auto resp = secplus1_states[index] == 0x39 ? 0x00 :
+                //             secplus1_states[index] == 0x3A ? 0x5C :
+                //             secplus1_states[index] == 0x38 ? 0x52 : 0xFF;
+#endif
+                // if (resp != 0xFF) {
+                //     this->transmit_byte(resp, true);
+                // }
+
+                index += 1;
+                if (index == 18) {
+                    index = 15;
                 }
+            }
+            this->scheduler_->set_timeout(this->ratgdo_, "wall_panel_emulation", 250, [this, index] {
+                this->wall_panel_emulation(index);
             });
         }
+    }
 
-        void Secplus1::wall_panel_emulation(size_t index)
-        {
-            if (this->flags_.wall_panel_starting) {
-                this->wall_panel_emulation_state_ = WallPanelEmulationState::WAITING;
-            } else if (this->wall_panel_emulation_state_ == WallPanelEmulationState::WAITING) {
-                ESP_LOGD(TAG, "Looking for security+ 1.0 wall panel...");
+    void Secplus1::light_action(LightAction action)
+    {
+        ESP_LOG1(TAG, "Light action: %s", LOG_STR_ARG(LightAction_to_string(action)));
+        if (action == LightAction::UNKNOWN) {
+            return;
+        }
+        if (
+            action == LightAction::TOGGLE || (action == LightAction::ON && this->light_state == LightState::OFF) || (action == LightAction::OFF && this->light_state == LightState::ON)) {
+            this->toggle_light();
+        }
+    }
 
-                if (this->door_state != DoorState::UNKNOWN || this->light_state != LightState::UNKNOWN) {
-                    ESP_LOG1(TAG, "Wall panel detected");
-                    return;
-                }
-                if (millis() - this->wall_panel_emulation_start_ > 35000 && !this->flags_.wall_panel_starting) {
-                    ESP_LOGD(TAG, "No wall panel detected. Switching to emulation mode.");
-                    this->wall_panel_emulation_state_ = WallPanelEmulationState::RUNNING;
-                }
-                this->scheduler_->set_timeout(this->ratgdo_, "wall_panel_emulation", 2000, [this] {
-                    this->wall_panel_emulation();
-                });
-                return;
-            } else if (this->wall_panel_emulation_state_ == WallPanelEmulationState::RUNNING) {
-#ifdef USE_ESP8266
-                // ESP_LOG2(TAG, "[Wall panel emulation] Sending byte: [%02X]", progmem_read_byte(&secplus1_states[index]));
-#else
-                // ESP_LOG2(TAG, "[Wall panel emulation] Sending byte: [%02X]", secplus1_states[index]);
-#endif
+    void Secplus1::lock_action(LockAction action)
+    {
+        ESP_LOG1(TAG, "Lock action: %s", LOG_STR_ARG(LockAction_to_string(action)));
+        if (action == LockAction::UNKNOWN) {
+            return;
+        }
+        if (
+            action == LockAction::TOGGLE || (action == LockAction::LOCK && this->lock_state == LockState::UNLOCKED) || (action == LockAction::UNLOCK && this->lock_state == LockState::LOCKED)) {
+            this->toggle_lock();
+        }
+    }
 
-                if (index < 15 || !this->do_transmit_if_pending()) {
-#ifdef USE_ESP8266
-                    this->transmit_byte(progmem_read_byte(&secplus1_states[index]));
-#else
-                    this->transmit_byte(secplus1_states[index]);
-#endif
-                    // gdo response simulation for testing
-#ifdef USE_ESP8266
-                    // auto resp = progmem_read_byte(&secplus1_states[index]) == 0x39 ? 0x00 :
-                    //             progmem_read_byte(&secplus1_states[index]) == 0x3A ? 0x5C :
-                    //             progmem_read_byte(&secplus1_states[index]) == 0x38 ? 0x52 : 0xFF;
-#else
-                    // auto resp = secplus1_states[index] == 0x39 ? 0x00 :
-                    //             secplus1_states[index] == 0x3A ? 0x5C :
-                    //             secplus1_states[index] == 0x38 ? 0x52 : 0xFF;
-#endif
-                    // if (resp != 0xFF) {
-                    //     this->transmit_byte(resp, true);
-                    // }
-
-                    index += 1;
-                    if (index == 18) {
-                        index = 15;
-                    }
-                }
-                this->scheduler_->set_timeout(this->ratgdo_, "wall_panel_emulation", 250, [this, index] {
-                    this->wall_panel_emulation(index);
-                });
-            }
+    void Secplus1::door_action(DoorAction action)
+    {
+        ESP_LOG1(TAG, "Door action: %s, door state: %s", LOG_STR_ARG(DoorAction_to_string(action)), LOG_STR_ARG(DoorState_to_string(this->door_state)));
+        if (action == DoorAction::UNKNOWN) {
+            return;
         }
 
-        void Secplus1::light_action(LightAction action)
-        {
-            ESP_LOG1(TAG, "Light action: %s", LOG_STR_ARG(LightAction_to_string(action)));
-            if (action == LightAction::UNKNOWN) {
-                return;
-            }
-            if (
-                action == LightAction::TOGGLE || (action == LightAction::ON && this->light_state == LightState::OFF) || (action == LightAction::OFF && this->light_state == LightState::ON)) {
-                this->toggle_light();
-            }
-        }
-
-        void Secplus1::lock_action(LockAction action)
-        {
-            ESP_LOG1(TAG, "Lock action: %s", LOG_STR_ARG(LockAction_to_string(action)));
-            if (action == LockAction::UNKNOWN) {
-                return;
-            }
-            if (
-                action == LockAction::TOGGLE || (action == LockAction::LOCK && this->lock_state == LockState::UNLOCKED) || (action == LockAction::UNLOCK && this->lock_state == LockState::LOCKED)) {
-                this->toggle_lock();
-            }
-        }
-
-        void Secplus1::door_action(DoorAction action)
-        {
-            ESP_LOG1(TAG, "Door action: %s, door state: %s", LOG_STR_ARG(DoorAction_to_string(action)), LOG_STR_ARG(DoorState_to_string(this->door_state)));
-            if (action == DoorAction::UNKNOWN) {
-                return;
-            }
-
-            const uint32_t double_toggle_delay = 1000;
-            if (action == DoorAction::TOGGLE) {
+        const uint32_t double_toggle_delay = 1000;
+        if (action == DoorAction::TOGGLE) {
+            this->toggle_door();
+        } else if (action == DoorAction::OPEN) {
+            if (this->door_state == DoorState::CLOSED || this->door_state == DoorState::CLOSING) {
                 this->toggle_door();
-            } else if (action == DoorAction::OPEN) {
-                if (this->door_state == DoorState::CLOSED || this->door_state == DoorState::CLOSING) {
-                    this->toggle_door();
-                } else if (this->door_state == DoorState::STOPPED) {
-                    this->toggle_door(); // this starts closing door
-                    this->on_door_state_([this](DoorState s) {
-                        if (s == DoorState::CLOSING) {
-                            // this changes direction of the door on some openers, on others it stops it
-                            this->toggle_door();
-                            this->on_door_state_([this](DoorState s) {
-                                if (s == DoorState::STOPPED) {
-                                    this->toggle_door();
-                                }
-                            });
-                        }
-                    });
-                }
-            } else if (action == DoorAction::CLOSE) {
-                if (this->door_state == DoorState::OPEN) {
-                    this->toggle_door();
-                } else if (this->door_state == DoorState::OPENING) {
-                    this->toggle_door(); // this switches to stopped
-                    // another toggle needed to close
-                    this->on_door_state_([this](DoorState s) {
-                        if (s == DoorState::STOPPED) {
-                            this->toggle_door();
-                        }
-                    });
-                } else if (this->door_state == DoorState::STOPPED) {
-                    this->toggle_door();
-                }
-            } else if (action == DoorAction::STOP) {
-                if (this->door_state == DoorState::OPENING) {
-                    this->toggle_door();
-                } else if (this->door_state == DoorState::CLOSING) {
-                    this->toggle_door(); // this switches to opening
+            } else if (this->door_state == DoorState::STOPPED) {
+                this->toggle_door(); // this starts closing door
+                this->on_door_state_([this](DoorState s) {
+                    if (s == DoorState::CLOSING) {
+                        // this changes direction of the door on some openers, on others it stops it
+                        this->toggle_door();
+                        this->on_door_state_([this](DoorState s) {
+                            if (s == DoorState::STOPPED) {
+                                this->toggle_door();
+                            }
+                        });
+                    }
+                });
+            }
+        } else if (action == DoorAction::CLOSE) {
+            if (this->door_state == DoorState::OPEN) {
+                this->toggle_door();
+            } else if (this->door_state == DoorState::OPENING) {
+                this->toggle_door(); // this switches to stopped
+                // another toggle needed to close
+                this->on_door_state_([this](DoorState s) {
+                    if (s == DoorState::STOPPED) {
+                        this->toggle_door();
+                    }
+                });
+            } else if (this->door_state == DoorState::STOPPED) {
+                this->toggle_door();
+            }
+        } else if (action == DoorAction::STOP) {
+            if (this->door_state == DoorState::OPENING) {
+                this->toggle_door();
+            } else if (this->door_state == DoorState::CLOSING) {
+                this->toggle_door(); // this switches to opening
 
-                    // another toggle needed to stop
-                    this->on_door_state_([this](DoorState s) {
-                        if (s == DoorState::OPENING) {
-                            this->toggle_door();
-                        }
-                    });
-                }
+                // another toggle needed to stop
+                this->on_door_state_([this](DoorState s) {
+                    if (s == DoorState::OPENING) {
+                        this->toggle_door();
+                    }
+                });
             }
         }
+    }
 
-        void Secplus1::toggle_light()
-        {
-            this->enqueue_transmit(CommandType::TOGGLE_LIGHT_PRESS);
+    void Secplus1::toggle_light()
+    {
+        this->enqueue_transmit(CommandType::TOGGLE_LIGHT_PRESS);
+    }
+
+    void Secplus1::toggle_lock()
+    {
+        this->enqueue_transmit(CommandType::TOGGLE_LOCK_PRESS);
+    }
+
+    void Secplus1::toggle_door()
+    {
+        this->enqueue_transmit(CommandType::TOGGLE_DOOR_PRESS);
+        this->enqueue_transmit(CommandType::QUERY_DOOR_STATUS);
+        if (this->door_state == DoorState::STOPPED || this->door_state == DoorState::OPEN || this->door_state == DoorState::CLOSED) {
+            this->flags_.door_moving = true;
         }
+    }
 
-        void Secplus1::toggle_lock()
-        {
-            this->enqueue_transmit(CommandType::TOGGLE_LOCK_PRESS);
-        }
+    Result Secplus1::call(Args args)
+    {
+        return { };
+    }
 
-        void Secplus1::toggle_door()
-        {
-            this->enqueue_transmit(CommandType::TOGGLE_DOOR_PRESS);
-            this->enqueue_transmit(CommandType::QUERY_DOOR_STATUS);
-            if (this->door_state == DoorState::STOPPED || this->door_state == DoorState::OPEN || this->door_state == DoorState::CLOSED) {
-                this->flags_.door_moving = true;
-            }
-        }
+    optional<RxCommand> Secplus1::read_command()
+    {
+        static bool reading_msg = false;
+        static uint32_t msg_start = 0;
+        static uint16_t byte_count = 0;
+        static RxPacket rx_packet;
 
-        Result Secplus1::call(Args args)
-        {
-            return { };
-        }
+        if (!reading_msg) {
+            while (this->sw_serial_.available()) {
+                uint8_t ser_byte = this->sw_serial_.read();
+                this->last_rx_ = millis();
 
-        optional<RxCommand> Secplus1::read_command()
-        {
-            static bool reading_msg = false;
-            static uint32_t msg_start = 0;
-            static uint16_t byte_count = 0;
-            static RxPacket rx_packet;
-
-            if (!reading_msg) {
-                while (this->sw_serial_.available()) {
-                    uint8_t ser_byte = this->sw_serial_.read();
-                    this->last_rx_ = millis();
-
-                    if (ser_byte < 0x30 || ser_byte > 0x3A) {
-                        ESP_LOG2(TAG, "[%d] Ignoring byte [%02X], baud: %d", millis(), ser_byte, this->sw_serial_.baudRate());
-                        byte_count = 0;
-                        continue;
-                    }
-                    rx_packet[byte_count++] = ser_byte;
-                    ESP_LOG2(TAG, "[%d] Received byte: [%02X]", millis(), ser_byte);
-                    reading_msg = true;
-
-                    if (ser_byte == 0x37 || (ser_byte >= 0x30 && ser_byte <= 0x35)) {
-                        rx_packet[byte_count++] = 0;
-                        reading_msg = false;
-                        byte_count = 0;
-                        ESP_LOG2(TAG, "[%d] Received command: [%02X]", millis(), rx_packet[0]);
-                        return this->decode_packet(rx_packet);
-                    }
-
-                    break;
+                if (ser_byte < 0x30 || ser_byte > 0x3A) {
+                    ESP_LOG2(TAG, "[%d] Ignoring byte [%02X], baud: %d", millis(), ser_byte, this->sw_serial_.baudRate());
+                    byte_count = 0;
+                    continue;
                 }
-            }
-            if (reading_msg) {
-                while (this->sw_serial_.available()) {
-                    uint8_t ser_byte = this->sw_serial_.read();
-                    this->last_rx_ = millis();
-                    rx_packet[byte_count++] = ser_byte;
-                    ESP_LOG2(TAG, "[%d] Received byte: [%02X]", millis(), ser_byte);
+                rx_packet[byte_count++] = ser_byte;
+                ESP_LOG2(TAG, "[%d] Received byte: [%02X]", millis(), ser_byte);
+                reading_msg = true;
 
-                    if (byte_count == RX_LENGTH) {
-                        reading_msg = false;
-                        byte_count = 0;
-                        this->print_rx_packet(rx_packet);
-                        return this->decode_packet(rx_packet);
-                    }
-                }
-
-                if (millis() - this->last_rx_ > 100) {
-                    // if we have a partial packet and it's been over 100ms since last byte was read,
-                    // the rest is not coming (a full packet should be received in ~20ms),
-                    // discard it so we can read the following packet correctly
-                    ESP_LOGW(TAG, "[%d] Discard incomplete packet: [%02X ...]", millis(), rx_packet[0]);
+                if (ser_byte == 0x37 || (ser_byte >= 0x30 && ser_byte <= 0x35)) {
+                    rx_packet[byte_count++] = 0;
                     reading_msg = false;
                     byte_count = 0;
+                    ESP_LOG2(TAG, "[%d] Received command: [%02X]", millis(), rx_packet[0]);
+                    return this->decode_packet(rx_packet);
+                }
+
+                break;
+            }
+        }
+        if (reading_msg) {
+            while (this->sw_serial_.available()) {
+                uint8_t ser_byte = this->sw_serial_.read();
+                this->last_rx_ = millis();
+                rx_packet[byte_count++] = ser_byte;
+                ESP_LOG2(TAG, "[%d] Received byte: [%02X]", millis(), ser_byte);
+
+                if (byte_count == RX_LENGTH) {
+                    reading_msg = false;
+                    byte_count = 0;
+                    this->print_rx_packet(rx_packet);
+                    return this->decode_packet(rx_packet);
                 }
             }
 
+            if (millis() - this->last_rx_ > 100) {
+                // if we have a partial packet and it's been over 100ms since last byte was read,
+                // the rest is not coming (a full packet should be received in ~20ms),
+                // discard it so we can read the following packet correctly
+                ESP_LOGW(TAG, "[%d] Discard incomplete packet: [%02X ...]", millis(), rx_packet[0]);
+                reading_msg = false;
+                byte_count = 0;
+            }
+        }
+
+        return { };
+    }
+
+    void Secplus1::print_rx_packet(const RxPacket& packet) const
+    {
+        ESP_LOG2(TAG, "[%d] Received packet: [%02X %02X]", millis(), packet[0], packet[1]);
+    }
+
+    void Secplus1::print_tx_packet(const TxPacket& packet) const
+    {
+        ESP_LOG2(TAG, "[%d] Sending packet: [%02X %02X]", millis(), packet[0], packet[1]);
+    }
+
+    optional<RxCommand> Secplus1::decode_packet(const RxPacket& packet) const
+    {
+        CommandType cmd_type = to_CommandType(packet[0], CommandType::UNKNOWN);
+        return RxCommand { cmd_type, packet[1] };
+    }
+
+    // unknown meaning of observed command-responses:
+    // 40 00 and 40 80
+    // 53 01
+    // C0 3F
+    // F8 3F
+    // FE 3F
+
+    void Secplus1::handle_command(const RxCommand& cmd)
+    {
+        if (cmd.req == CommandType::TOGGLE_DOOR_RELEASE || cmd.resp == 0x31) {
+            if (this->wall_panel_emulation_state_ == WallPanelEmulationState::WAITING) {
+                ESP_LOGD(TAG, "wall panel is starting");
+                this->flags_.wall_panel_starting = true;
+            }
+        } else if (cmd.req == CommandType::QUERY_DOOR_STATUS) {
+            DoorState door_state;
+            auto val = cmd.resp & 0x7;
+            // 000 0x0 stopped
+            // 001 0x1 opening
+            // 010 0x2 open
+            // 100 0x4 closing
+            // 101 0x5 closed
+            // 110 0x6 stopped
+
+            if (val == 0x2) {
+                door_state = DoorState::OPEN;
+            } else if (val == 0x5) {
+                door_state = DoorState::CLOSED;
+            } else if (val == 0x0 || val == 0x6) {
+                door_state = DoorState::STOPPED;
+            } else if (val == 0x1) {
+                door_state = DoorState::OPENING;
+            } else if (val == 0x4) {
+                door_state = DoorState::CLOSING;
+            } else {
+                door_state = DoorState::UNKNOWN;
+            }
+
+            if (this->maybe_door_state != door_state) {
+                this->on_door_state_.trigger(door_state);
+            }
+
+            if (!this->flags_.is_0x37_panel && door_state != this->maybe_door_state) {
+                this->maybe_door_state = door_state;
+                ESP_LOG1(TAG, "Door maybe %s, waiting for 2nd status message to confirm", LOG_STR_ARG(DoorState_to_string(door_state)));
+            } else {
+                this->maybe_door_state = door_state;
+                this->door_state = door_state;
+                if (this->door_state == DoorState::STOPPED || this->door_state == DoorState::OPEN || this->door_state == DoorState::CLOSED) {
+                    this->flags_.door_moving = false;
+                }
+                this->ratgdo_->received(door_state);
+            }
+        } else if (cmd.req == CommandType::QUERY_DOOR_STATUS_0x37) {
+            this->flags_.is_0x37_panel = true;
+            auto cmd = this->pending_tx();
+            if (cmd && cmd.value() == CommandType::TOGGLE_LOCK_PRESS) {
+                this->do_transmit_if_pending();
+            } else {
+                // inject door status request
+                if (flags_.door_moving || (millis() - this->last_status_query_ > 10000)) {
+                    this->transmit_byte(static_cast<uint8_t>(CommandType::QUERY_DOOR_STATUS));
+                    this->last_status_query_ = millis();
+                }
+            }
+        } else if (cmd.req == CommandType::QUERY_OTHER_STATUS) {
+            LightState light_state = to_LightState((cmd.resp >> 2) & 1, LightState::UNKNOWN);
+
+            if (!this->flags_.is_0x37_panel && light_state != this->maybe_light_state) {
+                this->maybe_light_state = light_state;
+            } else {
+                this->light_state = light_state;
+                this->ratgdo_->received(light_state);
+            }
+
+            LockState lock_state = to_LockState((~cmd.resp >> 3) & 1, LockState::UNKNOWN);
+            if (!this->flags_.is_0x37_panel && lock_state != this->maybe_lock_state) {
+                this->maybe_lock_state = lock_state;
+            } else {
+                this->lock_state = lock_state;
+                this->ratgdo_->received(lock_state);
+            }
+        } else if (cmd.req == CommandType::OBSTRUCTION) {
+            ObstructionState obstruction_state = cmd.resp == 0 ? ObstructionState::CLEAR : ObstructionState::OBSTRUCTED;
+            this->ratgdo_->received(obstruction_state);
+        } else if (cmd.req == CommandType::TOGGLE_LIGHT_PRESS) {
+            // motion was detected, or the light toggle button was pressed
+            // either way it's ok to trigger motion detection
+            if (this->light_state == LightState::OFF) {
+                this->ratgdo_->received(MotionState::DETECTED);
+            }
+        } else if (cmd.req == CommandType::TOGGLE_DOOR_PRESS) {
+            this->ratgdo_->received(ButtonState::PRESSED);
+        } else if (cmd.req == CommandType::TOGGLE_DOOR_RELEASE) {
+            this->ratgdo_->received(ButtonState::RELEASED);
+        }
+    }
+
+    bool Secplus1::do_transmit_if_pending()
+    {
+        auto cmd = this->pop_pending_tx();
+        if (cmd) {
+            this->enqueue_command_pair(cmd.value());
+            this->transmit_byte(static_cast<uint32_t>(cmd.value()));
+        }
+        return cmd.has_value();
+    }
+
+    void Secplus1::enqueue_command_pair(CommandType cmd)
+    {
+        auto now = millis();
+        if (cmd == CommandType::TOGGLE_DOOR_PRESS) {
+            this->enqueue_transmit(CommandType::TOGGLE_DOOR_RELEASE, now + 500);
+        } else if (cmd == CommandType::TOGGLE_LIGHT_PRESS) {
+            this->enqueue_transmit(CommandType::TOGGLE_LIGHT_RELEASE, now + 500);
+        } else if (cmd == CommandType::TOGGLE_LOCK_PRESS) {
+            this->enqueue_transmit(CommandType::TOGGLE_LOCK_RELEASE, now + 3500);
+        };
+    }
+
+    void Secplus1::enqueue_transmit(CommandType cmd, uint32_t time)
+    {
+        if (time == 0) {
+            time = millis();
+        }
+        this->pending_tx_.push(TxCommand { cmd, time });
+    }
+
+    optional<CommandType> Secplus1::pending_tx()
+    {
+        if (this->pending_tx_.empty()) {
             return { };
         }
-
-        void Secplus1::print_rx_packet(const RxPacket& packet) const
-        {
-            ESP_LOG2(TAG, "[%d] Received packet: [%02X %02X]", millis(), packet[0], packet[1]);
+        auto cmd = this->pending_tx_.top();
+        if (cmd.time > millis()) {
+            return { };
         }
+        return cmd.request;
+    }
 
-        void Secplus1::print_tx_packet(const TxPacket& packet) const
-        {
-            ESP_LOG2(TAG, "[%d] Sending packet: [%02X %02X]", millis(), packet[0], packet[1]);
+    optional<CommandType> Secplus1::pop_pending_tx()
+    {
+        auto cmd = this->pending_tx();
+        if (cmd) {
+            this->pending_tx_.pop();
         }
+        return cmd;
+    }
 
-        optional<RxCommand> Secplus1::decode_packet(const RxPacket& packet) const
-        {
-            CommandType cmd_type = to_CommandType(packet[0], CommandType::UNKNOWN);
-            return RxCommand { cmd_type, packet[1] };
+    void Secplus1::transmit_byte(uint32_t value)
+    {
+        bool enable_rx = (value == 0x38) || (value == 0x39) || (value == 0x3A);
+        if (!enable_rx) {
+            this->sw_serial_.enableIntTx(false);
         }
-
-        // unknown meaning of observed command-responses:
-        // 40 00 and 40 80
-        // 53 01
-        // C0 3F
-        // F8 3F
-        // FE 3F
-
-        void Secplus1::handle_command(const RxCommand& cmd)
-        {
-            if (cmd.req == CommandType::TOGGLE_DOOR_RELEASE || cmd.resp == 0x31) {
-                if (this->wall_panel_emulation_state_ == WallPanelEmulationState::WAITING) {
-                    ESP_LOGD(TAG, "wall panel is starting");
-                    this->flags_.wall_panel_starting = true;
-                }
-            } else if (cmd.req == CommandType::QUERY_DOOR_STATUS) {
-                DoorState door_state;
-                auto val = cmd.resp & 0x7;
-                // 000 0x0 stopped
-                // 001 0x1 opening
-                // 010 0x2 open
-                // 100 0x4 closing
-                // 101 0x5 closed
-                // 110 0x6 stopped
-
-                if (val == 0x2) {
-                    door_state = DoorState::OPEN;
-                } else if (val == 0x5) {
-                    door_state = DoorState::CLOSED;
-                } else if (val == 0x0 || val == 0x6) {
-                    door_state = DoorState::STOPPED;
-                } else if (val == 0x1) {
-                    door_state = DoorState::OPENING;
-                } else if (val == 0x4) {
-                    door_state = DoorState::CLOSING;
-                } else {
-                    door_state = DoorState::UNKNOWN;
-                }
-
-                if (this->maybe_door_state != door_state) {
-                    this->on_door_state_.trigger(door_state);
-                }
-
-                if (!this->flags_.is_0x37_panel && door_state != this->maybe_door_state) {
-                    this->maybe_door_state = door_state;
-                    ESP_LOG1(TAG, "Door maybe %s, waiting for 2nd status message to confirm", LOG_STR_ARG(DoorState_to_string(door_state)));
-                } else {
-                    this->maybe_door_state = door_state;
-                    this->door_state = door_state;
-                    if (this->door_state == DoorState::STOPPED || this->door_state == DoorState::OPEN || this->door_state == DoorState::CLOSED) {
-                        this->flags_.door_moving = false;
-                    }
-                    this->ratgdo_->received(door_state);
-                }
-            } else if (cmd.req == CommandType::QUERY_DOOR_STATUS_0x37) {
-                this->flags_.is_0x37_panel = true;
-                auto cmd = this->pending_tx();
-                if (cmd && cmd.value() == CommandType::TOGGLE_LOCK_PRESS) {
-                    this->do_transmit_if_pending();
-                } else {
-                    // inject door status request
-                    if (flags_.door_moving || (millis() - this->last_status_query_ > 10000)) {
-                        this->transmit_byte(static_cast<uint8_t>(CommandType::QUERY_DOOR_STATUS));
-                        this->last_status_query_ = millis();
-                    }
-                }
-            } else if (cmd.req == CommandType::QUERY_OTHER_STATUS) {
-                LightState light_state = to_LightState((cmd.resp >> 2) & 1, LightState::UNKNOWN);
-
-                if (!this->flags_.is_0x37_panel && light_state != this->maybe_light_state) {
-                    this->maybe_light_state = light_state;
-                } else {
-                    this->light_state = light_state;
-                    this->ratgdo_->received(light_state);
-                }
-
-                LockState lock_state = to_LockState((~cmd.resp >> 3) & 1, LockState::UNKNOWN);
-                if (!this->flags_.is_0x37_panel && lock_state != this->maybe_lock_state) {
-                    this->maybe_lock_state = lock_state;
-                } else {
-                    this->lock_state = lock_state;
-                    this->ratgdo_->received(lock_state);
-                }
-            } else if (cmd.req == CommandType::OBSTRUCTION) {
-                ObstructionState obstruction_state = cmd.resp == 0 ? ObstructionState::CLEAR : ObstructionState::OBSTRUCTED;
-                this->ratgdo_->received(obstruction_state);
-            } else if (cmd.req == CommandType::TOGGLE_LIGHT_PRESS) {
-                // motion was detected, or the light toggle button was pressed
-                // either way it's ok to trigger motion detection
-                if (this->light_state == LightState::OFF) {
-                    this->ratgdo_->received(MotionState::DETECTED);
-                }
-            } else if (cmd.req == CommandType::TOGGLE_DOOR_PRESS) {
-                this->ratgdo_->received(ButtonState::PRESSED);
-            } else if (cmd.req == CommandType::TOGGLE_DOOR_RELEASE) {
-                this->ratgdo_->received(ButtonState::RELEASED);
-            }
+        this->sw_serial_.write(value);
+        this->last_tx_ = millis();
+        if (!enable_rx) {
+            this->sw_serial_.enableIntTx(true);
         }
+        ESP_LOGD(TAG, "[%d] Sent byte: [%02X]", millis(), value);
+    }
 
-        bool Secplus1::do_transmit_if_pending()
-        {
-            auto cmd = this->pop_pending_tx();
-            if (cmd) {
-                this->enqueue_command_pair(cmd.value());
-                this->transmit_byte(static_cast<uint32_t>(cmd.value()));
-            }
-            return cmd.has_value();
-        }
-
-        void Secplus1::enqueue_command_pair(CommandType cmd)
-        {
-            auto now = millis();
-            if (cmd == CommandType::TOGGLE_DOOR_PRESS) {
-                this->enqueue_transmit(CommandType::TOGGLE_DOOR_RELEASE, now + 500);
-            } else if (cmd == CommandType::TOGGLE_LIGHT_PRESS) {
-                this->enqueue_transmit(CommandType::TOGGLE_LIGHT_RELEASE, now + 500);
-            } else if (cmd == CommandType::TOGGLE_LOCK_PRESS) {
-                this->enqueue_transmit(CommandType::TOGGLE_LOCK_RELEASE, now + 3500);
-            };
-        }
-
-        void Secplus1::enqueue_transmit(CommandType cmd, uint32_t time)
-        {
-            if (time == 0) {
-                time = millis();
-            }
-            this->pending_tx_.push(TxCommand { cmd, time });
-        }
-
-        optional<CommandType> Secplus1::pending_tx()
-        {
-            if (this->pending_tx_.empty()) {
-                return { };
-            }
-            auto cmd = this->pending_tx_.top();
-            if (cmd.time > millis()) {
-                return { };
-            }
-            return cmd.request;
-        }
-
-        optional<CommandType> Secplus1::pop_pending_tx()
-        {
-            auto cmd = this->pending_tx();
-            if (cmd) {
-                this->pending_tx_.pop();
-            }
-            return cmd;
-        }
-
-        void Secplus1::transmit_byte(uint32_t value)
-        {
-            bool enable_rx = (value == 0x38) || (value == 0x39) || (value == 0x3A);
-            if (!enable_rx) {
-                this->sw_serial_.enableIntTx(false);
-            }
-            this->sw_serial_.write(value);
-            this->last_tx_ = millis();
-            if (!enable_rx) {
-                this->sw_serial_.enableIntTx(true);
-            }
-            ESP_LOGD(TAG, "[%d] Sent byte: [%02X]", millis(), value);
-        }
-
-    } // namespace secplus1
-} // namespace ratgdo
-} // namespace esphome
+} // namespace secplus1
+} // namespace esphome::ratgdo
 
 #endif // PROTOCOL_SECPLUSV1

--- a/components/ratgdo/secplus1.h
+++ b/components/ratgdo/secplus1.h
@@ -17,151 +17,152 @@ namespace esphome {
 class Scheduler;
 class InternalGPIOPin;
 
-namespace ratgdo {
-    namespace secplus1 {
-
-        using namespace esphome::ratgdo::protocol;
-
-        static const uint8_t RX_LENGTH = 2;
-        typedef uint8_t RxPacket[RX_LENGTH];
-
-        static const uint8_t TX_LENGTH = 2;
-        typedef uint8_t TxPacket[TX_LENGTH];
-
-        static const TxPacket toggle_door = { 0x30, 0x31 };
-        static const TxPacket toggle_light = { 0x32, 0x33 };
-        static const TxPacket toggle_lock = { 0x34, 0x35 };
-
-        static const uint8_t secplus1_states[] PROGMEM = { 0x35, 0x35, 0x35, 0x35, 0x33, 0x33, 0x53, 0x53, 0x38, 0x3A, 0x3A, 0x3A, 0x39, 0x38, 0x3A, 0x38, 0x3A, 0x39, 0x3A };
-
-        ENUM_SPARSE(CommandType, uint8_t,
-            (TOGGLE_DOOR_PRESS, 0x30),
-            (TOGGLE_DOOR_RELEASE, 0x31),
-            (TOGGLE_LIGHT_PRESS, 0x32),
-            (TOGGLE_LIGHT_RELEASE, 0x33),
-            (TOGGLE_LOCK_PRESS, 0x34),
-            (TOGGLE_LOCK_RELEASE, 0x35),
-            (QUERY_DOOR_STATUS_0x37, 0x37),
-            (QUERY_DOOR_STATUS, 0x38),
-            (OBSTRUCTION, 0x39),
-            (QUERY_OTHER_STATUS, 0x3A),
-            (UNKNOWN, 0xFF), )
-
-        struct RxCommand {
-            CommandType req;
-            uint8_t resp;
-
-            RxCommand()
-                : req(CommandType::UNKNOWN)
-                , resp(0)
-            {
-            }
-            RxCommand(CommandType req_)
-                : req(req_)
-                , resp(0)
-            {
-            }
-            RxCommand(CommandType req_, uint8_t resp_ = 0)
-                : req(req_)
-                , resp(resp_)
-            {
-            }
-        };
-
-        struct TxCommand {
-            CommandType request;
-            uint32_t time;
-        };
-
-        struct FirstToSend {
-            bool operator()(const TxCommand l, const TxCommand r) const { return l.time > r.time; }
-        };
-
-        enum class WallPanelEmulationState {
-            WAITING,
-            RUNNING,
-        };
-
-        class Secplus1 : public Protocol {
-        public:
-            void setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin);
-            void loop();
-            void dump_config();
-
-            void sync();
-
-            void light_action(LightAction action);
-            void lock_action(LockAction action);
-            void door_action(DoorAction action);
-
-            Result call(Args args);
-
-            const Traits& traits() const { return this->traits_; }
-
-            // methods not used by secplus1
-            void set_open_limit(bool state) { }
-            void set_close_limit(bool state) { }
-            void set_discrete_open_pin(InternalGPIOPin* pin) { }
-            void set_discrete_close_pin(InternalGPIOPin* pin) { }
-
-        protected:
-            void wall_panel_emulation(size_t index = 0);
-
-            optional<RxCommand> read_command();
-            void handle_command(const RxCommand& cmd);
-
-            void print_rx_packet(const RxPacket& packet) const;
-            void print_tx_packet(const TxPacket& packet) const;
-            optional<RxCommand> decode_packet(const RxPacket& packet) const;
-
-            void enqueue_transmit(CommandType cmd, uint32_t time = 0);
-            optional<CommandType> pending_tx();
-            optional<CommandType> pop_pending_tx();
-            bool do_transmit_if_pending();
-            void enqueue_command_pair(CommandType cmd);
-            void transmit_byte(uint32_t value);
-
-            void toggle_light();
-            void toggle_lock();
-            void toggle_door();
-            void query_status();
-
-            // Pointers first (4-byte aligned)
-            InternalGPIOPin* tx_pin_;
-            InternalGPIOPin* rx_pin_;
-            RATGDOComponent* ratgdo_;
-            Scheduler* scheduler_;
-
-            // 4-byte members
-            uint32_t wall_panel_emulation_start_ { 0 };
-            uint32_t last_rx_ { 0 };
-            uint32_t last_tx_ { 0 };
-            uint32_t last_status_query_ { 0 };
-
-            // Larger structures
-            std::priority_queue<TxCommand, std::vector<TxCommand>, FirstToSend> pending_tx_;
-            SoftwareSerial sw_serial_;
-            OnceCallbacks<void(DoorState)> on_door_state_;
-            Traits traits_;
-
-            // Group all 1-byte members at the end to minimize padding
-            LightState light_state { LightState::UNKNOWN };
-            LockState lock_state { LockState::UNKNOWN };
-            DoorState door_state { DoorState::UNKNOWN };
-            LightState maybe_light_state { LightState::UNKNOWN };
-            LockState maybe_lock_state { LockState::UNKNOWN };
-            DoorState maybe_door_state { DoorState::UNKNOWN };
-            WallPanelEmulationState wall_panel_emulation_state_ { WallPanelEmulationState::WAITING };
-            struct {
-                uint8_t door_moving : 1;
-                uint8_t wall_panel_starting : 1;
-                uint8_t is_0x37_panel : 1;
-                uint8_t reserved : 5; // Reserved for future use
-            } flags_ { 0 };
-        };
-
-    } // namespace secplus1
-} // namespace ratgdo
 } // namespace esphome
+
+namespace esphome::ratgdo {
+namespace secplus1 {
+
+    using namespace esphome::ratgdo::protocol;
+
+    static const uint8_t RX_LENGTH = 2;
+    typedef uint8_t RxPacket[RX_LENGTH];
+
+    static const uint8_t TX_LENGTH = 2;
+    typedef uint8_t TxPacket[TX_LENGTH];
+
+    static const TxPacket toggle_door = { 0x30, 0x31 };
+    static const TxPacket toggle_light = { 0x32, 0x33 };
+    static const TxPacket toggle_lock = { 0x34, 0x35 };
+
+    static const uint8_t secplus1_states[] PROGMEM = { 0x35, 0x35, 0x35, 0x35, 0x33, 0x33, 0x53, 0x53, 0x38, 0x3A, 0x3A, 0x3A, 0x39, 0x38, 0x3A, 0x38, 0x3A, 0x39, 0x3A };
+
+    ENUM_SPARSE(CommandType, uint8_t,
+        (TOGGLE_DOOR_PRESS, 0x30),
+        (TOGGLE_DOOR_RELEASE, 0x31),
+        (TOGGLE_LIGHT_PRESS, 0x32),
+        (TOGGLE_LIGHT_RELEASE, 0x33),
+        (TOGGLE_LOCK_PRESS, 0x34),
+        (TOGGLE_LOCK_RELEASE, 0x35),
+        (QUERY_DOOR_STATUS_0x37, 0x37),
+        (QUERY_DOOR_STATUS, 0x38),
+        (OBSTRUCTION, 0x39),
+        (QUERY_OTHER_STATUS, 0x3A),
+        (UNKNOWN, 0xFF), )
+
+    struct RxCommand {
+        CommandType req;
+        uint8_t resp;
+
+        RxCommand()
+            : req(CommandType::UNKNOWN)
+            , resp(0)
+        {
+        }
+        RxCommand(CommandType req_)
+            : req(req_)
+            , resp(0)
+        {
+        }
+        RxCommand(CommandType req_, uint8_t resp_ = 0)
+            : req(req_)
+            , resp(resp_)
+        {
+        }
+    };
+
+    struct TxCommand {
+        CommandType request;
+        uint32_t time;
+    };
+
+    struct FirstToSend {
+        bool operator()(const TxCommand l, const TxCommand r) const { return l.time > r.time; }
+    };
+
+    enum class WallPanelEmulationState {
+        WAITING,
+        RUNNING,
+    };
+
+    class Secplus1 : public Protocol {
+    public:
+        void setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin);
+        void loop();
+        void dump_config();
+
+        void sync();
+
+        void light_action(LightAction action);
+        void lock_action(LockAction action);
+        void door_action(DoorAction action);
+
+        Result call(Args args);
+
+        const Traits& traits() const { return this->traits_; }
+
+        // methods not used by secplus1
+        void set_open_limit(bool state) { }
+        void set_close_limit(bool state) { }
+        void set_discrete_open_pin(InternalGPIOPin* pin) { }
+        void set_discrete_close_pin(InternalGPIOPin* pin) { }
+
+    protected:
+        void wall_panel_emulation(size_t index = 0);
+
+        optional<RxCommand> read_command();
+        void handle_command(const RxCommand& cmd);
+
+        void print_rx_packet(const RxPacket& packet) const;
+        void print_tx_packet(const TxPacket& packet) const;
+        optional<RxCommand> decode_packet(const RxPacket& packet) const;
+
+        void enqueue_transmit(CommandType cmd, uint32_t time = 0);
+        optional<CommandType> pending_tx();
+        optional<CommandType> pop_pending_tx();
+        bool do_transmit_if_pending();
+        void enqueue_command_pair(CommandType cmd);
+        void transmit_byte(uint32_t value);
+
+        void toggle_light();
+        void toggle_lock();
+        void toggle_door();
+        void query_status();
+
+        // Pointers first (4-byte aligned)
+        InternalGPIOPin* tx_pin_;
+        InternalGPIOPin* rx_pin_;
+        RATGDOComponent* ratgdo_;
+        Scheduler* scheduler_;
+
+        // 4-byte members
+        uint32_t wall_panel_emulation_start_ { 0 };
+        uint32_t last_rx_ { 0 };
+        uint32_t last_tx_ { 0 };
+        uint32_t last_status_query_ { 0 };
+
+        // Larger structures
+        std::priority_queue<TxCommand, std::vector<TxCommand>, FirstToSend> pending_tx_;
+        SoftwareSerial sw_serial_;
+        OnceCallbacks<void(DoorState)> on_door_state_;
+        Traits traits_;
+
+        // Group all 1-byte members at the end to minimize padding
+        LightState light_state { LightState::UNKNOWN };
+        LockState lock_state { LockState::UNKNOWN };
+        DoorState door_state { DoorState::UNKNOWN };
+        LightState maybe_light_state { LightState::UNKNOWN };
+        LockState maybe_lock_state { LockState::UNKNOWN };
+        DoorState maybe_door_state { DoorState::UNKNOWN };
+        WallPanelEmulationState wall_panel_emulation_state_ { WallPanelEmulationState::WAITING };
+        struct {
+            uint8_t door_moving : 1;
+            uint8_t wall_panel_starting : 1;
+            uint8_t is_0x37_panel : 1;
+            uint8_t reserved : 5; // Reserved for future use
+        } flags_ { 0 };
+    };
+
+} // namespace secplus1
+} // namespace esphome::ratgdo
 
 #endif // PROTOCOL_SECPLUSV1

--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -12,505 +12,503 @@ extern "C" {
 #include "secplus.h"
 }
 
-namespace esphome {
-namespace ratgdo {
-    namespace secplus2 {
+namespace esphome::ratgdo {
+namespace secplus2 {
 
-        // MAX_CODES_WITHOUT_FLASH_WRITE is a bit of a guess
-        // since we write the flash at most every every 1min
-        //
-        // We want the rolling counter to be high enough that the
-        // GDO will accept the command after an unexpected reboot
-        // that did not save the counter to flash in time which
-        // results in the rolling counter being behind what the GDO
-        // expects.
-        static const uint8_t MAX_CODES_WITHOUT_FLASH_WRITE = 60;
+    // MAX_CODES_WITHOUT_FLASH_WRITE is a bit of a guess
+    // since we write the flash at most every every 1min
+    //
+    // We want the rolling counter to be high enough that the
+    // GDO will accept the command after an unexpected reboot
+    // that did not save the counter to flash in time which
+    // results in the rolling counter being behind what the GDO
+    // expects.
+    static const uint8_t MAX_CODES_WITHOUT_FLASH_WRITE = 60;
 
-        static const char* const TAG = "ratgdo_secplus2";
+    static const char* const TAG = "ratgdo_secplus2";
 
-        void Secplus2::setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin)
-        {
-            this->ratgdo_ = ratgdo;
-            this->scheduler_ = scheduler;
-            this->tx_pin_ = tx_pin;
-            this->rx_pin_ = rx_pin;
+    void Secplus2::setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin)
+    {
+        this->ratgdo_ = ratgdo;
+        this->scheduler_ = scheduler;
+        this->tx_pin_ = tx_pin;
+        this->rx_pin_ = rx_pin;
 
-            this->sw_serial_.begin(9600, SWSERIAL_8N1, rx_pin->get_pin(), tx_pin->get_pin(), true);
-            this->sw_serial_.enableIntTx(false);
-            this->sw_serial_.enableAutoBaud(true);
+        this->sw_serial_.begin(9600, SWSERIAL_8N1, rx_pin->get_pin(), tx_pin->get_pin(), true);
+        this->sw_serial_.enableIntTx(false);
+        this->sw_serial_.enableAutoBaud(true);
 
-            this->traits_.set_features(Traits::all());
-        }
+        this->traits_.set_features(Traits::all());
+    }
 
-        void Secplus2::loop()
-        {
-            if (this->flags_.transmit_pending) {
-                if (!this->transmit_packet()) {
-                    return;
-                }
-            }
-
-            auto cmd = this->read_command();
-            if (cmd) {
-                this->handle_command(*cmd);
-            }
-        }
-
-        void Secplus2::dump_config()
-        {
-            ESP_LOGCONFIG(TAG, "  Rolling Code Counter: %d", *this->rolling_code_counter_);
-            ESP_LOGCONFIG(TAG, "  Client ID: %d", this->client_id_);
-            ESP_LOGCONFIG(TAG, "  Protocol: SEC+ v2");
-        }
-
-        void Secplus2::sync_helper(uint32_t start, uint32_t delay, uint8_t tries)
-        {
-            bool synced = true;
-            if (*this->ratgdo_->door_state == DoorState::UNKNOWN) {
-                this->query_status();
-                synced = false;
-            }
-            if (*this->ratgdo_->openings == 0) {
-                this->query_openings();
-                synced = false;
-            }
-            if (*this->ratgdo_->paired_total == PAIRED_DEVICES_UNKNOWN) {
-                this->query_paired_devices(PairedDevice::ALL);
-                synced = false;
-            }
-            if (*this->ratgdo_->paired_remotes == PAIRED_DEVICES_UNKNOWN) {
-                this->query_paired_devices(PairedDevice::REMOTE);
-                synced = false;
-            }
-            if (*this->ratgdo_->paired_keypads == PAIRED_DEVICES_UNKNOWN) {
-                this->query_paired_devices(PairedDevice::KEYPAD);
-                synced = false;
-            }
-            if (*this->ratgdo_->paired_wall_controls == PAIRED_DEVICES_UNKNOWN) {
-                this->query_paired_devices(PairedDevice::WALL_CONTROL);
-                synced = false;
-            }
-            if (*this->ratgdo_->paired_accessories == PAIRED_DEVICES_UNKNOWN) {
-                this->query_paired_devices(PairedDevice::ACCESSORY);
-                synced = false;
-            }
-
-            if (synced) {
+    void Secplus2::loop()
+    {
+        if (this->flags_.transmit_pending) {
+            if (!this->transmit_packet()) {
                 return;
             }
+        }
 
-            if (tries == 2 && *this->ratgdo_->door_state == DoorState::UNKNOWN) { // made a few attempts and no progress (door state is the first sync request)
-                // increment rolling code counter by some amount in case we crashed without writing to flash the latest value
-                this->increment_rolling_code_counter(MAX_CODES_WITHOUT_FLASH_WRITE);
+        auto cmd = this->read_command();
+        if (cmd) {
+            this->handle_command(*cmd);
+        }
+    }
+
+    void Secplus2::dump_config()
+    {
+        ESP_LOGCONFIG(TAG, "  Rolling Code Counter: %d", *this->rolling_code_counter_);
+        ESP_LOGCONFIG(TAG, "  Client ID: %d", this->client_id_);
+        ESP_LOGCONFIG(TAG, "  Protocol: SEC+ v2");
+    }
+
+    void Secplus2::sync_helper(uint32_t start, uint32_t delay, uint8_t tries)
+    {
+        bool synced = true;
+        if (*this->ratgdo_->door_state == DoorState::UNKNOWN) {
+            this->query_status();
+            synced = false;
+        }
+        if (*this->ratgdo_->openings == 0) {
+            this->query_openings();
+            synced = false;
+        }
+        if (*this->ratgdo_->paired_total == PAIRED_DEVICES_UNKNOWN) {
+            this->query_paired_devices(PairedDevice::ALL);
+            synced = false;
+        }
+        if (*this->ratgdo_->paired_remotes == PAIRED_DEVICES_UNKNOWN) {
+            this->query_paired_devices(PairedDevice::REMOTE);
+            synced = false;
+        }
+        if (*this->ratgdo_->paired_keypads == PAIRED_DEVICES_UNKNOWN) {
+            this->query_paired_devices(PairedDevice::KEYPAD);
+            synced = false;
+        }
+        if (*this->ratgdo_->paired_wall_controls == PAIRED_DEVICES_UNKNOWN) {
+            this->query_paired_devices(PairedDevice::WALL_CONTROL);
+            synced = false;
+        }
+        if (*this->ratgdo_->paired_accessories == PAIRED_DEVICES_UNKNOWN) {
+            this->query_paired_devices(PairedDevice::ACCESSORY);
+            synced = false;
+        }
+
+        if (synced) {
+            return;
+        }
+
+        if (tries == 2 && *this->ratgdo_->door_state == DoorState::UNKNOWN) { // made a few attempts and no progress (door state is the first sync request)
+            // increment rolling code counter by some amount in case we crashed without writing to flash the latest value
+            this->increment_rolling_code_counter(MAX_CODES_WITHOUT_FLASH_WRITE);
+        }
+
+        // not sync-ed after 30s, notify failure
+        if (millis() - start > 30000) {
+            ESP_LOGW(TAG, "Triggering sync failed actions.");
+            this->ratgdo_->sync_failed = true;
+        } else {
+            if (tries % 3 == 0) {
+                delay *= 1.5;
             }
-
-            // not sync-ed after 30s, notify failure
-            if (millis() - start > 30000) {
-                ESP_LOGW(TAG, "Triggering sync failed actions.");
-                this->ratgdo_->sync_failed = true;
-            } else {
-                if (tries % 3 == 0) {
-                    delay *= 1.5;
-                }
-                this->scheduler_->set_timeout(this->ratgdo_, "sync", delay, [this, start, delay, tries]() {
-                    this->sync_helper(start, delay, tries + 1);
-                });
-            };
-        }
-
-        void Secplus2::sync()
-        {
-            this->scheduler_->cancel_timeout(this->ratgdo_, "sync");
-            this->sync_helper(millis(), 500, 0);
-        }
-
-        void Secplus2::light_action(LightAction action)
-        {
-            if (action == LightAction::UNKNOWN) {
-                return;
-            }
-            this->send_command(Command(CommandType::LIGHT, static_cast<uint8_t>(action)));
-        }
-
-        void Secplus2::lock_action(LockAction action)
-        {
-            if (action == LockAction::UNKNOWN) {
-                return;
-            }
-            this->send_command(Command(CommandType::LOCK, static_cast<uint8_t>(action)));
-        }
-
-        void Secplus2::door_action(DoorAction action)
-        {
-            if (action == DoorAction::UNKNOWN) {
-                return;
-            }
-            this->door_command(action);
-        }
-
-        Result Secplus2::call(Args args)
-        {
-            using Tag = Args::Tag;
-            if (args.tag == Tag::query_status) {
-                this->send_command(CommandType::GET_STATUS);
-            } else if (args.tag == Tag::query_openings) {
-                this->send_command(CommandType::GET_OPENINGS);
-            } else if (args.tag == Tag::get_rolling_code_counter) {
-                return Result(RollingCodeCounter { std::addressof(this->rolling_code_counter_) });
-            } else if (args.tag == Tag::set_rolling_code_counter) {
-                this->set_rolling_code_counter(args.value.set_rolling_code_counter.counter);
-            } else if (args.tag == Tag::set_client_id) {
-                this->set_client_id(args.value.set_client_id.client_id);
-            } else if (args.tag == Tag::query_paired_devices) {
-                this->query_paired_devices(args.value.query_paired_devices.kind);
-            } else if (args.tag == Tag::query_paired_devices_all) {
-                this->query_paired_devices();
-            } else if (args.tag == Tag::clear_paired_devices) {
-                this->clear_paired_devices(args.value.clear_paired_devices.kind);
-            } else if (args.tag == Tag::activate_learn) {
-                this->activate_learn();
-            } else if (args.tag == Tag::inactivate_learn) {
-                this->inactivate_learn();
-            }
-            return { };
-        }
-
-        void Secplus2::door_command(DoorAction action)
-        {
-            this->send_command(Command(CommandType::DOOR_ACTION, static_cast<uint8_t>(action), 1, 1), IncrementRollingCode::NO, [this, action]() {
-                this->scheduler_->set_timeout(this->ratgdo_, "", 150, [this, action] {
-                    this->send_command(Command(CommandType::DOOR_ACTION, static_cast<uint8_t>(action), 0, 1));
-                });
+            this->scheduler_->set_timeout(this->ratgdo_, "sync", delay, [this, start, delay, tries]() {
+                this->sync_helper(start, delay, tries + 1);
             });
-        }
+        };
+    }
 
-        void Secplus2::query_status()
-        {
+    void Secplus2::sync()
+    {
+        this->scheduler_->cancel_timeout(this->ratgdo_, "sync");
+        this->sync_helper(millis(), 500, 0);
+    }
+
+    void Secplus2::light_action(LightAction action)
+    {
+        if (action == LightAction::UNKNOWN) {
+            return;
+        }
+        this->send_command(Command(CommandType::LIGHT, static_cast<uint8_t>(action)));
+    }
+
+    void Secplus2::lock_action(LockAction action)
+    {
+        if (action == LockAction::UNKNOWN) {
+            return;
+        }
+        this->send_command(Command(CommandType::LOCK, static_cast<uint8_t>(action)));
+    }
+
+    void Secplus2::door_action(DoorAction action)
+    {
+        if (action == DoorAction::UNKNOWN) {
+            return;
+        }
+        this->door_command(action);
+    }
+
+    Result Secplus2::call(Args args)
+    {
+        using Tag = Args::Tag;
+        if (args.tag == Tag::query_status) {
             this->send_command(CommandType::GET_STATUS);
-        }
-
-        void Secplus2::query_openings()
-        {
+        } else if (args.tag == Tag::query_openings) {
             this->send_command(CommandType::GET_OPENINGS);
+        } else if (args.tag == Tag::get_rolling_code_counter) {
+            return Result(RollingCodeCounter { std::addressof(this->rolling_code_counter_) });
+        } else if (args.tag == Tag::set_rolling_code_counter) {
+            this->set_rolling_code_counter(args.value.set_rolling_code_counter.counter);
+        } else if (args.tag == Tag::set_client_id) {
+            this->set_client_id(args.value.set_client_id.client_id);
+        } else if (args.tag == Tag::query_paired_devices) {
+            this->query_paired_devices(args.value.query_paired_devices.kind);
+        } else if (args.tag == Tag::query_paired_devices_all) {
+            this->query_paired_devices();
+        } else if (args.tag == Tag::clear_paired_devices) {
+            this->clear_paired_devices(args.value.clear_paired_devices.kind);
+        } else if (args.tag == Tag::activate_learn) {
+            this->activate_learn();
+        } else if (args.tag == Tag::inactivate_learn) {
+            this->inactivate_learn();
         }
+        return { };
+    }
 
-        void Secplus2::query_paired_devices()
-        {
-            const auto kinds = {
-                PairedDevice::ALL,
-                PairedDevice::REMOTE,
-                PairedDevice::KEYPAD,
-                PairedDevice::WALL_CONTROL,
-                PairedDevice::ACCESSORY
-            };
-            uint32_t timeout = 0;
-            for (auto kind : kinds) {
-                timeout += 200;
-                this->scheduler_->set_timeout(this->ratgdo_, "", timeout, [this, kind] { this->query_paired_devices(kind); });
-            }
+    void Secplus2::door_command(DoorAction action)
+    {
+        this->send_command(Command(CommandType::DOOR_ACTION, static_cast<uint8_t>(action), 1, 1), IncrementRollingCode::NO, [this, action]() {
+            this->scheduler_->set_timeout(this->ratgdo_, "", 150, [this, action] {
+                this->send_command(Command(CommandType::DOOR_ACTION, static_cast<uint8_t>(action), 0, 1));
+            });
+        });
+    }
+
+    void Secplus2::query_status()
+    {
+        this->send_command(CommandType::GET_STATUS);
+    }
+
+    void Secplus2::query_openings()
+    {
+        this->send_command(CommandType::GET_OPENINGS);
+    }
+
+    void Secplus2::query_paired_devices()
+    {
+        const auto kinds = {
+            PairedDevice::ALL,
+            PairedDevice::REMOTE,
+            PairedDevice::KEYPAD,
+            PairedDevice::WALL_CONTROL,
+            PairedDevice::ACCESSORY
+        };
+        uint32_t timeout = 0;
+        for (auto kind : kinds) {
+            timeout += 200;
+            this->scheduler_->set_timeout(this->ratgdo_, "", timeout, [this, kind] { this->query_paired_devices(kind); });
         }
+    }
 
-        void Secplus2::query_paired_devices(PairedDevice kind)
-        {
-            ESP_LOGD(TAG, "Query paired devices of type: %s", LOG_STR_ARG(PairedDevice_to_string(kind)));
-            this->send_command(Command { CommandType::GET_PAIRED_DEVICES, static_cast<uint8_t>(kind) });
+    void Secplus2::query_paired_devices(PairedDevice kind)
+    {
+        ESP_LOGD(TAG, "Query paired devices of type: %s", LOG_STR_ARG(PairedDevice_to_string(kind)));
+        this->send_command(Command { CommandType::GET_PAIRED_DEVICES, static_cast<uint8_t>(kind) });
+    }
+
+    // wipe devices from memory based on get paired devices nibble values
+    void Secplus2::clear_paired_devices(PairedDevice kind)
+    {
+        if (kind == PairedDevice::UNKNOWN) {
+            return;
         }
-
-        // wipe devices from memory based on get paired devices nibble values
-        void Secplus2::clear_paired_devices(PairedDevice kind)
-        {
-            if (kind == PairedDevice::UNKNOWN) {
-                return;
-            }
-            ESP_LOGW(TAG, "Clear paired devices of type: %s", LOG_STR_ARG(PairedDevice_to_string(kind)));
-            if (kind == PairedDevice::ALL) {
-                this->scheduler_->set_timeout(this->ratgdo_, "", 200, [this] { this->send_command(Command { CommandType::CLEAR_PAIRED_DEVICES, static_cast<uint8_t>(PairedDevice::REMOTE) - 1 }); }); // wireless
-                this->scheduler_->set_timeout(this->ratgdo_, "", 400, [this] { this->send_command(Command { CommandType::CLEAR_PAIRED_DEVICES, static_cast<uint8_t>(PairedDevice::KEYPAD) - 1 }); }); // keypads
-                this->scheduler_->set_timeout(this->ratgdo_, "", 600, [this] { this->send_command(Command { CommandType::CLEAR_PAIRED_DEVICES, static_cast<uint8_t>(PairedDevice::WALL_CONTROL) - 1 }); }); // wall controls
-                this->scheduler_->set_timeout(this->ratgdo_, "", 800, [this] { this->send_command(Command { CommandType::CLEAR_PAIRED_DEVICES, static_cast<uint8_t>(PairedDevice::ACCESSORY) - 1 }); }); // accessories
-                this->scheduler_->set_timeout(this->ratgdo_, "", 1000, [this] { this->query_status(); });
-                this->scheduler_->set_timeout(this->ratgdo_, "", 1200, [this] { this->query_paired_devices(); });
-            } else {
-                uint8_t dev_kind = static_cast<uint8_t>(kind) - 1;
-                this->send_command(Command { CommandType::CLEAR_PAIRED_DEVICES, dev_kind }); // just requested device
-                this->scheduler_->set_timeout(this->ratgdo_, "", 200, [this] { this->query_status(); });
-                this->scheduler_->set_timeout(this->ratgdo_, "", 400, [this, kind] { this->query_paired_devices(kind); });
-            }
+        ESP_LOGW(TAG, "Clear paired devices of type: %s", LOG_STR_ARG(PairedDevice_to_string(kind)));
+        if (kind == PairedDevice::ALL) {
+            this->scheduler_->set_timeout(this->ratgdo_, "", 200, [this] { this->send_command(Command { CommandType::CLEAR_PAIRED_DEVICES, static_cast<uint8_t>(PairedDevice::REMOTE) - 1 }); }); // wireless
+            this->scheduler_->set_timeout(this->ratgdo_, "", 400, [this] { this->send_command(Command { CommandType::CLEAR_PAIRED_DEVICES, static_cast<uint8_t>(PairedDevice::KEYPAD) - 1 }); }); // keypads
+            this->scheduler_->set_timeout(this->ratgdo_, "", 600, [this] { this->send_command(Command { CommandType::CLEAR_PAIRED_DEVICES, static_cast<uint8_t>(PairedDevice::WALL_CONTROL) - 1 }); }); // wall controls
+            this->scheduler_->set_timeout(this->ratgdo_, "", 800, [this] { this->send_command(Command { CommandType::CLEAR_PAIRED_DEVICES, static_cast<uint8_t>(PairedDevice::ACCESSORY) - 1 }); }); // accessories
+            this->scheduler_->set_timeout(this->ratgdo_, "", 1000, [this] { this->query_status(); });
+            this->scheduler_->set_timeout(this->ratgdo_, "", 1200, [this] { this->query_paired_devices(); });
+        } else {
+            uint8_t dev_kind = static_cast<uint8_t>(kind) - 1;
+            this->send_command(Command { CommandType::CLEAR_PAIRED_DEVICES, dev_kind }); // just requested device
+            this->scheduler_->set_timeout(this->ratgdo_, "", 200, [this] { this->query_status(); });
+            this->scheduler_->set_timeout(this->ratgdo_, "", 400, [this, kind] { this->query_paired_devices(kind); });
         }
+    }
 
-        // Learn functions
-        void Secplus2::activate_learn()
-        {
-            // Send LEARN with nibble = 0 then nibble = 1 to mimic wall control learn button
-            this->send_command(Command { CommandType::LEARN, 0 });
-            this->scheduler_->set_timeout(this->ratgdo_, "", 150, [this] { this->send_command(Command { CommandType::LEARN, 1 }); });
-            this->scheduler_->set_timeout(this->ratgdo_, "", 500, [this] { this->query_status(); });
-        }
+    // Learn functions
+    void Secplus2::activate_learn()
+    {
+        // Send LEARN with nibble = 0 then nibble = 1 to mimic wall control learn button
+        this->send_command(Command { CommandType::LEARN, 0 });
+        this->scheduler_->set_timeout(this->ratgdo_, "", 150, [this] { this->send_command(Command { CommandType::LEARN, 1 }); });
+        this->scheduler_->set_timeout(this->ratgdo_, "", 500, [this] { this->query_status(); });
+    }
 
-        void Secplus2::inactivate_learn()
-        {
-            // Send LEARN twice with nibble = 0 to inactivate learn and get status to update switch state
-            this->send_command(Command { CommandType::LEARN, 0 });
-            this->scheduler_->set_timeout(this->ratgdo_, "", 150, [this] { this->send_command(Command { CommandType::LEARN, 0 }); });
-            this->scheduler_->set_timeout(this->ratgdo_, "", 500, [this] { this->query_status(); });
-        }
+    void Secplus2::inactivate_learn()
+    {
+        // Send LEARN twice with nibble = 0 to inactivate learn and get status to update switch state
+        this->send_command(Command { CommandType::LEARN, 0 });
+        this->scheduler_->set_timeout(this->ratgdo_, "", 150, [this] { this->send_command(Command { CommandType::LEARN, 0 }); });
+        this->scheduler_->set_timeout(this->ratgdo_, "", 500, [this] { this->query_status(); });
+    }
 
-        optional<Command> Secplus2::read_command()
-        {
-            static bool reading_msg = false;
-            static uint32_t msg_start = 0;
-            static uint16_t byte_count = 0;
-            static WirePacket rx_packet;
-            static uint32_t last_read = 0;
+    optional<Command> Secplus2::read_command()
+    {
+        static bool reading_msg = false;
+        static uint32_t msg_start = 0;
+        static uint16_t byte_count = 0;
+        static WirePacket rx_packet;
+        static uint32_t last_read = 0;
 
-            if (!reading_msg) {
-                while (this->sw_serial_.available()) {
-                    uint8_t ser_byte = this->sw_serial_.read();
-                    last_read = millis();
+        if (!reading_msg) {
+            while (this->sw_serial_.available()) {
+                uint8_t ser_byte = this->sw_serial_.read();
+                last_read = millis();
 
-                    if (ser_byte != 0x55 && ser_byte != 0x01 && ser_byte != 0x00) {
-                        ESP_LOG2(TAG, "Ignoring byte (%d): %02X, baud: %d", byte_count, ser_byte, this->sw_serial_.baudRate());
-                        byte_count = 0;
-                        continue;
-                    }
-                    msg_start = ((msg_start << 8) | ser_byte) & 0xffffff;
-                    byte_count++;
+                if (ser_byte != 0x55 && ser_byte != 0x01 && ser_byte != 0x00) {
+                    ESP_LOG2(TAG, "Ignoring byte (%d): %02X, baud: %d", byte_count, ser_byte, this->sw_serial_.baudRate());
+                    byte_count = 0;
+                    continue;
+                }
+                msg_start = ((msg_start << 8) | ser_byte) & 0xffffff;
+                byte_count++;
 
-                    // if we are at the start of a message, capture the next 16 bytes
-                    if (msg_start == 0x550100) {
-                        ESP_LOG1(TAG, "Baud: %d", this->sw_serial_.baudRate());
-                        rx_packet[0] = 0x55;
-                        rx_packet[1] = 0x01;
-                        rx_packet[2] = 0x00;
+                // if we are at the start of a message, capture the next 16 bytes
+                if (msg_start == 0x550100) {
+                    ESP_LOG1(TAG, "Baud: %d", this->sw_serial_.baudRate());
+                    rx_packet[0] = 0x55;
+                    rx_packet[1] = 0x01;
+                    rx_packet[2] = 0x00;
 
-                        reading_msg = true;
-                        break;
-                    }
+                    reading_msg = true;
+                    break;
                 }
             }
-            if (reading_msg) {
-                while (this->sw_serial_.available()) {
-                    uint8_t ser_byte = this->sw_serial_.read();
-                    last_read = millis();
-                    rx_packet[byte_count] = ser_byte;
-                    byte_count++;
-                    // ESP_LOG2(TAG, "Received byte (%d): %02X, baud: %d", byte_count, ser_byte, this->sw_serial_.baudRate());
+        }
+        if (reading_msg) {
+            while (this->sw_serial_.available()) {
+                uint8_t ser_byte = this->sw_serial_.read();
+                last_read = millis();
+                rx_packet[byte_count] = ser_byte;
+                byte_count++;
+                // ESP_LOG2(TAG, "Received byte (%d): %02X, baud: %d", byte_count, ser_byte, this->sw_serial_.baudRate());
 
-                    if (byte_count == PACKET_LENGTH) {
-                        reading_msg = false;
-                        byte_count = 0;
-                        this->print_packet(LOG_STR("Received packet: "), rx_packet);
-                        return this->decode_packet(rx_packet);
-                    }
-                }
-
-                if (millis() - last_read > 100) {
-                    // if we have a partial packet and it's been over 100ms since last byte was read,
-                    // the rest is not coming (a full packet should be received in ~20ms),
-                    // discard it so we can read the following packet correctly
-                    ESP_LOGW(TAG, "Discard incomplete packet, length: %d", byte_count);
+                if (byte_count == PACKET_LENGTH) {
                     reading_msg = false;
                     byte_count = 0;
+                    this->print_packet(LOG_STR("Received packet: "), rx_packet);
+                    return this->decode_packet(rx_packet);
                 }
             }
 
+            if (millis() - last_read > 100) {
+                // if we have a partial packet and it's been over 100ms since last byte was read,
+                // the rest is not coming (a full packet should be received in ~20ms),
+                // discard it so we can read the following packet correctly
+                ESP_LOGW(TAG, "Discard incomplete packet, length: %d", byte_count);
+                reading_msg = false;
+                byte_count = 0;
+            }
+        }
+
+        return { };
+    }
+
+    void Secplus2::print_packet(const esphome::LogString* prefix, const WirePacket& packet) const
+    {
+        ESP_LOGD(TAG, "%s: [%02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X]",
+            LOG_STR_ARG(prefix),
+            packet[0],
+            packet[1],
+            packet[2],
+            packet[3],
+            packet[4],
+            packet[5],
+            packet[6],
+            packet[7],
+            packet[8],
+            packet[9],
+            packet[10],
+            packet[11],
+            packet[12],
+            packet[13],
+            packet[14],
+            packet[15],
+            packet[16],
+            packet[17],
+            packet[18]);
+    }
+
+    optional<Command> Secplus2::decode_packet(const WirePacket& packet) const
+    {
+        uint32_t rolling = 0;
+        uint64_t fixed = 0;
+        uint32_t data = 0;
+
+        int err = decode_wireline(packet, &rolling, &fixed, &data);
+        if (err < 0) {
+            ESP_LOGW(TAG, "Decode failed (parity error or invalid frame)");
             return { };
         }
 
-        void Secplus2::print_packet(const esphome::LogString* prefix, const WirePacket& packet) const
-        {
-            ESP_LOGD(TAG, "%s: [%02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X %02X]",
-                LOG_STR_ARG(prefix),
-                packet[0],
-                packet[1],
-                packet[2],
-                packet[3],
-                packet[4],
-                packet[5],
-                packet[6],
-                packet[7],
-                packet[8],
-                packet[9],
-                packet[10],
-                packet[11],
-                packet[12],
-                packet[13],
-                packet[14],
-                packet[15],
-                packet[16],
-                packet[17],
-                packet[18]);
+        uint16_t cmd = ((fixed >> 24) & 0xf00) | (data & 0xff);
+        data &= ~0xf000; // clear parity nibble
+
+        if ((fixed & 0xFFFFFFFF) == this->client_id_) { // my commands
+            ESP_LOG1(TAG, "[%ld] received mine: rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, millis(), rolling, fixed, data);
+            return { };
+        } else {
+            ESP_LOG1(TAG, "[%ld] received rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, millis(), rolling, fixed, data);
         }
 
-        optional<Command> Secplus2::decode_packet(const WirePacket& packet) const
-        {
-            uint32_t rolling = 0;
-            uint64_t fixed = 0;
-            uint32_t data = 0;
+        CommandType cmd_type = to_CommandType(cmd, CommandType::UNKNOWN);
+        uint8_t nibble = (data >> 8) & 0xff;
+        uint8_t byte1 = (data >> 16) & 0xff;
+        uint8_t byte2 = (data >> 24) & 0xff;
 
-            int err = decode_wireline(packet, &rolling, &fixed, &data);
-            if (err < 0) {
-                ESP_LOGW(TAG, "Decode failed (parity error or invalid frame)");
-                return { };
+        ESP_LOG1(TAG, "cmd=%03x (%s) byte2=%02x byte1=%02x nibble=%01x", cmd, LOG_STR_ARG(CommandType_to_string(cmd_type)), byte2, byte1, nibble);
+
+        return Command { cmd_type, nibble, byte1, byte2 };
+    }
+
+    void Secplus2::handle_command(const Command& cmd)
+    {
+        ESP_LOG1(TAG, "Handle command: %s", LOG_STR_ARG(CommandType_to_string(cmd.type)));
+
+        if (cmd.type == CommandType::STATUS) {
+
+            this->ratgdo_->received(to_DoorState(cmd.nibble, DoorState::UNKNOWN));
+            this->ratgdo_->received(to_LightState((cmd.byte2 >> 1) & 1, LightState::UNKNOWN));
+            this->ratgdo_->received(to_LockState((cmd.byte2 & 1), LockState::UNKNOWN));
+            // ESP_LOGD(TAG, "Obstruction: reading from byte2, bit2, status=%d", ((byte2 >> 2) & 1) == 1);
+            this->ratgdo_->received(to_ObstructionState((cmd.byte1 >> 6) & 1, ObstructionState::UNKNOWN));
+            this->ratgdo_->received(to_LearnState((cmd.byte2 >> 5) & 1, LearnState::UNKNOWN));
+        } else if (cmd.type == CommandType::LIGHT) {
+            this->ratgdo_->received(to_LightAction(cmd.nibble, LightAction::UNKNOWN));
+        } else if (cmd.type == CommandType::MOTOR_ON) {
+            this->ratgdo_->received(MotorState::ON);
+        } else if (cmd.type == CommandType::DOOR_ACTION) {
+            auto button_state = (cmd.byte1 & 1) == 1 ? ButtonState::PRESSED : ButtonState::RELEASED;
+            this->ratgdo_->received(button_state);
+        } else if (cmd.type == CommandType::MOTION) {
+            this->ratgdo_->received(MotionState::DETECTED);
+        } else if (cmd.type == CommandType::OPENINGS) {
+            this->ratgdo_->received(Openings { static_cast<uint16_t>((cmd.byte1 << 8) | cmd.byte2), cmd.nibble });
+        } else if (cmd.type == CommandType::SET_TTC) {
+            this->ratgdo_->received(TimeToClose { static_cast<uint16_t>((cmd.byte1 << 8) | cmd.byte2) });
+        } else if (cmd.type == CommandType::PAIRED_DEVICES) {
+            PairedDeviceCount pdc;
+            pdc.kind = to_PairedDevice(cmd.nibble, PairedDevice::UNKNOWN);
+            if (pdc.kind == PairedDevice::ALL) {
+                pdc.count = cmd.byte2;
+            } else if (pdc.kind == PairedDevice::REMOTE) {
+                pdc.count = cmd.byte2;
+            } else if (pdc.kind == PairedDevice::KEYPAD) {
+                pdc.count = cmd.byte2;
+            } else if (pdc.kind == PairedDevice::WALL_CONTROL) {
+                pdc.count = cmd.byte2;
+            } else if (pdc.kind == PairedDevice::ACCESSORY) {
+                pdc.count = cmd.byte2;
             }
+            this->ratgdo_->received(pdc);
+        } else if (cmd.type == CommandType::BATTERY_STATUS) {
+            this->ratgdo_->received(to_BatteryState(cmd.byte1, BatteryState::UNKNOWN));
+        }
 
-            uint16_t cmd = ((fixed >> 24) & 0xf00) | (data & 0xff);
-            data &= ~0xf000; // clear parity nibble
+        ESP_LOG1(TAG, "Done handle command: %s", LOG_STR_ARG(CommandType_to_string(cmd.type)));
+    }
 
-            if ((fixed & 0xFFFFFFFF) == this->client_id_) { // my commands
-                ESP_LOG1(TAG, "[%ld] received mine: rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, millis(), rolling, fixed, data);
-                return { };
+    void Secplus2::send_command(Command command, IncrementRollingCode increment)
+    {
+        ESP_LOGD(TAG, "Send command: %s, data: %02X%02X%02X", LOG_STR_ARG(CommandType_to_string(command.type)), command.byte2, command.byte1, command.nibble);
+        if (!this->flags_.transmit_pending) { // have an untransmitted packet
+            this->encode_packet(command, this->tx_packet_);
+            if (increment == IncrementRollingCode::YES) {
+                this->increment_rolling_code_counter();
+            }
+        } else {
+            // unlikely this would happed (unless not connected to GDO), we're ensuring any pending packet
+            // is transmitted each loop before doing anyting else
+            if (this->transmit_pending_start_ > 0) {
+                ESP_LOGW(TAG, "Have untransmitted packet, ignoring command: %s", LOG_STR_ARG(CommandType_to_string(command.type)));
             } else {
-                ESP_LOG1(TAG, "[%ld] received rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, millis(), rolling, fixed, data);
+                ESP_LOGW(TAG, "Not connected to GDO, ignoring command: %s", LOG_STR_ARG(CommandType_to_string(command.type)));
             }
-
-            CommandType cmd_type = to_CommandType(cmd, CommandType::UNKNOWN);
-            uint8_t nibble = (data >> 8) & 0xff;
-            uint8_t byte1 = (data >> 16) & 0xff;
-            uint8_t byte2 = (data >> 24) & 0xff;
-
-            ESP_LOG1(TAG, "cmd=%03x (%s) byte2=%02x byte1=%02x nibble=%01x", cmd, LOG_STR_ARG(CommandType_to_string(cmd_type)), byte2, byte1, nibble);
-
-            return Command { cmd_type, nibble, byte1, byte2 };
         }
+        this->transmit_packet();
+    }
 
-        void Secplus2::handle_command(const Command& cmd)
-        {
-            ESP_LOG1(TAG, "Handle command: %s", LOG_STR_ARG(CommandType_to_string(cmd.type)));
+    void Secplus2::send_command(Command command, IncrementRollingCode increment, std::function<void()>&& on_sent)
+    {
+        this->on_command_sent_(on_sent);
+        this->send_command(command, increment);
+    }
 
-            if (cmd.type == CommandType::STATUS) {
+    void Secplus2::encode_packet(Command command, WirePacket& packet)
+    {
+        auto cmd = static_cast<uint64_t>(command.type);
+        uint64_t fixed = ((cmd & ~0xff) << 24) | this->client_id_;
+        uint32_t data = (static_cast<uint64_t>(command.byte2) << 24) | (static_cast<uint64_t>(command.byte1) << 16) | (static_cast<uint64_t>(command.nibble) << 8) | (cmd & 0xff);
 
-                this->ratgdo_->received(to_DoorState(cmd.nibble, DoorState::UNKNOWN));
-                this->ratgdo_->received(to_LightState((cmd.byte2 >> 1) & 1, LightState::UNKNOWN));
-                this->ratgdo_->received(to_LockState((cmd.byte2 & 1), LockState::UNKNOWN));
-                // ESP_LOGD(TAG, "Obstruction: reading from byte2, bit2, status=%d", ((byte2 >> 2) & 1) == 1);
-                this->ratgdo_->received(to_ObstructionState((cmd.byte1 >> 6) & 1, ObstructionState::UNKNOWN));
-                this->ratgdo_->received(to_LearnState((cmd.byte2 >> 5) & 1, LearnState::UNKNOWN));
-            } else if (cmd.type == CommandType::LIGHT) {
-                this->ratgdo_->received(to_LightAction(cmd.nibble, LightAction::UNKNOWN));
-            } else if (cmd.type == CommandType::MOTOR_ON) {
-                this->ratgdo_->received(MotorState::ON);
-            } else if (cmd.type == CommandType::DOOR_ACTION) {
-                auto button_state = (cmd.byte1 & 1) == 1 ? ButtonState::PRESSED : ButtonState::RELEASED;
-                this->ratgdo_->received(button_state);
-            } else if (cmd.type == CommandType::MOTION) {
-                this->ratgdo_->received(MotionState::DETECTED);
-            } else if (cmd.type == CommandType::OPENINGS) {
-                this->ratgdo_->received(Openings { static_cast<uint16_t>((cmd.byte1 << 8) | cmd.byte2), cmd.nibble });
-            } else if (cmd.type == CommandType::SET_TTC) {
-                this->ratgdo_->received(TimeToClose { static_cast<uint16_t>((cmd.byte1 << 8) | cmd.byte2) });
-            } else if (cmd.type == CommandType::PAIRED_DEVICES) {
-                PairedDeviceCount pdc;
-                pdc.kind = to_PairedDevice(cmd.nibble, PairedDevice::UNKNOWN);
-                if (pdc.kind == PairedDevice::ALL) {
-                    pdc.count = cmd.byte2;
-                } else if (pdc.kind == PairedDevice::REMOTE) {
-                    pdc.count = cmd.byte2;
-                } else if (pdc.kind == PairedDevice::KEYPAD) {
-                    pdc.count = cmd.byte2;
-                } else if (pdc.kind == PairedDevice::WALL_CONTROL) {
-                    pdc.count = cmd.byte2;
-                } else if (pdc.kind == PairedDevice::ACCESSORY) {
-                    pdc.count = cmd.byte2;
+        ESP_LOG2(TAG, "[%ld] Encode for transmit rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, millis(), *this->rolling_code_counter_, fixed, data);
+        encode_wireline(*this->rolling_code_counter_, fixed, data, packet);
+    }
+
+    bool Secplus2::transmit_packet()
+    {
+        auto now = micros();
+
+        while (micros() - now < 1300) {
+            if (this->rx_pin_->digital_read()) {
+                if (!this->flags_.transmit_pending) {
+                    this->flags_.transmit_pending = true;
+                    this->transmit_pending_start_ = millis();
+                    ESP_LOGD(TAG, "Collision detected, waiting to send packet");
+                } else if (millis() - this->transmit_pending_start_ >= 5000) {
+                    this->transmit_pending_start_ = 0; // to indicate GDO not connected state
                 }
-                this->ratgdo_->received(pdc);
-            } else if (cmd.type == CommandType::BATTERY_STATUS) {
-                this->ratgdo_->received(to_BatteryState(cmd.byte1, BatteryState::UNKNOWN));
+                return false;
             }
-
-            ESP_LOG1(TAG, "Done handle command: %s", LOG_STR_ARG(CommandType_to_string(cmd.type)));
+            delayMicroseconds(100);
         }
 
-        void Secplus2::send_command(Command command, IncrementRollingCode increment)
-        {
-            ESP_LOGD(TAG, "Send command: %s, data: %02X%02X%02X", LOG_STR_ARG(CommandType_to_string(command.type)), command.byte2, command.byte1, command.nibble);
-            if (!this->flags_.transmit_pending) { // have an untransmitted packet
-                this->encode_packet(command, this->tx_packet_);
-                if (increment == IncrementRollingCode::YES) {
-                    this->increment_rolling_code_counter();
-                }
-            } else {
-                // unlikely this would happed (unless not connected to GDO), we're ensuring any pending packet
-                // is transmitted each loop before doing anyting else
-                if (this->transmit_pending_start_ > 0) {
-                    ESP_LOGW(TAG, "Have untransmitted packet, ignoring command: %s", LOG_STR_ARG(CommandType_to_string(command.type)));
-                } else {
-                    ESP_LOGW(TAG, "Not connected to GDO, ignoring command: %s", LOG_STR_ARG(CommandType_to_string(command.type)));
-                }
-            }
-            this->transmit_packet();
-        }
+        this->print_packet(LOG_STR("Sending packet"), this->tx_packet_);
 
-        void Secplus2::send_command(Command command, IncrementRollingCode increment, std::function<void()>&& on_sent)
-        {
-            this->on_command_sent_(on_sent);
-            this->send_command(command, increment);
-        }
+        // indicate the start of a frame by pulling the 12V line low for at leat 1 byte followed by
+        // one STOP bit, which indicates to the receiving end that the start of the message follows
+        // The output pin is controlling a transistor, so the logic is inverted
+        this->tx_pin_->digital_write(true); // pull the line low for at least 1 byte
+        delayMicroseconds(1300);
+        this->tx_pin_->digital_write(false); // line high for at least 1 bit
+        delayMicroseconds(130);
 
-        void Secplus2::encode_packet(Command command, WirePacket& packet)
-        {
-            auto cmd = static_cast<uint64_t>(command.type);
-            uint64_t fixed = ((cmd & ~0xff) << 24) | this->client_id_;
-            uint32_t data = (static_cast<uint64_t>(command.byte2) << 24) | (static_cast<uint64_t>(command.byte1) << 16) | (static_cast<uint64_t>(command.nibble) << 8) | (cmd & 0xff);
+        this->sw_serial_.write(this->tx_packet_, PACKET_LENGTH);
 
-            ESP_LOG2(TAG, "[%ld] Encode for transmit rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, millis(), *this->rolling_code_counter_, fixed, data);
-            encode_wireline(*this->rolling_code_counter_, fixed, data, packet);
-        }
+        this->flags_.transmit_pending = false;
+        this->transmit_pending_start_ = 0;
+        this->on_command_sent_.trigger();
+        return true;
+    }
 
-        bool Secplus2::transmit_packet()
-        {
-            auto now = micros();
+    void Secplus2::increment_rolling_code_counter(int delta)
+    {
+        this->rolling_code_counter_ = (*this->rolling_code_counter_ + delta) & 0xfffffff;
+    }
 
-            while (micros() - now < 1300) {
-                if (this->rx_pin_->digital_read()) {
-                    if (!this->flags_.transmit_pending) {
-                        this->flags_.transmit_pending = true;
-                        this->transmit_pending_start_ = millis();
-                        ESP_LOGD(TAG, "Collision detected, waiting to send packet");
-                    } else if (millis() - this->transmit_pending_start_ >= 5000) {
-                        this->transmit_pending_start_ = 0; // to indicate GDO not connected state
-                    }
-                    return false;
-                }
-                delayMicroseconds(100);
-            }
+    void Secplus2::set_rolling_code_counter(uint32_t counter)
+    {
+        ESP_LOGV(TAG, "Set rolling code counter to %d", counter);
+        this->rolling_code_counter_ = counter;
+    }
 
-            this->print_packet(LOG_STR("Sending packet"), this->tx_packet_);
+    void Secplus2::set_client_id(uint64_t client_id)
+    {
+        this->client_id_ = client_id & 0xFFFFFFFF;
+    }
 
-            // indicate the start of a frame by pulling the 12V line low for at leat 1 byte followed by
-            // one STOP bit, which indicates to the receiving end that the start of the message follows
-            // The output pin is controlling a transistor, so the logic is inverted
-            this->tx_pin_->digital_write(true); // pull the line low for at least 1 byte
-            delayMicroseconds(1300);
-            this->tx_pin_->digital_write(false); // line high for at least 1 bit
-            delayMicroseconds(130);
-
-            this->sw_serial_.write(this->tx_packet_, PACKET_LENGTH);
-
-            this->flags_.transmit_pending = false;
-            this->transmit_pending_start_ = 0;
-            this->on_command_sent_.trigger();
-            return true;
-        }
-
-        void Secplus2::increment_rolling_code_counter(int delta)
-        {
-            this->rolling_code_counter_ = (*this->rolling_code_counter_ + delta) & 0xfffffff;
-        }
-
-        void Secplus2::set_rolling_code_counter(uint32_t counter)
-        {
-            ESP_LOGV(TAG, "Set rolling code counter to %d", counter);
-            this->rolling_code_counter_ = counter;
-        }
-
-        void Secplus2::set_client_id(uint64_t client_id)
-        {
-            this->client_id_ = client_id & 0xFFFFFFFF;
-        }
-
-    } // namespace secplus2
-} // namespace ratgdo
-} // namespace esphome
+} // namespace secplus2
+} // namespace esphome::ratgdo
 
 #endif // PROTOCOL_SECPLUSV2

--- a/components/ratgdo/secplus2.h
+++ b/components/ratgdo/secplus2.h
@@ -16,157 +16,158 @@ namespace esphome {
 class Scheduler;
 class InternalGPIOPin;
 
-namespace ratgdo {
-    class RATGDOComponent;
-
-    namespace secplus2 {
-
-        using namespace esphome::ratgdo::protocol;
-
-        static const uint8_t PACKET_LENGTH = 19;
-        typedef uint8_t WirePacket[PACKET_LENGTH];
-
-        ENUM_SPARSE(CommandType, uint16_t,
-            (UNKNOWN, 0x000),
-            (GET_STATUS, 0x080),
-            (STATUS, 0x081),
-            (OBST_1, 0x084), // sent when an obstruction happens?
-            (OBST_2, 0x085), // sent when an obstruction happens?
-            (BATTERY_STATUS, 0x09d),
-            (PAIR_3, 0x0a0),
-            (PAIR_3_RESP, 0x0a1),
-
-            (LEARN, 0x181),
-            (LOCK, 0x18c),
-            (DOOR_ACTION, 0x280),
-            (LIGHT, 0x281),
-            (MOTOR_ON, 0x284),
-            (MOTION, 0x285),
-
-            (GET_PAIRED_DEVICES, 0x307), // nibble 0 for total, 1 wireless, 2 keypads, 3 wall, 4 accessories.
-            (PAIRED_DEVICES, 0x308), // byte2 holds number of paired devices
-            (CLEAR_PAIRED_DEVICES, 0x30D), // nibble 0 to clear remotes, 1 keypads, 2 wall, 3 accessories (offset from above)
-
-            (LEARN_1, 0x391),
-            (PING, 0x392),
-            (PING_RESP, 0x393),
-
-            (PAIR_2, 0x400),
-            (PAIR_2_RESP, 0x401),
-            (SET_TTC, 0x402), // ttc_in_seconds = (byte1<<8)+byte2
-            (CANCEL_TTC, 0x408), // ?
-            (TTC, 0x40a), // Time to close
-            (GET_OPENINGS, 0x48b),
-            (OPENINGS, 0x48c), // openings = (byte1<<8)+byte2
-        )
-
-        inline bool operator==(const uint16_t cmd_i, const CommandType& cmd_e) { return cmd_i == static_cast<uint16_t>(cmd_e); }
-        inline bool operator==(const CommandType& cmd_e, const uint16_t cmd_i) { return cmd_i == static_cast<uint16_t>(cmd_e); }
-
-        enum class IncrementRollingCode {
-            NO,
-            YES,
-        };
-
-        struct Command {
-            CommandType type;
-            uint8_t nibble;
-            uint8_t byte1;
-            uint8_t byte2;
-
-            Command()
-                : type(CommandType::UNKNOWN)
-            {
-            }
-            Command(CommandType type_, uint8_t nibble_ = 0, uint8_t byte1_ = 0, uint8_t byte2_ = 0)
-                : type(type_)
-                , nibble(nibble_)
-                , byte1(byte1_)
-                , byte2(byte2_)
-            {
-            }
-        };
-
-        class Secplus2 : public Protocol {
-        public:
-            void setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin);
-            void loop();
-            void dump_config();
-
-            void sync();
-
-            void light_action(LightAction action);
-            void lock_action(LockAction action);
-            void door_action(DoorAction action);
-
-            Result call(Args args);
-
-            const Traits& traits() const { return this->traits_; }
-
-            // methods not used by secplus2
-            void set_open_limit(bool state) { }
-            void set_close_limit(bool state) { }
-            void set_discrete_open_pin(InternalGPIOPin* pin) { }
-            void set_discrete_close_pin(InternalGPIOPin* pin) { }
-
-        protected:
-            void increment_rolling_code_counter(int delta = 1);
-            void set_rolling_code_counter(uint32_t counter);
-            void set_client_id(uint64_t client_id);
-
-            optional<Command> read_command();
-            void handle_command(const Command& cmd);
-
-            void send_command(Command cmd, IncrementRollingCode increment = IncrementRollingCode::YES);
-            void send_command(Command cmd, IncrementRollingCode increment, std::function<void()>&& on_sent);
-            void encode_packet(Command cmd, WirePacket& packet);
-            bool transmit_packet();
-
-            void door_command(DoorAction action);
-
-            void query_status();
-            void query_openings();
-            void query_paired_devices();
-            void query_paired_devices(PairedDevice kind);
-            void clear_paired_devices(PairedDevice kind);
-            void activate_learn();
-            void inactivate_learn();
-
-            void print_packet(const esphome::LogString* prefix, const WirePacket& packet) const;
-            optional<Command> decode_packet(const WirePacket& packet) const;
-
-            void sync_helper(uint32_t start, uint32_t delay, uint8_t tries);
-
-            // 8-byte member first (may require 8-byte alignment on some 32-bit systems)
-            uint64_t client_id_ { 0x539 };
-
-            // Pointers (4-byte aligned)
-            InternalGPIOPin* tx_pin_;
-            InternalGPIOPin* rx_pin_;
-            RATGDOComponent* ratgdo_;
-            Scheduler* scheduler_;
-
-            // 4-byte members
-            uint32_t transmit_pending_start_ { 0 };
-
-            // Larger structures
-            single_observable<uint32_t> rolling_code_counter_ { 0 };
-            OnceCallbacks<void()> on_command_sent_;
-            Traits traits_;
-            SoftwareSerial sw_serial_;
-
-            // 19-byte array
-            WirePacket tx_packet_;
-
-            // Small members at the end
-            LearnState learn_state_ { LearnState::UNKNOWN };
-            struct {
-                uint8_t transmit_pending : 1;
-                uint8_t reserved : 7; // Reserved for future use
-            } flags_ { 0 };
-        };
-    } // namespace secplus2
-} // namespace ratgdo
 } // namespace esphome
+
+namespace esphome::ratgdo {
+class RATGDOComponent;
+
+namespace secplus2 {
+
+    using namespace esphome::ratgdo::protocol;
+
+    static const uint8_t PACKET_LENGTH = 19;
+    typedef uint8_t WirePacket[PACKET_LENGTH];
+
+    ENUM_SPARSE(CommandType, uint16_t,
+        (UNKNOWN, 0x000),
+        (GET_STATUS, 0x080),
+        (STATUS, 0x081),
+        (OBST_1, 0x084), // sent when an obstruction happens?
+        (OBST_2, 0x085), // sent when an obstruction happens?
+        (BATTERY_STATUS, 0x09d),
+        (PAIR_3, 0x0a0),
+        (PAIR_3_RESP, 0x0a1),
+
+        (LEARN, 0x181),
+        (LOCK, 0x18c),
+        (DOOR_ACTION, 0x280),
+        (LIGHT, 0x281),
+        (MOTOR_ON, 0x284),
+        (MOTION, 0x285),
+
+        (GET_PAIRED_DEVICES, 0x307), // nibble 0 for total, 1 wireless, 2 keypads, 3 wall, 4 accessories.
+        (PAIRED_DEVICES, 0x308), // byte2 holds number of paired devices
+        (CLEAR_PAIRED_DEVICES, 0x30D), // nibble 0 to clear remotes, 1 keypads, 2 wall, 3 accessories (offset from above)
+
+        (LEARN_1, 0x391),
+        (PING, 0x392),
+        (PING_RESP, 0x393),
+
+        (PAIR_2, 0x400),
+        (PAIR_2_RESP, 0x401),
+        (SET_TTC, 0x402), // ttc_in_seconds = (byte1<<8)+byte2
+        (CANCEL_TTC, 0x408), // ?
+        (TTC, 0x40a), // Time to close
+        (GET_OPENINGS, 0x48b),
+        (OPENINGS, 0x48c), // openings = (byte1<<8)+byte2
+    )
+
+    inline bool operator==(const uint16_t cmd_i, const CommandType& cmd_e) { return cmd_i == static_cast<uint16_t>(cmd_e); }
+    inline bool operator==(const CommandType& cmd_e, const uint16_t cmd_i) { return cmd_i == static_cast<uint16_t>(cmd_e); }
+
+    enum class IncrementRollingCode {
+        NO,
+        YES,
+    };
+
+    struct Command {
+        CommandType type;
+        uint8_t nibble;
+        uint8_t byte1;
+        uint8_t byte2;
+
+        Command()
+            : type(CommandType::UNKNOWN)
+        {
+        }
+        Command(CommandType type_, uint8_t nibble_ = 0, uint8_t byte1_ = 0, uint8_t byte2_ = 0)
+            : type(type_)
+            , nibble(nibble_)
+            , byte1(byte1_)
+            , byte2(byte2_)
+        {
+        }
+    };
+
+    class Secplus2 : public Protocol {
+    public:
+        void setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin);
+        void loop();
+        void dump_config();
+
+        void sync();
+
+        void light_action(LightAction action);
+        void lock_action(LockAction action);
+        void door_action(DoorAction action);
+
+        Result call(Args args);
+
+        const Traits& traits() const { return this->traits_; }
+
+        // methods not used by secplus2
+        void set_open_limit(bool state) { }
+        void set_close_limit(bool state) { }
+        void set_discrete_open_pin(InternalGPIOPin* pin) { }
+        void set_discrete_close_pin(InternalGPIOPin* pin) { }
+
+    protected:
+        void increment_rolling_code_counter(int delta = 1);
+        void set_rolling_code_counter(uint32_t counter);
+        void set_client_id(uint64_t client_id);
+
+        optional<Command> read_command();
+        void handle_command(const Command& cmd);
+
+        void send_command(Command cmd, IncrementRollingCode increment = IncrementRollingCode::YES);
+        void send_command(Command cmd, IncrementRollingCode increment, std::function<void()>&& on_sent);
+        void encode_packet(Command cmd, WirePacket& packet);
+        bool transmit_packet();
+
+        void door_command(DoorAction action);
+
+        void query_status();
+        void query_openings();
+        void query_paired_devices();
+        void query_paired_devices(PairedDevice kind);
+        void clear_paired_devices(PairedDevice kind);
+        void activate_learn();
+        void inactivate_learn();
+
+        void print_packet(const esphome::LogString* prefix, const WirePacket& packet) const;
+        optional<Command> decode_packet(const WirePacket& packet) const;
+
+        void sync_helper(uint32_t start, uint32_t delay, uint8_t tries);
+
+        // 8-byte member first (may require 8-byte alignment on some 32-bit systems)
+        uint64_t client_id_ { 0x539 };
+
+        // Pointers (4-byte aligned)
+        InternalGPIOPin* tx_pin_;
+        InternalGPIOPin* rx_pin_;
+        RATGDOComponent* ratgdo_;
+        Scheduler* scheduler_;
+
+        // 4-byte members
+        uint32_t transmit_pending_start_ { 0 };
+
+        // Larger structures
+        single_observable<uint32_t> rolling_code_counter_ { 0 };
+        OnceCallbacks<void()> on_command_sent_;
+        Traits traits_;
+        SoftwareSerial sw_serial_;
+
+        // 19-byte array
+        WirePacket tx_packet_;
+
+        // Small members at the end
+        LearnState learn_state_ { LearnState::UNKNOWN };
+        struct {
+            uint8_t transmit_pending : 1;
+            uint8_t reserved : 7; // Reserved for future use
+        } flags_ { 0 };
+    };
+} // namespace secplus2
+} // namespace esphome::ratgdo
 
 #endif // PROTOCOL_SECPLUSV2

--- a/components/ratgdo/sensor/ratgdo_sensor.cpp
+++ b/components/ratgdo/sensor/ratgdo_sensor.cpp
@@ -2,143 +2,141 @@
 #include "../ratgdo_state.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    static const char* const TAG = "ratgdo.sensor";
-    static const int MIN_DISTANCE = 100; // ignore bugs crawling on the distance sensor & dust protection film
-    static const int MAX_DISTANCE = 4500; // default maximum distance
+static const char* const TAG = "ratgdo.sensor";
+static const int MIN_DISTANCE = 100; // ignore bugs crawling on the distance sensor & dust protection film
+static const int MAX_DISTANCE = 4500; // default maximum distance
 
-    void RATGDOSensor::setup()
-    {
-        switch (this->ratgdo_sensor_type_) {
-        case RATGDOSensorType::RATGDO_OPENINGS:
-            this->parent_->subscribe_openings([this](uint16_t value) {
-                this->publish_state(value);
-            });
-            break;
-        case RATGDOSensorType::RATGDO_PAIRED_DEVICES_TOTAL:
-            this->parent_->subscribe_paired_devices_total([this](uint8_t value) {
-                this->publish_state(value);
-            });
-            break;
-        case RATGDOSensorType::RATGDO_PAIRED_REMOTES:
-            this->parent_->subscribe_paired_remotes([this](uint8_t value) {
-                this->publish_state(value);
-            });
-            break;
-        case RATGDOSensorType::RATGDO_PAIRED_KEYPADS:
-            this->parent_->subscribe_paired_keypads([this](uint8_t value) {
-                this->publish_state(value);
-            });
-            break;
-        case RATGDOSensorType::RATGDO_PAIRED_WALL_CONTROLS:
-            this->parent_->subscribe_paired_wall_controls([this](uint8_t value) {
-                this->publish_state(value);
-            });
-            break;
-        case RATGDOSensorType::RATGDO_PAIRED_ACCESSORIES:
-            this->parent_->subscribe_paired_accessories([this](uint8_t value) {
-                this->publish_state(value);
-            });
-            break;
-        case RATGDOSensorType::RATGDO_DISTANCE:
+void RATGDOSensor::setup()
+{
+    switch (this->ratgdo_sensor_type_) {
+    case RATGDOSensorType::RATGDO_OPENINGS:
+        this->parent_->subscribe_openings([this](uint16_t value) {
+            this->publish_state(value);
+        });
+        break;
+    case RATGDOSensorType::RATGDO_PAIRED_DEVICES_TOTAL:
+        this->parent_->subscribe_paired_devices_total([this](uint8_t value) {
+            this->publish_state(value);
+        });
+        break;
+    case RATGDOSensorType::RATGDO_PAIRED_REMOTES:
+        this->parent_->subscribe_paired_remotes([this](uint8_t value) {
+            this->publish_state(value);
+        });
+        break;
+    case RATGDOSensorType::RATGDO_PAIRED_KEYPADS:
+        this->parent_->subscribe_paired_keypads([this](uint8_t value) {
+            this->publish_state(value);
+        });
+        break;
+    case RATGDOSensorType::RATGDO_PAIRED_WALL_CONTROLS:
+        this->parent_->subscribe_paired_wall_controls([this](uint8_t value) {
+            this->publish_state(value);
+        });
+        break;
+    case RATGDOSensorType::RATGDO_PAIRED_ACCESSORIES:
+        this->parent_->subscribe_paired_accessories([this](uint8_t value) {
+            this->publish_state(value);
+        });
+        break;
+    case RATGDOSensorType::RATGDO_DISTANCE:
 #ifdef RATGDO_USE_DISTANCE_SENSOR
-            this->distance_sensor_.setI2cDevice(&I2C);
-            this->distance_sensor_.setXShutPin(32);
-            // I2C.begin(17,16);
-            I2C.begin(19, 18);
-            this->distance_sensor_.begin();
-            this->distance_sensor_.VL53L4CX_Off();
-            this->distance_sensor_.InitSensor(0x59);
-            this->distance_sensor_.VL53L4CX_SetDistanceMode(VL53L4CX_DISTANCEMODE_LONG);
-            this->distance_sensor_.VL53L4CX_StartMeasurement();
+        this->distance_sensor_.setI2cDevice(&I2C);
+        this->distance_sensor_.setXShutPin(32);
+        // I2C.begin(17,16);
+        I2C.begin(19, 18);
+        this->distance_sensor_.begin();
+        this->distance_sensor_.VL53L4CX_Off();
+        this->distance_sensor_.InitSensor(0x59);
+        this->distance_sensor_.VL53L4CX_SetDistanceMode(VL53L4CX_DISTANCEMODE_LONG);
+        this->distance_sensor_.VL53L4CX_StartMeasurement();
 #ifdef RATGDO_USE_DISTANCE_SENSOR
-            this->parent_->subscribe_distance_measurement([this](int16_t value) {
-                this->publish_state(value);
-            });
+        this->parent_->subscribe_distance_measurement([this](int16_t value) {
+            this->publish_state(value);
+        });
 #endif
 #endif
-            break;
-        default:
-            break;
-        }
+        break;
+    default:
+        break;
     }
+}
 
-    void RATGDOSensor::dump_config()
-    {
-        LOG_SENSOR("", "RATGDO Sensor", this);
-        switch (this->ratgdo_sensor_type_) {
-        case RATGDOSensorType::RATGDO_OPENINGS:
-            ESP_LOGCONFIG(TAG, "  Type: Openings");
-            break;
-        case RATGDOSensorType::RATGDO_PAIRED_DEVICES_TOTAL:
-            ESP_LOGCONFIG(TAG, "  Type: Paired Devices");
-            break;
-        case RATGDOSensorType::RATGDO_PAIRED_REMOTES:
-            ESP_LOGCONFIG(TAG, "  Type: Paired Remotes");
-            break;
-        case RATGDOSensorType::RATGDO_PAIRED_KEYPADS:
-            ESP_LOGCONFIG(TAG, "  Type: Paired Keypads");
-            break;
-        case RATGDOSensorType::RATGDO_PAIRED_WALL_CONTROLS:
-            ESP_LOGCONFIG(TAG, "  Type: Paired Wall Controls");
-            break;
-        case RATGDOSensorType::RATGDO_PAIRED_ACCESSORIES:
-            ESP_LOGCONFIG(TAG, "  Type: Paired Accessories");
-            break;
-        case RATGDOSensorType::RATGDO_DISTANCE:
-            ESP_LOGCONFIG(TAG, "  Type: Distance");
-            break;
-        default:
-            break;
-        }
+void RATGDOSensor::dump_config()
+{
+    LOG_SENSOR("", "RATGDO Sensor", this);
+    switch (this->ratgdo_sensor_type_) {
+    case RATGDOSensorType::RATGDO_OPENINGS:
+        ESP_LOGCONFIG(TAG, "  Type: Openings");
+        break;
+    case RATGDOSensorType::RATGDO_PAIRED_DEVICES_TOTAL:
+        ESP_LOGCONFIG(TAG, "  Type: Paired Devices");
+        break;
+    case RATGDOSensorType::RATGDO_PAIRED_REMOTES:
+        ESP_LOGCONFIG(TAG, "  Type: Paired Remotes");
+        break;
+    case RATGDOSensorType::RATGDO_PAIRED_KEYPADS:
+        ESP_LOGCONFIG(TAG, "  Type: Paired Keypads");
+        break;
+    case RATGDOSensorType::RATGDO_PAIRED_WALL_CONTROLS:
+        ESP_LOGCONFIG(TAG, "  Type: Paired Wall Controls");
+        break;
+    case RATGDOSensorType::RATGDO_PAIRED_ACCESSORIES:
+        ESP_LOGCONFIG(TAG, "  Type: Paired Accessories");
+        break;
+    case RATGDOSensorType::RATGDO_DISTANCE:
+        ESP_LOGCONFIG(TAG, "  Type: Distance");
+        break;
+    default:
+        break;
     }
+}
 
 #ifdef RATGDO_USE_DISTANCE_SENSOR
-    void RATGDOSensor::loop()
-    {
-        if (this->ratgdo_sensor_type_ == RATGDOSensorType::RATGDO_DISTANCE) {
-            VL53L4CX_MultiRangingData_t distanceData;
-            VL53L4CX_MultiRangingData_t* pDistanceData = &distanceData;
-            uint8_t dataReady = 0;
-            int objCount = 0;
-            int16_t maxDistance = -1;
-            int status;
+void RATGDOSensor::loop()
+{
+    if (this->ratgdo_sensor_type_ == RATGDOSensorType::RATGDO_DISTANCE) {
+        VL53L4CX_MultiRangingData_t distanceData;
+        VL53L4CX_MultiRangingData_t* pDistanceData = &distanceData;
+        uint8_t dataReady = 0;
+        int objCount = 0;
+        int16_t maxDistance = -1;
+        int status;
 
-            if (this->distance_sensor_.VL53L4CX_GetMeasurementDataReady(&dataReady) == 0 && dataReady) {
-                status = this->distance_sensor_.VL53L4CX_GetMultiRangingData(pDistanceData);
-                objCount = pDistanceData->NumberOfObjectsFound;
+        if (this->distance_sensor_.VL53L4CX_GetMeasurementDataReady(&dataReady) == 0 && dataReady) {
+            status = this->distance_sensor_.VL53L4CX_GetMultiRangingData(pDistanceData);
+            objCount = pDistanceData->NumberOfObjectsFound;
 
-                for (int i = 0; i < distanceData.NumberOfObjectsFound; i++) {
-                    VL53L4CX_TargetRangeData_t* d = &pDistanceData->RangeData[i];
-                    if (d->RangeStatus == 0) {
-                        maxDistance = std::max(maxDistance, d->RangeMilliMeter);
-                        maxDistance = maxDistance <= MIN_DISTANCE ? -1 : maxDistance;
-                    }
+            for (int i = 0; i < distanceData.NumberOfObjectsFound; i++) {
+                VL53L4CX_TargetRangeData_t* d = &pDistanceData->RangeData[i];
+                if (d->RangeStatus == 0) {
+                    maxDistance = std::max(maxDistance, d->RangeMilliMeter);
+                    maxDistance = maxDistance <= MIN_DISTANCE ? -1 : maxDistance;
                 }
+            }
 
-                if (maxDistance < 0)
-                    maxDistance = MAX_DISTANCE;
+            if (maxDistance < 0)
+                maxDistance = MAX_DISTANCE;
 
-                // maxDistance = objCount == 0 ? -1 : pDistanceData->RangeData[objCount - 1].RangeMilliMeter;
-                /*
-                 * if the sensor is pointed at glass, there are many error -1 readings which will fill the
-                 * vector with out of range data. The sensor should be sensitive enough to detect the floor
-                 * in most situations, but daylight and/or really high ceilings can cause long distance
-                 * measurements to be out of range.
-                 */
-                this->parent_->set_distance_measurement(maxDistance);
+            // maxDistance = objCount == 0 ? -1 : pDistanceData->RangeData[objCount - 1].RangeMilliMeter;
+            /*
+             * if the sensor is pointed at glass, there are many error -1 readings which will fill the
+             * vector with out of range data. The sensor should be sensitive enough to detect the floor
+             * in most situations, but daylight and/or really high ceilings can cause long distance
+             * measurements to be out of range.
+             */
+            this->parent_->set_distance_measurement(maxDistance);
 
-                // ESP_LOGD(TAG,"# obj found %d; distance %d",objCount, maxDistance);
+            // ESP_LOGD(TAG,"# obj found %d; distance %d",objCount, maxDistance);
 
-                if (status == 0) {
-                    status = this->distance_sensor_.VL53L4CX_ClearInterruptAndStartMeasurement();
-                }
+            if (status == 0) {
+                status = this->distance_sensor_.VL53L4CX_ClearInterruptAndStartMeasurement();
             }
         }
     }
+}
 #endif
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/sensor/ratgdo_sensor.h
+++ b/components/ratgdo/sensor/ratgdo_sensor.h
@@ -12,35 +12,33 @@
 #define I2C Wire
 #endif
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    enum RATGDOSensorType : uint8_t {
-        RATGDO_OPENINGS,
-        RATGDO_PAIRED_DEVICES_TOTAL,
-        RATGDO_PAIRED_REMOTES,
-        RATGDO_PAIRED_KEYPADS,
-        RATGDO_PAIRED_WALL_CONTROLS,
-        RATGDO_PAIRED_ACCESSORIES,
-        RATGDO_DISTANCE
-    };
+enum RATGDOSensorType : uint8_t {
+    RATGDO_OPENINGS,
+    RATGDO_PAIRED_DEVICES_TOTAL,
+    RATGDO_PAIRED_REMOTES,
+    RATGDO_PAIRED_KEYPADS,
+    RATGDO_PAIRED_WALL_CONTROLS,
+    RATGDO_PAIRED_ACCESSORIES,
+    RATGDO_DISTANCE
+};
 
-    class RATGDOSensor : public sensor::Sensor, public RATGDOClient, public Component {
-    public:
-        void dump_config() override;
-        void setup() override;
+class RATGDOSensor : public sensor::Sensor, public RATGDOClient, public Component {
+public:
+    void dump_config() override;
+    void setup() override;
 #ifdef RATGDO_USE_DISTANCE_SENSOR
-        void loop() override;
+    void loop() override;
 #endif
-        void set_ratgdo_sensor_type(RATGDOSensorType ratgdo_sensor_type_) { this->ratgdo_sensor_type_ = ratgdo_sensor_type_; }
+    void set_ratgdo_sensor_type(RATGDOSensorType ratgdo_sensor_type_) { this->ratgdo_sensor_type_ = ratgdo_sensor_type_; }
 
-    protected:
-        RATGDOSensorType ratgdo_sensor_type_;
+protected:
+    RATGDOSensorType ratgdo_sensor_type_;
 
 #ifdef RATGDO_USE_DISTANCE_SENSOR
-        VL53L4CX distance_sensor_;
+    VL53L4CX distance_sensor_;
 #endif
-    };
+};
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/switch/ratgdo_switch.cpp
+++ b/components/ratgdo/switch/ratgdo_switch.cpp
@@ -2,65 +2,63 @@
 #include "../ratgdo_state.h"
 #include "esphome/core/log.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    static const char* const TAG = "ratgdo.switch";
+static const char* const TAG = "ratgdo.switch";
 
-    void RATGDOSwitch::dump_config()
-    {
-        LOG_SWITCH("", "RATGDO Switch", this);
-        switch (this->switch_type_) {
-        case SwitchType::RATGDO_LEARN:
-            ESP_LOGCONFIG(TAG, "  Type: Learn");
-            break;
-        case SwitchType::RATGDO_LED:
-            ESP_LOGCONFIG(TAG, "  Type: LED");
-            break;
-        default:
-            break;
-        }
+void RATGDOSwitch::dump_config()
+{
+    LOG_SWITCH("", "RATGDO Switch", this);
+    switch (this->switch_type_) {
+    case SwitchType::RATGDO_LEARN:
+        ESP_LOGCONFIG(TAG, "  Type: Learn");
+        break;
+    case SwitchType::RATGDO_LED:
+        ESP_LOGCONFIG(TAG, "  Type: LED");
+        break;
+    default:
+        break;
     }
+}
 
-    void RATGDOSwitch::setup()
-    {
-        switch (this->switch_type_) {
-        case SwitchType::RATGDO_LEARN:
-            this->parent_->subscribe_learn_state([this](LearnState state) {
-                this->publish_state(state == LearnState::ACTIVE);
-            });
-            break;
-        case SwitchType::RATGDO_LED:
-            this->pin_->setup();
+void RATGDOSwitch::setup()
+{
+    switch (this->switch_type_) {
+    case SwitchType::RATGDO_LEARN:
+        this->parent_->subscribe_learn_state([this](LearnState state) {
+            this->publish_state(state == LearnState::ACTIVE);
+        });
+        break;
+    case SwitchType::RATGDO_LED:
+        this->pin_->setup();
 #ifdef RATGDO_USE_VEHICLE_SENSORS
-            this->parent_->subscribe_vehicle_arriving_state([this](VehicleArrivingState state) {
-                this->write_state(state == VehicleArrivingState::YES);
-            });
+        this->parent_->subscribe_vehicle_arriving_state([this](VehicleArrivingState state) {
+            this->write_state(state == VehicleArrivingState::YES);
+        });
 #endif
-            break;
-        default:
-            break;
-        }
+        break;
+    default:
+        break;
     }
+}
 
-    void RATGDOSwitch::write_state(bool state)
-    {
-        switch (this->switch_type_) {
-        case SwitchType::RATGDO_LEARN:
-            if (state) {
-                this->parent_->activate_learn();
-            } else {
-                this->parent_->inactivate_learn();
-            }
-            break;
-        case SwitchType::RATGDO_LED:
-            this->pin_->digital_write(state);
-            this->publish_state(state);
-            break;
-        default:
-            break;
+void RATGDOSwitch::write_state(bool state)
+{
+    switch (this->switch_type_) {
+    case SwitchType::RATGDO_LEARN:
+        if (state) {
+            this->parent_->activate_learn();
+        } else {
+            this->parent_->inactivate_learn();
         }
+        break;
+    case SwitchType::RATGDO_LED:
+        this->pin_->digital_write(state);
+        this->publish_state(state);
+        break;
+    default:
+        break;
     }
+}
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo

--- a/components/ratgdo/switch/ratgdo_switch.h
+++ b/components/ratgdo/switch/ratgdo_switch.h
@@ -6,27 +6,25 @@
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
 
-namespace esphome {
-namespace ratgdo {
+namespace esphome::ratgdo {
 
-    enum SwitchType {
-        RATGDO_LEARN,
-        RATGDO_LED
-    };
+enum SwitchType {
+    RATGDO_LEARN,
+    RATGDO_LED
+};
 
-    class RATGDOSwitch : public switch_::Switch, public RATGDOClient, public Component {
-    public:
-        void dump_config() override;
-        void setup() override;
-        void set_switch_type(SwitchType switch_type_) { this->switch_type_ = switch_type_; }
+class RATGDOSwitch : public switch_::Switch, public RATGDOClient, public Component {
+public:
+    void dump_config() override;
+    void setup() override;
+    void set_switch_type(SwitchType switch_type_) { this->switch_type_ = switch_type_; }
 
-        void write_state(bool state) override;
-        void set_pin(GPIOPin* pin) { pin_ = pin; }
+    void write_state(bool state) override;
+    void set_pin(GPIOPin* pin) { pin_ = pin; }
 
-    protected:
-        SwitchType switch_type_;
-        GPIOPin* pin_;
-    };
+protected:
+    SwitchType switch_type_;
+    GPIOPin* pin_;
+};
 
-} // namespace ratgdo
-} // namespace esphome
+} // namespace esphome::ratgdo


### PR DESCRIPTION
## Summary
- Replace `namespace esphome { namespace ratgdo {` with C++17 `namespace esphome::ratgdo {` syntax across all C++ files
- Forward declarations of `Scheduler` and `InternalGPIOPin` moved to a separate `namespace esphome {}` block before the combined namespace
- clang-format applied to all modified files

## Test plan
- [x] Verify CI build passes for all protocol variants (secplus1, secplus2, dry_contact)