### PR TITLE
Throttle VL53L4CX distance sensor polling to 50ms interval

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -6,7 +6,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/ratgdo/esphome-ratgdo
-      ref: main
+      ref: throttle-distance-sensor-polling
     refresh: 1s
   # - source:
   #     type: local

--- a/base_drycontact.yaml
+++ b/base_drycontact.yaml
@@ -6,7 +6,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/ratgdo/esphome-ratgdo
-      ref: main
+      ref: throttle-distance-sensor-polling
     refresh: 1s
   # - source:
   #     type: local

--- a/base_secplusv1.yaml
+++ b/base_secplusv1.yaml
@@ -6,7 +6,7 @@ external_components:
   - source:
       type: git
       url: https://github.com/ratgdo/esphome-ratgdo
-      ref: main
+      ref: throttle-distance-sensor-polling
     refresh: 1s
   # - source:
   #     type: local

--- a/components/ratgdo/sensor/ratgdo_sensor.cpp
+++ b/components/ratgdo/sensor/ratgdo_sensor.cpp
@@ -1,5 +1,6 @@
 #include "ratgdo_sensor.h"
 #include "../ratgdo_state.h"
+#include "esphome/core/application.h"
 #include "esphome/core/log.h"
 
 namespace esphome::ratgdo {
@@ -95,9 +96,16 @@ void RATGDOSensor::dump_config()
 }
 
 #ifdef RATGDO_USE_DISTANCE_SENSOR
