### PR TITLE
Fix startup sync bug

### DIFF
--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -109,7 +109,7 @@ namespace secplus2 {
             return;
         }
 
-        if (tries == 2 && !synced) { // made a few attempts and no progress
+        if (tries == 2) { // made a few attempts and no progress
             // increment rolling code counter by some amount in case we crashed without writing to flash the latest value
             this->increment_rolling_code_counter(MAX_CODES_WITHOUT_FLASH_WRITE);
         }

--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -109,7 +109,7 @@ namespace secplus2 {
             return;
         }
 
-        if (tries == 2 && *this->ratgdo_->door_state == DoorState::UNKNOWN) { // made a few attempts and no progress (door state is the first sync request)
+        if (tries == 2 && !synced) { // made a few attempts and no progress
             // increment rolling code counter by some amount in case we crashed without writing to flash the latest value
             this->increment_rolling_code_counter(MAX_CODES_WITHOUT_FLASH_WRITE);
         }


### PR DESCRIPTION
increment_rolling_code_counter was never firing because the DoorState is broadcast by the GDO.

Attempt to fix issue #633 