### PR TITLE
Wake main loop from UART RX ISR on ESP32

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -1,6 +1,6 @@
 ---
 esphome:
-  min_version: 2026.2.0
+  min_version: 2026.4.0
 
 external_components:
   - source:

--- a/base_drycontact.yaml
+++ b/base_drycontact.yaml
@@ -1,6 +1,6 @@
 ---
 esphome:
-  min_version: 2026.2.0
+  min_version: 2026.4.0
 
 external_components:
   - source:

--- a/base_secplusv1.yaml
+++ b/base_secplusv1.yaml
@@ -1,6 +1,6 @@
 ---
 esphome:
-  min_version: 2026.2.0
+  min_version: 2026.4.0
 
 external_components:
   - source:

--- a/components/ratgdo/ratgdo_uart_esp32.cpp
+++ b/components/ratgdo/ratgdo_uart_esp32.cpp
@@ -78,8 +78,8 @@ void RatgdoUART::begin(int baud, RatgdoUARTConfig config, int rx_pin,
 
     // Wake the main loop from the UART rx ISR so bytes are consumed on the
     // next tick instead of waiting for the scheduler.
-    ESP_ERROR_CHECK(uart_set_select_notif_callback((uart_port_t)this->uart_num_,
-        &RatgdoUART::uart_rx_isr_callback));
+    uart_set_select_notif_callback((uart_port_t)this->uart_num_,
+        &RatgdoUART::uart_rx_isr_callback);
 
     rmt_tx_channel_config_t tx_chan_config = { };
     tx_chan_config.gpio_num = (gpio_num_t)tx_pin;

--- a/components/ratgdo/ratgdo_uart_esp32.cpp
+++ b/components/ratgdo/ratgdo_uart_esp32.cpp
@@ -2,6 +2,8 @@
 
 #ifdef USE_ESP32
 
+#include "esphome/core/application.h"
+#include "esphome/core/hal.h"
 #include "esphome/core/log.h"
 #include <driver/uart.h>
 
@@ -73,6 +75,11 @@ void RatgdoUART::begin(int baud, RatgdoUARTConfig config, int rx_pin,
     ESP_ERROR_CHECK(
         uart_driver_install((uart_port_t)this->uart_num_, UART_RX_BUFFER_SIZE, 0, 0, NULL, 0));
     ESP_ERROR_CHECK(uart_param_config((uart_port_t)this->uart_num_, &uart_config));
+
+    // Wake the main loop from the UART rx ISR so bytes are consumed on the
+    // next tick instead of waiting for the scheduler.
+    uart_set_select_notif_callback((uart_port_t)this->uart_num_,
+        &RatgdoUART::uart_rx_isr_callback);
 
     rmt_tx_channel_config_t tx_chan_config = { };
     tx_chan_config.gpio_num = (gpio_num_t)tx_pin;
@@ -169,6 +176,14 @@ int RatgdoUART::read()
         return data;
     }
     return -1;
+}
+
+void IRAM_ATTR RatgdoUART::uart_rx_isr_callback(uart_port_t uart_num,
+    uart_select_notif_t uart_select_notif, BaseType_t* task_woken)
+{
+    if (uart_select_notif == UART_SELECT_READ_NOTIF) {
+        App.wake_loop_isrsafe(task_woken);
+    }
 }
 
 void RatgdoUART::on_shutdown()