+static const uint32_t DISTANCE_POLL_INTERVAL_MS = 50;
+
 void RATGDOSensor::loop()
 {
     if (this->ratgdo_sensor_type_ == RATGDOSensorType::RATGDO_DISTANCE) {
+        uint32_t now = App.get_loop_component_start_time();
+        if (now - this->last_distance_poll_ms_ < DISTANCE_POLL_INTERVAL_MS)
+            return;
+        this->last_distance_poll_ms_ = now;
+
         VL53L4CX_MultiRangingData_t distanceData;
         VL53L4CX_MultiRangingData_t* pDistanceData = &distanceData;
         uint8_t dataReady = 0;

--- a/components/ratgdo/sensor/ratgdo_sensor.cpp
+++ b/components/ratgdo/sensor/ratgdo_sensor.cpp
@@ -135,9 +135,11 @@ void RATGDOSensor::loop()
              * in most situations, but daylight and/or really high ceilings can cause long distance
              * measurements to be out of range.
              */
+            if (maxDistance != this->last_distance_) {
+                ESP_LOGI(TAG, "distance changed: %d -> %d (obj=%d)", this->last_distance_, maxDistance, objCount);
+                this->last_distance_ = maxDistance;
+            }
             this->parent_->set_distance_measurement(maxDistance);
-
-            // ESP_LOGD(TAG,"# obj found %d; distance %d",objCount, maxDistance);
 
             if (status == 0) {
                 status = this->distance_sensor_.VL53L4CX_ClearInterruptAndStartMeasurement();

--- a/components/ratgdo/sensor/ratgdo_sensor.h
+++ b/components/ratgdo/sensor/ratgdo_sensor.h
@@ -38,6 +38,7 @@ protected:
 
 #ifdef RATGDO_USE_DISTANCE_SENSOR
     VL53L4CX distance_sensor_;
+    uint32_t last_distance_poll_ms_ { 0 };
 #endif
 };
 

--- a/components/ratgdo/sensor/ratgdo_sensor.h
+++ b/components/ratgdo/sensor/ratgdo_sensor.h
@@ -39,6 +39,7 @@ protected:
 #ifdef RATGDO_USE_DISTANCE_SENSOR
     VL53L4CX distance_sensor_;
     uint32_t last_distance_poll_ms_ { 0 };
+    int16_t last_distance_ { -1 };
 #endif
 };
 

--- a/static/v25board_esp32_d1_mini.yaml
+++ b/static/v25board_esp32_d1_mini.yaml
@@ -28,12 +28,12 @@ esp32:
     type: arduino
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v25board_esp32_d1_mini.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v25board_esp32_d1_mini.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v25board_esp32_d1_mini_secplusv1.yaml
+++ b/static/v25board_esp32_d1_mini_secplusv1.yaml
@@ -28,12 +28,12 @@ esp32:
     type: arduino
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v25board_esp32_d1_mini_secplusv1.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v25board_esp32_d1_mini_secplusv1.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base_secplusv1.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v25board_esp8266_d1_mini.yaml
+++ b/static/v25board_esp8266_d1_mini.yaml
@@ -26,12 +26,12 @@ esp8266:
   restore_from_flash: true
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v25board_esp8266_d1_mini.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v25board_esp8266_d1_mini.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v25board_esp8266_d1_mini_lite.yaml
+++ b/static/v25board_esp8266_d1_mini_lite.yaml
@@ -26,12 +26,12 @@ esp8266:
   restore_from_flash: true
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v25board_esp8266_d1_mini_lite.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v25board_esp8266_d1_mini_lite.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v25board_esp8266_d1_mini_lite_secplusv1.yaml
+++ b/static/v25board_esp8266_d1_mini_lite_secplusv1.yaml
@@ -26,12 +26,12 @@ esp8266:
   restore_from_flash: true
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v25board_esp8266_d1_mini_lite_secplusv1.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v25board_esp8266_d1_mini_lite_secplusv1.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base_secplusv1.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v25board_esp8266_d1_mini_secplusv1.yaml
+++ b/static/v25board_esp8266_d1_mini_secplusv1.yaml
@@ -26,12 +26,12 @@ esp8266:
   restore_from_flash: true
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v25board_esp8266_d1_mini_secplusv1.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v25board_esp8266_d1_mini_secplusv1.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base_secplusv1.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v25iboard.yaml
+++ b/static/v25iboard.yaml
@@ -27,12 +27,12 @@ esp8266:
   restore_from_flash: true
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v25iboard.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v25iboard.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v25iboard_drycontact.yaml
+++ b/static/v25iboard_drycontact.yaml
@@ -26,12 +26,12 @@ esp8266:
   restore_from_flash: true
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v25iboard_drycontact.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v25iboard_drycontact.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base_drycontact.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v25iboard_secplusv1.yaml
+++ b/static/v25iboard_secplusv1.yaml
@@ -27,12 +27,12 @@ esp8266:
   restore_from_flash: true
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v25iboard_secplusv1.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v25iboard_secplusv1.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base_secplusv1.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v2board_esp32_d1_mini.yaml
+++ b/static/v2board_esp32_d1_mini.yaml
@@ -28,12 +28,12 @@ esp32:
     type: arduino
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v2board_esp32_d1_mini.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v2board_esp32_d1_mini.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v2board_esp32_lolin_s2_mini.yaml
+++ b/static/v2board_esp32_lolin_s2_mini.yaml
@@ -27,12 +27,12 @@ esp32:
     type: arduino
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v2board_esp32_lolin_s2_mini.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v2board_esp32_lolin_s2_mini.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v2board_esp8266_d1_mini.yaml
+++ b/static/v2board_esp8266_d1_mini.yaml
@@ -26,12 +26,12 @@ esp8266:
   restore_from_flash: true
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v2board_esp8266_d1_mini.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v2board_esp8266_d1_mini.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v2board_esp8266_d1_mini_lite.yaml
+++ b/static/v2board_esp8266_d1_mini_lite.yaml
@@ -26,12 +26,12 @@ esp8266:
   restore_from_flash: true
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v2board_esp8266_d1_mini_lite.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v2board_esp8266_d1_mini_lite.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v32board.yaml
+++ b/static/v32board.yaml
@@ -29,12 +29,12 @@ esp32:
     type: arduino
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v32board.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v32board.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v32board_drycontact.yaml
+++ b/static/v32board_drycontact.yaml
@@ -28,12 +28,12 @@ esp32:
     type: arduino
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v32board_drycontact.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v32board_drycontact.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base_drycontact.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v32board_secplusv1.yaml
+++ b/static/v32board_secplusv1.yaml
@@ -29,12 +29,12 @@ esp32:
     type: arduino
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v32board_secplusv1.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v32board_secplusv1.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base_secplusv1.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v32disco.yaml
+++ b/static/v32disco.yaml
@@ -30,12 +30,12 @@ esp32:
     type: arduino
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v32disco.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v32disco.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v32disco_drycontact.yaml
+++ b/static/v32disco_drycontact.yaml
@@ -29,12 +29,12 @@ esp32:
     type: arduino
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v32disco_drycontact.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v32disco_drycontact.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base_drycontact.yaml]
     refresh: 1s
   # remote_package: !include

--- a/static/v32disco_secplusv1.yaml
+++ b/static/v32disco_secplusv1.yaml
@@ -30,12 +30,12 @@ esp32:
     type: arduino
 
 dashboard_import:
-  package_import_url: github://ratgdo/esphome-ratgdo/v32disco_secplusv1.yaml@main
+  package_import_url: github://ratgdo/esphome-ratgdo/v32disco_secplusv1.yaml@throttle-distance-sensor-polling
 
 packages:
   remote_package:
     url: https://github.com/ratgdo/esphome-ratgdo
-    ref: main
+    ref: throttle-distance-sensor-polling
     files: [base_secplusv1.yaml]
     refresh: 1s
   # remote_package: !include


### PR DESCRIPTION
## Summary
- The distance sensor I2C call to `VL53L4CX_GetMeasurementDataReady` was running every loop iteration, consuming ~7ms avg per call (~37s total over 5109 loops)
- Added a 50ms polling interval using `App.get_loop_component_start_time()` to skip redundant I2C reads
- The VL53L4CX in long distance mode can't produce data faster than ~33ms, so no measurements are missed

## Test plan
- [ ] Deploy to device with VL53L4CX distance sensor and verify distance readings still work correctly
- [ ] Check runtime_stats to confirm `ratgdo.sensor` CPU usage drops significantly