### PR TITLE
[RFC] Configure inverted obstruction pin logic via platform pin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,23 @@ Most ESP32 boards use the **ESP-IDF** framework. The project originally depended
 The **v3.2 Disco** board uses the Arduino framework because its VL53L4CX distance sensor library and Wire I2C library require it.
 
 ESP8266 boards continue to use the Arduino framework as ESPHome requires it on that platform.
+
+## Troubleshooting
+
+### False obstruction events
+
+Starting with the v32 board series the obstruction sensor input uses circuitry that causes logic levels to be inverted. If the input pins for the obstruction sensor are not configured correctly this can cause misreads on the obstruction sensor in some instances.
+
+This is accounted for in the configurations provided in this repository. However, if you are creating a custom ESPHome configuration you need to ensure that the pin connected to the obstruction sensor is configured with the `mode` set to `INPUT_PULLUP` and the `inverted` flag set to `true` for these newer boards:
+
+```yaml
+ratgdo:
+  input_obst_pin:
+    number: GPIO4
+    mode: INPUT_PULLUP
+    inverted: true
+```
+> [!NOTE]
+> There were revisions in which this behavior was controlled using the `obst_sleep_low` flag on the `ratgdo` entry. This setting has been removed and the abovementioned configuration should be used instead. The example shown above is equivalent to `obst_sleep_low` being set to `false` when used with an ESP32 and `obst_sleep_low` being set to `true` when used with an ESP8266.
+>
+> If you were using `obst_sleep_low` to fix an issue previously, chances are that you don't have to configure anything additionally and you can just drop this setting from your config.

--- a/README.md
+++ b/README.md
@@ -48,19 +48,3 @@ Most ESP32 boards use the **ESP-IDF** framework. The project originally depended
 The **v3.2 Disco** board uses the Arduino framework because its VL53L4CX distance sensor library and Wire I2C library require it.
 
 ESP8266 boards continue to use the Arduino framework as ESPHome requires it on that platform.
-
-## Troubleshooting
-
-### False obstruction events on ESP32 v2.5 boards
-
-Some v2.5 boards using ESP32 D1 Mini controllers may report spurious obstruction events. This is caused by the obstruction sensor "asleep" detection logic being inverted on these boards.
-
-To fix this, add the following to your ESPHome config:
-
-```yaml
-ratgdo:
-  id: ratgdov25
-  obst_sleep_low: true
-```
-
-The `id` must match the `id` of the existing `ratgdo` component in your config (e.g. `ratgdov25` for v2.5 boards). This setting tells the obstruction sensor to treat LOW as the "asleep" state instead of the ESP32 default of HIGH.

--- a/components/ratgdo/__init__.py
+++ b/components/ratgdo/__init__.py
@@ -4,7 +4,13 @@ from esphome import automation, pins
 import esphome.codegen as cg
 from esphome.components import binary_sensor, sensor
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_TRIGGER_ID
+from esphome.const import (
+    CONF_ID,
+    CONF_INVERTED,
+    CONF_MODE,
+    CONF_NUMBER,
+    CONF_TRIGGER_ID,
+)
 from esphome.core import CORE
 from esphome.coroutine import CoroPriority, coroutine_with_priority
 import voluptuous as vol
@@ -100,6 +106,12 @@ DEFAULT_INPUT_GDO = (
 )
 CONF_INPUT_OBST = "input_obst_pin"
 DEFAULT_INPUT_OBST = "D7"  # D7 black obstruction sensor terminal
+# All v32 boards use inverted logic on GPIO4 for the obstruction sensor, so we set that as the default for ESP32 boards.
+DEFAULT_INPUT_OBST_ESP32 = {
+    CONF_NUMBER: "GPIO4",
+    CONF_MODE: "INPUT_PULLUP",
+    CONF_INVERTED: True,
+}
 
 CONF_DISCRETE_OPEN_PIN = "discrete_open_pin"
 CONF_DISCRETE_CLOSE_PIN = "discrete_close_pin"
@@ -201,9 +213,11 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(
                 CONF_INPUT_GDO, default=DEFAULT_INPUT_GDO
             ): pins.gpio_input_pin_schema,
