### PR TITLE
Trigger rtttl finished-playback callback from YAML automation

### DIFF
--- a/components/ratgdo/output/ratgdo_output.cpp
+++ b/components/ratgdo/output/ratgdo_output.cpp
@@ -11,8 +11,6 @@ void RATGDOOutput::setup()
     ESP_LOGD(TAG, "Output was setup");
 
     if (this->output_type_ == OutputType::RATGDO_BEEPER) {
-        this->beeper_->add_on_finished_playback_callback([this] { this->finished_playback(); });
-
 #ifdef RATGDO_USE_VEHICLE_SENSORS
         this->parent_->subscribe_vehicle_arriving_state([this](VehicleArrivingState state) {
             if (state == VehicleArrivingState::YES) {

--- a/static/v32disco.yaml
+++ b/static/v32disco.yaml
@@ -106,6 +106,10 @@ output:
 rtttl:
   - id: ${id_prefix}_rtttl
     output: ${id_prefix}_ledc
+    on_finished_playback:
+      then:
+        lambda: !lambda |-
+          id(${id_prefix}_beeper).finished_playback();
 
 switch:
   - platform: ratgdo

--- a/static/v32disco_drycontact.yaml
+++ b/static/v32disco_drycontact.yaml
@@ -102,6 +102,10 @@ output:
 rtttl:
   - id: ${id_prefix}_rtttl
     output: ${id_prefix}_ledc
+    on_finished_playback:
+      then:
+        lambda: !lambda |-
+          id(${id_prefix}_beeper).finished_playback();
 
 switch:
   - platform: ratgdo

--- a/static/v32disco_secplusv1.yaml
+++ b/static/v32disco_secplusv1.yaml
@@ -103,6 +103,10 @@ output:
 rtttl:
   - id: ${id_prefix}_rtttl
     output: ${id_prefix}_ledc
+    on_finished_playback:
+      then:
+        lambda: !lambda |-
+          id(${id_prefix}_beeper).finished_playback();
 
 switch:
   - platform: ratgdo


### PR DESCRIPTION
## What

Register the rtttl finished-playback callback from YAML instead of from C++ in `RATGDOOutput::setup()`, restoring the v32 disco build on ESPHome 2026.5.0.

## Why

ESPHome 2026.5.0 gates `Rtttl::add_on_finished_playback_callback` behind `USE_RTTTL_FINISHED_PLAYBACK_CALLBACK`, and the rtttl component only sets that define when a `rtttl:` entry configures `on_finished_playback:`. `RATGDOOutput::setup()` was calling the method directly from C++, so the v32 disco beeper build now fails with `'class esphome::rtttl::Rtttl' has no member named 'add_on_finished_playback_callback'`.

## How

- Drop the `add_on_finished_playback_callback` registration from `RATGDOOutput::setup()`; the existing public `RATGDOOutput::finished_playback()` is now the entry point invoked from YAML.
- Add an `on_finished_playback:` automation to the rtttl entry in `v32disco.yaml`, `v32disco_secplusv1.yaml`, and `v32disco_drycontact.yaml`. The automation calls `id(${id_prefix}_beeper).finished_playback()` via lambda, which both flips the define on at compile time and routes completion events back into the existing repeat logic.

The C++ `finished_playback()` body still consults `repeat_`, which is still driven by the `subscribe_door_action_delayed` subscription in `setup()`, so beeper song repeat continues to work unchanged.

## Testing

- `pytest tests/` passes (11 passed).
- `pre-commit run` clean on the touched files.
- Unverified on hardware; needs the operator to flash a v32 disco board and confirm the door-action delay beeper sequence still repeats while the door is moving, and stops on completion.

Closes #627