### PR TITLE
Implement a watchdog to query for status

### DIFF
--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -238,6 +238,8 @@ public:
     void query_openings();
     void sync();
 
+    using Component::cancel_interval;
+    using Component::set_interval;
     using Component::set_timeout;
 
     void set_door_state_expiry();

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -458,7 +458,7 @@ namespace scheduler_ids {
         TIMEOUT_CLEAR_PRESENCE,
         TIMEOUT_WALL_PANEL_EMULATION,
         TIMEOUT_SYNC,
-        TIMEOUT_STATUS_WATCHDOG,
+        INTERVAL_STATUS_WATCHDOG,
     };
 } // namespace scheduler_ids
 

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -458,6 +458,7 @@ namespace scheduler_ids {
         TIMEOUT_CLEAR_PRESENCE,
         TIMEOUT_WALL_PANEL_EMULATION,
         TIMEOUT_SYNC,
+        TIMEOUT_STATUS_WATCHDOG,
     };
 } // namespace scheduler_ids
 

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -461,6 +461,7 @@ namespace scheduler_ids {
         TIMEOUT_WALL_PANEL_EMULATION,
         TIMEOUT_SYNC,
         INTERVAL_STATUS_WATCHDOG,
+        INTERVAL_PING,
     };
 } // namespace scheduler_ids
 

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -461,7 +461,6 @@ namespace scheduler_ids {
         TIMEOUT_WALL_PANEL_EMULATION,
         TIMEOUT_SYNC,
         INTERVAL_STATUS_WATCHDOG,
-        INTERVAL_PING,
     };
 } // namespace scheduler_ids
 

--- a/components/ratgdo/ratgdo_uart_esp32.cpp
+++ b/components/ratgdo/ratgdo_uart_esp32.cpp
@@ -154,8 +154,14 @@ int RatgdoUART::available()
 {
     if (!this->is_initialized_)
         return 0;
+
     size_t length = 0;
     uart_get_buffered_data_len((uart_port_t)this->uart_num_, &length);
+
+    if (length >= UART_RX_BUFFER_SIZE) {
+        ESP_LOGD(TAG, "UART buffer overflow detected!");
+    }
+
     return length;
 }
 