--- a/components/ratgdo/ratgdo_uart_esp32.cpp
+++ b/components/ratgdo/ratgdo_uart_esp32.cpp
@@ -78,8 +78,8 @@ void RatgdoUART::begin(int baud, RatgdoUARTConfig config, int rx_pin,
 
     // Wake the main loop from the UART rx ISR so bytes are consumed on the
     // next tick instead of waiting for the scheduler.
-    uart_set_select_notif_callback((uart_port_t)this->uart_num_,
-        &RatgdoUART::uart_rx_isr_callback);
+    ESP_ERROR_CHECK(uart_set_select_notif_callback((uart_port_t)this->uart_num_,
+        &RatgdoUART::uart_rx_isr_callback));
 
     rmt_tx_channel_config_t tx_chan_config = { };
     tx_chan_config.gpio_num = (gpio_num_t)tx_pin;
@@ -181,6 +181,7 @@ int RatgdoUART::read()
 void IRAM_ATTR RatgdoUART::uart_rx_isr_callback(uart_port_t uart_num,
     uart_select_notif_t uart_select_notif, BaseType_t* task_woken)
 {
+    (void)uart_num;
     if (uart_select_notif == UART_SELECT_READ_NOTIF) {
         App.wake_loop_isrsafe(task_woken);
     }

--- a/components/ratgdo/ratgdo_uart_esp32.h
+++ b/components/ratgdo/ratgdo_uart_esp32.h
@@ -5,6 +5,8 @@
 #ifdef USE_ESP32
 
 #include <driver/rmt_tx.h>
+#include <driver/uart_select.h>
+#include <freertos/FreeRTOS.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -34,6 +36,9 @@ public:
     void transmit_secplus2_preamble();
 
     void on_shutdown();
+
+    static void uart_rx_isr_callback(uart_port_t uart_num,
+        uart_select_notif_t uart_select_notif, BaseType_t* task_woken);
 
 private:
     // Pointers (4 bytes on 32-bit)

--- a/components/ratgdo/ratgdo_uart_esp32.h
+++ b/components/ratgdo/ratgdo_uart_esp32.h
@@ -5,6 +5,7 @@
 #ifdef USE_ESP32
 
 #include <driver/rmt_tx.h>
+#include <driver/uart.h>
 #include <driver/uart_select.h>
 #include <freertos/FreeRTOS.h>
 #include <stddef.h>

--- a/static/v25board_esp32_d1_mini.yaml
+++ b/static/v25board_esp32_d1_mini.yaml
@@ -17,7 +17,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2026.2.0
+  min_version: 2026.4.0
   project:
     name: ratgdo.v25board_esp32_secplus2
     version: "2.5"

--- a/static/v25board_esp32_d1_mini_secplusv1.yaml
+++ b/static/v25board_esp32_d1_mini_secplusv1.yaml
@@ -17,7 +17,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2026.2.0
+  min_version: 2026.4.0
   project:
     name: ratgdo.v25board_esp32_secplusv1
     version: "2.5"

--- a/static/v2board_esp32_d1_mini.yaml
+++ b/static/v2board_esp32_d1_mini.yaml
@@ -17,7 +17,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2026.2.0
+  min_version: 2026.4.0
   project:
     name: ratgdo.v2board_esp32_d1_mini
     version: "2.0"

--- a/static/v32board.yaml
+++ b/static/v32board.yaml
@@ -18,7 +18,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2026.2.0
+  min_version: 2026.4.0
   project:
     name: ratgdo.v32board_secplus2
     version: "32.0"

--- a/static/v32board_drycontact.yaml
+++ b/static/v32board_drycontact.yaml
@@ -17,7 +17,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2026.2.0
+  min_version: 2026.4.0
   project:
     name: ratgdo.v32board_drycontact
     version: "32.0"

--- a/static/v32board_secplusv1.yaml
+++ b/static/v32board_secplusv1.yaml
@@ -18,7 +18,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2026.2.0
+  min_version: 2026.4.0
   project:
     name: ratgdo.v32board_secplusv1
     version: "32.0"

--- a/static/v32disco.yaml
+++ b/static/v32disco.yaml
@@ -19,7 +19,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2026.2.0
+  min_version: 2026.4.0
   project:
     name: ratgdo.v32disco_secplus2
     version: "32disco"

--- a/static/v32disco_drycontact.yaml
+++ b/static/v32disco_drycontact.yaml
@@ -18,7 +18,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2026.2.0
+  min_version: 2026.4.0
   project:
     name: ratgdo.v32disco_drycontact
     version: "32disco"

--- a/static/v32disco_secplusv1.yaml
+++ b/static/v32disco_secplusv1.yaml
@@ -19,7 +19,7 @@ esphome:
   name: ${id_prefix}
   friendly_name: ${friendly_name}
   name_add_mac_suffix: true
-  min_version: 2026.2.0
+  min_version: 2026.4.0
   project:
     name: ratgdo.v32disco_secplusv1
     version: "32disco"


### PR DESCRIPTION
Today secplus1 and secplus2 only drain the ESP32 UART driver when the ESPHome main loop happens to run. Under load the 512 byte rx ring buffer can fill before we pick bytes up, which shows up as garbled packets and retries.

Register a select notif callback on the ESP-IDF UART driver so an incoming byte notifies the main task directly from the driver ISR via vTaskNotifyGiveFromISR(). Bytes are consumed on the very next tick instead of waiting for the scheduler; less chance of the buffer filling, fewer overruns, more reliable secplus decoding.

Mirrors the pattern already used in esphome/components/uart/uart_component_esp_idf.cpp. task_woken is passed straight through to App.wake_loop_isrsafe(), and the ESP-IDF UART driver handles portYIELD_FROM_ISR at its ISR exit.

Bumps min_version to 2026.4.0 since App.wake_loop_isrsafe() became part of core in that release. Companion to #609 which does the same thing for the ESP8266 softwareserial path.