### PR TITLE
Improve README header with product description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 
 # ratgdo for ESPHome
 
-[Visit the ratcloud.llc to purchase boards](https://ratcloud.llc)
+[ESPHome](https://esphome.io/) component for [ratgdo](https://ratcloud.llc) — a WiFi control board for garage door openers that works over your local network. Compatible with most residential Chamberlain and LiftMaster openers, with dry contact support for other brands.
+
+Purchase boards at [ratcloud.llc](https://ratcloud.llc).
 
 ## Installation
 


### PR DESCRIPTION
## Summary

- Replace the bare "Visit ratcloud.llc" link with a proper description of what ratgdo is
- Add links to ESPHome and ratgdo sites
- Mention compatibility with Chamberlain/LiftMaster openers and dry contact support