--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -140,7 +140,7 @@ namespace secplus2 {
             // Rollover-safe: unsigned subtraction wraps correctly across millis() overflow.
             const uint32_t now = App.get_loop_component_start_time();
             if (static_cast<uint32_t>(now - this->last_status_ms_) > STATUS_WATCHDOG_TIMEOUT) {
-                ESP_LOGW(TAG, "No status received in 11 minutes, querying status");
+                ESP_LOGW(TAG, "No status received in 6 minutes, querying status");
                 this->query_status();
                 this->last_status_ms_ = now;
             }

--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -45,6 +45,11 @@ namespace secplus2 {
         this->traits_.set_features(Traits::all());
         this->last_status_ms_ = App.get_loop_component_start_time();
         this->start_status_watchdog();
+
+        this->ratgdo_->set_interval(INTERVAL_PING, PING_INTERVAL, [this]() {
+            ESP_LOGD(TAG, "Sending PING command");
+            this->send_command(Command(CommandType::PING));
+        });
     }
 
     void Secplus2::loop()

--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -315,6 +315,17 @@ namespace secplus2 {
                 this->rx_last_read_ = millis();
                 this->rx_packet_[this->rx_byte_count_] = ser_byte;
                 this->rx_byte_count_++;
+
+                this->rx_msg_start_ = ((this->rx_msg_start_ << 8) | ser_byte) & 0xffffff;
+                if (this->rx_msg_start_ == 0x550100) {
+                    ESP_LOGD(TAG, "Sync sequence found mid-packet. Discarding %d bytes and restarting.", this->rx_byte_count_ - 3);
+                    this->rx_packet_[0] = 0x55;
+                    this->rx_packet_[1] = 0x01;
+                    this->rx_packet_[2] = 0x00;
+                    this->rx_byte_count_ = 3;
+                    continue;
+                }
+
                 // ESP_LOG2(TAG, "Received byte (%d): %02X, baud: %d", this->rx_byte_count_, ser_byte, this->uart_.baudRate());
 
                 if (this->rx_byte_count_ == PACKET_LENGTH) {

--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -45,11 +45,6 @@ namespace secplus2 {
         this->traits_.set_features(Traits::all());
         this->last_status_ms_ = App.get_loop_component_start_time();
         this->start_status_watchdog();
-
-        this->ratgdo_->set_interval(INTERVAL_PING, PING_INTERVAL, [this]() {
-            ESP_LOGD(TAG, "Sending PING command");
-            this->send_command(Command(CommandType::PING));
-        });
     }
 
     void Secplus2::loop()

--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -4,6 +4,7 @@
 #include "secplus2.h"
 #include "ratgdo.h"
 
+#include "esphome/core/application.h"
 #include "esphome/core/gpio.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
@@ -42,7 +43,8 @@ namespace secplus2 {
         this->uart_.enableAutoBaud(true);
 
         this->traits_.set_features(Traits::all());
-        this->reset_status_watchdog();
+        this->last_status_ms_ = App.get_loop_component_start_time();
+        this->start_status_watchdog();
     }
 
     void Secplus2::loop()
@@ -132,12 +134,16 @@ namespace secplus2 {
         this->sync_helper(millis(), 500, 0);
     }
 
-    void Secplus2::reset_status_watchdog()
+    void Secplus2::start_status_watchdog()
     {
-        this->ratgdo_->set_timeout(TIMEOUT_STATUS_WATCHDOG, STATUS_WATCHDOG_TIMEOUT, [this]() {
-            ESP_LOGW(TAG, "No status received in 11 minutes, querying status");
-            this->query_status();
-            this->reset_status_watchdog();
+        this->ratgdo_->set_interval(INTERVAL_STATUS_WATCHDOG, STATUS_WATCHDOG_POLL, [this]() {
+            // Rollover-safe: unsigned subtraction wraps correctly across millis() overflow.
+            const uint32_t now = App.get_loop_component_start_time();
+            if (static_cast<uint32_t>(now - this->last_status_ms_) > STATUS_WATCHDOG_TIMEOUT) {
+                ESP_LOGW(TAG, "No status received in 11 minutes, querying status");
+                this->query_status();
+                this->last_status_ms_ = now;
+            }
         });
     }
 
@@ -376,7 +382,7 @@ namespace secplus2 {
         ESP_LOG1(TAG, "Handle command: %s", LOG_STR_ARG(CommandType_to_string(cmd.type)));
 
         if (cmd.type == CommandType::STATUS) {
-            this->reset_status_watchdog();
+            this->last_status_ms_ = App.get_loop_component_start_time();
             this->ratgdo_->received(to_DoorState(cmd.nibble, DoorState::UNKNOWN));
             this->ratgdo_->received(to_LightState((cmd.byte2 >> 1) & 1, LightState::UNKNOWN));
             this->ratgdo_->received(to_LockState((cmd.byte2 & 1), LockState::UNKNOWN));

--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -42,6 +42,7 @@ namespace secplus2 {
         this->uart_.enableAutoBaud(true);
 
         this->traits_.set_features(Traits::all());
+        this->reset_status_watchdog();
     }
 
     void Secplus2::loop()
@@ -129,6 +130,15 @@ namespace secplus2 {
     {
         this->scheduler_->cancel_timeout(this->ratgdo_, TIMEOUT_SYNC);
         this->sync_helper(millis(), 500, 0);
+    }
+
+    void Secplus2::reset_status_watchdog()
+    {
+        this->ratgdo_->set_timeout(TIMEOUT_STATUS_WATCHDOG, STATUS_WATCHDOG_TIMEOUT, [this]() {
+            ESP_LOGW(TAG, "No status received in 11 minutes, querying status");
+            this->query_status();
+            this->reset_status_watchdog();
+        });
     }
 
     void Secplus2::light_action(LightAction action)
@@ -366,7 +376,7 @@ namespace secplus2 {
         ESP_LOG1(TAG, "Handle command: %s", LOG_STR_ARG(CommandType_to_string(cmd.type)));
 
         if (cmd.type == CommandType::STATUS) {
-
+            this->reset_status_watchdog();
             this->ratgdo_->received(to_DoorState(cmd.nibble, DoorState::UNKNOWN));
             this->ratgdo_->received(to_LightState((cmd.byte2 >> 1) & 1, LightState::UNKNOWN));
             this->ratgdo_->received(to_LockState((cmd.byte2 & 1), LockState::UNKNOWN));

--- a/components/ratgdo/secplus2.h
+++ b/components/ratgdo/secplus2.h
@@ -27,6 +27,7 @@ namespace secplus2 {
 
     static const uint8_t PACKET_LENGTH = 19;
     static constexpr uint32_t STATUS_WATCHDOG_TIMEOUT = 660000; // 11 min. status updates are normally every ~5 min
+    static constexpr uint32_t STATUS_WATCHDOG_POLL = 60000; // check once per minute
     typedef uint8_t WirePacket[PACKET_LENGTH];
 
     ENUM_SPARSE(CommandType, uint16_t,
@@ -156,7 +157,7 @@ namespace secplus2 {
         optional<Command> decode_packet(const WirePacket& packet) const;
 
         void sync_helper(uint32_t start, uint32_t delay, uint8_t tries);
-        void reset_status_watchdog();
+        void start_status_watchdog();
 
         // 8-byte member first (may require 8-byte alignment on some 32-bit systems)
         uint64_t client_id_ { 0x539 };
@@ -171,6 +172,7 @@ namespace secplus2 {
         uint32_t transmit_pending_start_ { 0 };
         uint32_t rx_msg_start_ { 0 };
         uint32_t rx_last_read_ { 0 };
+        uint32_t last_status_ms_ { 0 };
 
         // Larger structures
         single_observable<uint32_t> rolling_code_counter_ { 0 };

--- a/components/ratgdo/secplus2.h
+++ b/components/ratgdo/secplus2.h
@@ -26,7 +26,7 @@ namespace secplus2 {
     using namespace esphome::ratgdo::protocol;
 
     static const uint8_t PACKET_LENGTH = 19;
-    static constexpr uint32_t STATUS_WATCHDOG_TIMEOUT = 660000; // 11 min. status updates are normally every ~5 min
+    static constexpr uint32_t STATUS_WATCHDOG_TIMEOUT = 360000; // 6 min. status updates are normally every ~5 min
     static constexpr uint32_t STATUS_WATCHDOG_POLL = 60000; // check once per minute
     typedef uint8_t WirePacket[PACKET_LENGTH];
 

--- a/components/ratgdo/secplus2.h
+++ b/components/ratgdo/secplus2.h
@@ -28,6 +28,7 @@ namespace secplus2 {
     static const uint8_t PACKET_LENGTH = 19;
     static constexpr uint32_t STATUS_WATCHDOG_TIMEOUT = 360000; // 6 min. status updates are normally every ~5 min
     static constexpr uint32_t STATUS_WATCHDOG_POLL = 60000; // check once per minute
+    static constexpr uint32_t PING_INTERVAL = 21600000; // 6 hours
     typedef uint8_t WirePacket[PACKET_LENGTH];
 
     ENUM_SPARSE(CommandType, uint16_t,

--- a/components/ratgdo/secplus2.h
+++ b/components/ratgdo/secplus2.h
@@ -26,6 +26,7 @@ namespace secplus2 {
     using namespace esphome::ratgdo::protocol;
 
     static const uint8_t PACKET_LENGTH = 19;
+    static constexpr uint32_t STATUS_WATCHDOG_TIMEOUT = 660000; // 11 min. status updates are normally every ~5 min
     typedef uint8_t WirePacket[PACKET_LENGTH];
 
     ENUM_SPARSE(CommandType, uint16_t,
@@ -155,6 +156,7 @@ namespace secplus2 {
         optional<Command> decode_packet(const WirePacket& packet) const;
 
         void sync_helper(uint32_t start, uint32_t delay, uint8_t tries);
+        void reset_status_watchdog();
 
         // 8-byte member first (may require 8-byte alignment on some 32-bit systems)
         uint64_t client_id_ { 0x539 };

--- a/components/ratgdo/secplus2.h
+++ b/components/ratgdo/secplus2.h
@@ -28,7 +28,6 @@ namespace secplus2 {
     static const uint8_t PACKET_LENGTH = 19;
     static constexpr uint32_t STATUS_WATCHDOG_TIMEOUT = 360000; // 6 min. status updates are normally every ~5 min
     static constexpr uint32_t STATUS_WATCHDOG_POLL = 60000; // check once per minute
-    static constexpr uint32_t PING_INTERVAL = 21600000; // 6 hours
     typedef uint8_t WirePacket[PACKET_LENGTH];
 
     ENUM_SPARSE(CommandType, uint16_t,


### PR DESCRIPTION
If no status updates are received from sec + 2 opener after a timeout, query for status. Ref issue #179 