### PR TITLE
Filter unused protocol sources from the build

### DIFF
--- a/components/ratgdo/__init__.py
+++ b/components/ratgdo/__init__.py
@@ -103,6 +103,23 @@ PROTOCOL_SECPLUSV2 = "secplusv2"
 PROTOCOL_DRYCONTACT = "drycontact"
 SUPPORTED_PROTOCOLS = [PROTOCOL_SECPLUSV1, PROTOCOL_SECPLUSV2, PROTOCOL_DRYCONTACT]
 
+_PROTOCOL_SOURCE_FILES = {
+    PROTOCOL_SECPLUSV1: "secplus1.cpp",
+    PROTOCOL_SECPLUSV2: "secplus2.cpp",
+    PROTOCOL_DRYCONTACT: "dry_contact.cpp",
+}
+
+
+def FILTER_SOURCE_FILES() -> list[str]:
+    """Exclude protocol implementations that are not selected in YAML."""
+    selected = CORE.config.get(DOMAIN, {}).get(CONF_PROTOCOL, PROTOCOL_SECPLUSV2)
+    return [
+        source
+        for protocol, source in _PROTOCOL_SOURCE_FILES.items()
+        if protocol != selected
+    ]
+
+
 CONF_DRY_CONTACT_OPEN_SENSOR = "dry_contact_open_sensor"
 CONF_DRY_CONTACT_CLOSE_SENSOR = "dry_contact_close_sensor"
 CONF_DRY_CONTACT_SENSOR_GROUP = "dry_contact_sensor_group"


### PR DESCRIPTION
## What

Add a `FILTER_SOURCE_FILES` hook to `components/ratgdo/__init__.py` so the two protocol implementations that are not selected in YAML are no longer copied into the build tree.

## Why

Every board YAML picks exactly one protocol (`secplusv1`, `secplusv2`, or `drycontact`) via `cg.add_build_flag`, and each `.cpp` is wrapped in `#ifdef PROTOCOL_*`; the unselected files were still compiled to empty translation units on every build. ESPHome already exposes the standard `FILTER_SOURCE_FILES` hook for this case, it just was not wired up here.

## How

Map each protocol to its source file and return the two non-selected entries from `FILTER_SOURCE_FILES`; the default falls back to `secplusv2`, matching `CONFIG_SCHEMA`.

## Testing

- `pytest tests/ -v`; 11 passed.
- `esphome config` on `v32board.yaml`, `v32board_secplusv1.yaml`, `v32board_drycontact.yaml`; all valid.
- `esphome compile --only-generate` against a local-path YAML for each protocol; confirmed that `.esphome/build/<name>/src/esphome/components/ratgdo/` contains only the selected protocol's `.cpp` (e.g. `secplus2.cpp` only when `protocol: secplusv2`).
- Unverified on hardware; needs the operator to flash a board for each protocol and confirm the door still opens, closes, and reports state.