-            cv.Optional(CONF_INPUT_OBST, default=DEFAULT_INPUT_OBST): cv.Any(
-                cv.none, pins.gpio_input_pin_schema
-            ),
+            cv.SplitDefault(
+                CONF_INPUT_OBST,
+                esp32=DEFAULT_INPUT_OBST_ESP32,
+                esp8266=DEFAULT_INPUT_OBST,
+            ): cv.Any(cv.none, pins.gpio_input_pin_schema),
             cv.Optional(CONF_DISCRETE_OPEN_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_DISCRETE_CLOSE_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_ON_SYNC_FAILED): automation.validate_automation(

--- a/components/ratgdo/__init__.py
+++ b/components/ratgdo/__init__.py
@@ -101,8 +101,6 @@ DEFAULT_INPUT_GDO = (
 CONF_INPUT_OBST = "input_obst_pin"
 DEFAULT_INPUT_OBST = "D7"  # D7 black obstruction sensor terminal
 
-CONF_OBST_SLEEP_LOW = "obst_sleep_low"
-
 CONF_DISCRETE_OPEN_PIN = "discrete_open_pin"
 CONF_DISCRETE_CLOSE_PIN = "discrete_close_pin"
 
@@ -206,7 +204,6 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_INPUT_OBST, default=DEFAULT_INPUT_OBST): cv.Any(
                 cv.none, pins.gpio_input_pin_schema
             ),
-            cv.SplitDefault(CONF_OBST_SLEEP_LOW, esp32=False, esp8266=True): cv.boolean,
             cv.Optional(CONF_DISCRETE_OPEN_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_DISCRETE_CLOSE_PIN): pins.gpio_output_pin_schema,
             cv.Optional(CONF_ON_SYNC_FAILED): automation.validate_automation(
@@ -255,8 +252,6 @@ async def to_code(config):
     if config.get(CONF_INPUT_OBST):
         pin = await cg.gpio_pin_expression(config[CONF_INPUT_OBST])
         cg.add(var.set_input_obst_pin(pin))
-
-    cg.add(var.set_obst_sleep_low(config[CONF_OBST_SLEEP_LOW]))
 
     if config.get(CONF_DRY_CONTACT_OPEN_SENSOR):
         dry_contact_open_sensor = await cg.get_variable(

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -83,11 +83,6 @@ void RATGDOComponent::setup()
     this->input_gdo_pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
 
     this->input_obst_pin_->setup();
-#ifdef USE_ESP32
-    this->input_obst_pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
-#else
-    this->input_obst_pin_->pin_mode(gpio::FLAG_INPUT);
-#endif
     this->input_obst_pin_->attach_interrupt(RATGDOStore::isr_obstruction,
         &this->isr_store_,
         gpio::INTERRUPT_FALLING_EDGE);
@@ -605,11 +600,7 @@ void RATGDOComponent::obstruction_loop()
             this->flags_.obstruction_sensor_detected = true;
         } else if (this->isr_store_.obstruction_low_count == 0) {
             // if there have been no pulses the line is steady high or low
-#ifdef USE_ESP32
-            if (this->input_obst_pin_->digital_read()) {
-#else
             if (!this->input_obst_pin_->digital_read()) {
-#endif
                 // asleep
                 last_asleep = current_millis;
             } else {

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -82,6 +82,9 @@ void RATGDOComponent::setup()
     this->input_gdo_pin_->setup();
     this->input_gdo_pin_->pin_mode(gpio::FLAG_INPUT | gpio::FLAG_PULLUP);
 
+    // We rely on the obstruction PIN config being correct in the YAML config to tell us if we need to
+    // invert logic and/or enable the internal pullup on this pin (hence no hard-coded `pin_mode` call here).
+    // This also ensures interrupts automatically consider the correct logic levels for edge detection.
     this->input_obst_pin_->setup();
     this->input_obst_pin_->attach_interrupt(RATGDOStore::isr_obstruction,
         &this->isr_store_,

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -605,7 +605,11 @@ void RATGDOComponent::obstruction_loop()
             this->flags_.obstruction_sensor_detected = true;
         } else if (this->isr_store_.obstruction_low_count == 0) {
             // if there have been no pulses the line is steady high or low
-            if (this->input_obst_pin_->digital_read() != this->flags_.obst_sleep_low) {
+#ifdef USE_ESP32
+            if (this->input_obst_pin_->digital_read()) {
+#else
+            if (!this->input_obst_pin_->digital_read()) {
+#endif
                 // asleep
                 last_asleep = current_millis;
             } else {

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -175,7 +175,6 @@ public:
     void set_output_gdo_pin(InternalGPIOPin* pin) { this->output_gdo_pin_ = pin; }
     void set_input_gdo_pin(InternalGPIOPin* pin) { this->input_gdo_pin_ = pin; }
     void set_input_obst_pin(InternalGPIOPin* pin) { this->input_obst_pin_ = pin; }
-    void set_obst_sleep_low(bool low) { this->flags_.obst_sleep_low = low; }
 
     // dry contact methods
     void set_dry_contact_open_sensor(esphome::binary_sensor::BinarySensor* dry_contact_open_sensor_);
@@ -403,7 +402,6 @@ protected:
     // Bool members packed into bitfield
     struct {
         uint8_t obstruction_sensor_detected : 1;
-        uint8_t obst_sleep_low : 1;
 #ifdef RATGDO_USE_VEHICLE_SENSORS
         uint8_t presence_detect_window_active : 1;
 #endif

--- a/static/customized_examples/v32board_gate_party_mode.yaml
+++ b/static/customized_examples/v32board_gate_party_mode.yaml
@@ -4,7 +4,10 @@ substitutions:
   friendly_name: "ratgdo32"
   uart_tx_pin: GPIO17
   uart_rx_pin: GPIO21
-  input_obst_pin: GPIO4
+  input_obst_pin:
+    number: GPIO4
+    mode: INPUT_PULLUP
+    inverted: true
   dry_contact_open_pin: GPIO13
   dry_contact_close_pin: GPIO14
   discrete_open_pin: GPIO26

--- a/static/v25board_esp32_d1_mini.yaml
+++ b/static/v25board_esp32_d1_mini.yaml
@@ -39,10 +39,6 @@ packages:
   # remote_package: !include
   #   file: base.yaml
 
-ratgdo:
-  id: ${id_prefix}
-  obst_sleep_low: true
-
 # Sync time with Home Assistant.
 time:
   - platform: homeassistant

--- a/static/v32board.yaml
+++ b/static/v32board.yaml
@@ -4,7 +4,10 @@ substitutions:
   friendly_name: "ratgdo32"
   uart_tx_pin: GPIO17
   uart_rx_pin: GPIO21
-  input_obst_pin: GPIO4
+  input_obst_pin:
+    number: GPIO4
+    mode: INPUT_PULLUP
+    inverted: true
   status_door_pin: GPIO26
   status_obstruction_pin: GPIO25
   dry_contact_open_pin: GPIO13

--- a/static/v32board_drycontact.yaml
+++ b/static/v32board_drycontact.yaml
@@ -4,7 +4,10 @@ substitutions:
   friendly_name: "ratgdo32"
   uart_tx_pin: GPIO17
   uart_rx_pin: GPIO21
-  input_obst_pin: GPIO4
+  input_obst_pin:
+    number: GPIO4
+    mode: INPUT_PULLUP
+    inverted: true
   dry_contact_open_pin: GPIO13
   dry_contact_close_pin: GPIO14
   discrete_open_pin: GPIO26

--- a/static/v32board_drycontact_enc.yaml
+++ b/static/v32board_drycontact_enc.yaml
@@ -4,7 +4,10 @@ substitutions:
   friendly_name: "ratgdo32"
   uart_tx_pin: GPIO17
   uart_rx_pin: GPIO21
-  input_obst_pin: GPIO4
+  input_obst_pin:
+    number: GPIO4
+    mode: INPUT_PULLUP
+    inverted: true
   dry_contact_open_pin: GPIO13
   dry_contact_close_pin: GPIO14
   discrete_open_pin: GPIO26

--- a/static/v32board_secplusv1.yaml
+++ b/static/v32board_secplusv1.yaml
@@ -4,7 +4,10 @@ substitutions:
   friendly_name: "ratgdo32"
   uart_tx_pin: GPIO17
   uart_rx_pin: GPIO21
-  input_obst_pin: GPIO4
+  input_obst_pin:
+    number: GPIO4
+    mode: INPUT_PULLUP
+    inverted: true
   status_door_pin: GPIO26
   status_obstruction_pin: GPIO25
   dry_contact_open_pin: GPIO13

--- a/static/v32disco.yaml
+++ b/static/v32disco.yaml
@@ -4,7 +4,10 @@ substitutions:
   friendly_name: "ratgdo32disco"
   uart_tx_pin: GPIO17
   uart_rx_pin: GPIO21
-  input_obst_pin: GPIO4
+  input_obst_pin:
+    number: GPIO4
+    mode: INPUT_PULLUP
+    inverted: true
   status_door_pin: GPIO26
   status_obstruction_pin: GPIO25
   dry_contact_open_pin: GPIO13

--- a/static/v32disco_drycontact.yaml
+++ b/static/v32disco_drycontact.yaml
@@ -4,7 +4,10 @@ substitutions:
   friendly_name: "ratgdo32disco"
   uart_tx_pin: GPIO17
   uart_rx_pin: GPIO21
-  input_obst_pin: GPIO4
+  input_obst_pin:
+    number: GPIO4
+    mode: INPUT_PULLUP
+    inverted: true
   dry_contact_open_pin: GPIO13
   dry_contact_close_pin: GPIO14
   discrete_open_pin: GPIO26

--- a/static/v32disco_drycontact_enc.yaml
+++ b/static/v32disco_drycontact_enc.yaml
@@ -4,7 +4,10 @@ substitutions:
   friendly_name: "ratgdo32disco"
   uart_tx_pin: GPIO17
   uart_rx_pin: GPIO21
-  input_obst_pin: GPIO4
+  input_obst_pin:
+    number: GPIO4
+    mode: INPUT_PULLUP
+    inverted: true
   dry_contact_open_pin: GPIO13
   dry_contact_close_pin: GPIO14
   discrete_open_pin: GPIO26

--- a/static/v32disco_secplusv1.yaml
+++ b/static/v32disco_secplusv1.yaml
@@ -4,7 +4,10 @@ substitutions:
   friendly_name: "ratgdo32disco"
   uart_tx_pin: GPIO17
   uart_rx_pin: GPIO21
-  input_obst_pin: GPIO4
+  input_obst_pin:
+    number: GPIO4
+    mode: INPUT_PULLUP
+    inverted: true
   status_door_pin: GPIO26
   status_obstruction_pin: GPIO25
   dry_contact_open_pin: GPIO13


### PR DESCRIPTION
Looking for some comments here on this alternative suggestion to dealing with inverted logic on the obstruction sensor signal.

This essentially reverts #511 and leaves configuring expected logic states to the platform pin configuration and initialization.

Currently the component code does not allow configuring the obstruction input pin pullup, as it is hardcoded to be enabled on ESP32: https://github.com/ratgdo/esphome-ratgdo/blob/77db677ec0572fcb96fa6b423279f59d6ca8ff41/components/ratgdo/ratgdo.cpp#L87

#511 introduced another logic path and configuration option to work around a difference in board design between revisions. To me it makes more sense to handle these difference declaratively (i.e. in the ESPHome configuration) rather than bending the logic in the code around how board revisions are constructed.
This approach simplifies reasoning over the logic inside the component code and ensures that things such as interrupts and pull-ups/pull-downs behave as intended, as they were not part of #511.

On boards that use the old circuitry (voltage divider instead of MOSFET) on the obstruction sensor input keeping the pullup enabled (even though it is not needed) raises the floating voltage of the pin when the sensor signal is low which can cause misreads.

I tested this code on a board that uses the old voltage divider circuit and an ESP32. I have not tested this with a new v32 board (as I don't have such board), so I would be interested if someone could test this and report back.