### PR TITLE
feat: enable IPv6 for ESP32 ratgdo boards

### DIFF
--- a/static/v32board_drycontact.yaml
+++ b/static/v32board_drycontact.yaml
@@ -71,6 +71,9 @@ wifi:
   ap:
     ssid: "ratgdo"
 
+network:
+  enable_ipv6: true
+
 captive_portal:
 
 logger:

--- a/static/v32board_secplusv1.yaml
+++ b/static/v32board_secplusv1.yaml
@@ -72,6 +72,9 @@ wifi:
   ap:
     ssid: "ratgdo"
 
+network:
+  enable_ipv6: true
+
 captive_portal:
 
 logger:

--- a/static/v32disco.yaml
+++ b/static/v32disco.yaml
@@ -58,6 +58,9 @@ wifi:
   ap:
     ssid: "ratgdo"
 
+network:
+  enable_ipv6: true
+
 captive_portal:
 
 logger:

--- a/static/v32disco_drycontact.yaml
+++ b/static/v32disco_drycontact.yaml
@@ -56,6 +56,9 @@ esp32_improv:
 wifi:
   ap:
 
+network:
+  enable_ipv6: true
+
 logger:
   logs:
     sensor: NONE

--- a/static/v32disco_secplusv1.yaml
+++ b/static/v32disco_secplusv1.yaml
@@ -57,6 +57,9 @@ esp32_improv:
 wifi:
   ap:
 
+network:
+  enable_ipv6: true
+
 logger:
   logs:
     sensor: NONE


### PR DESCRIPTION
In an effort to make more of my home network IPv6 native or IPv4/IPv6 dual-stack, I recently went through my smart home devices and switched on IPv6.

I noticed that for ESPHome devices with enough system resources this is a simple toggle in the YAML file.

Since I can only test with the v32disco I have, I just enabled it for the v32 devices.

My process:
- Verify lack of IPv6 connectivity to the ratgdo device
- Clone the repo locally
- Update `static/v32disco.yaml` with the `network: enable_ipv6: true` config
- Build the firmware
- Update the firmware via the web UI
- Reboot the device
- Verify IPv6 connectivity
  - `http://ratgdo32disco-2ae4f4.local/` in a web browser resolves to an IPv6 address
  - Adding to HA via DNS name connects via IPv6
  - `ping` and `ping6` give similar latency results

I've been using it for the last 2 months or so without issue and believe this is a meaningful inclusion for most users.

Please let me know if you have any questions or feedback. Happy to make changes.

Thank you!