### PR TITLE
Security+1 reliability: reliable light toggle, steady readback, and post-reboot bus sync

### DIFF
--- a/components/ratgdo/secplus1.cpp
+++ b/components/ratgdo/secplus1.cpp
@@ -16,6 +16,10 @@ namespace secplus1 {
     using namespace scheduler_ids;
     static const char* const TAG = "ratgdo_secplus1";
     static constexpr uint32_t DOOR_STATE_CALLBACK_TIMEOUT = 2000;
+    // After a light command, ignore polled light status this long so the opener's
+    // reporting latency cannot bounce the reported light state on/off/on while it
+    // settles.
+    static constexpr uint32_t LIGHT_CMD_SUPPRESS_MS = 2000;
 
     void Secplus1::setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin)
     {
@@ -138,6 +142,9 @@ namespace secplus1 {
         }
         if (
             action == LightAction::TOGGLE || (action == LightAction::ON && this->light_state == LightState::OFF) || (action == LightAction::OFF && this->light_state == LightState::ON)) {
+            // Record when the command was issued so QUERY_OTHER_STATUS can
+            // briefly ignore stale readback and not bounce the reported state.
+            this->light_command_at_ = millis();
             this->toggle_light();
         }
     }
@@ -407,7 +414,15 @@ namespace secplus1 {
         } else if (cmd.req == CommandType::QUERY_OTHER_STATUS) {
             LightState light_state = to_LightState((cmd.resp >> 2) & 1, LightState::UNKNOWN);
 
-            if (!this->flags_.is_0x37_panel && light_state != this->maybe_light_state) {
+            if (this->light_command_at_ != 0 && millis() - this->light_command_at_ < LIGHT_CMD_SUPPRESS_MS) {
+                // A light command was just issued and the opener is still
+                // settling. Track the reading but don't apply it, so a stale
+                // pre-command status can't bounce the reported state. The
+                // light_command_at_ != 0 guard keeps this from suppressing
+                // readback during the first seconds after boot (timestamp
+                // starts at 0).
+                this->maybe_light_state = light_state;
+            } else if (!this->flags_.is_0x37_panel && light_state != this->maybe_light_state) {
                 this->maybe_light_state = light_state;
             } else {
                 this->light_state = light_state;

--- a/components/ratgdo/secplus1.cpp
+++ b/components/ratgdo/secplus1.cpp
@@ -20,6 +20,11 @@ namespace secplus1 {
     // reporting latency cannot bounce the reported light state on/off/on while it
     // settles.
     static constexpr uint32_t LIGHT_CMD_SUPPRESS_MS = 2000;
+    // How long the bus must stay silent after boot before we conclude no wall
+    // panel is actively transmitting and allow our first transmit. A present,
+    // running panel is heard within milliseconds, so this only delays the
+    // first command on a silent bus.
+    static constexpr uint32_t BUS_QUIET_GRACE_MS = 2000;
 
     void Secplus1::setup(RATGDOComponent* ratgdo, Scheduler* scheduler, InternalGPIOPin* rx_pin, InternalGPIOPin* tx_pin)
     {
@@ -29,6 +34,10 @@ namespace secplus1 {
         this->rx_pin_ = rx_pin;
 
         this->uart_.begin(1200, RATGDO_UART_8E1, rx_pin->get_pin(), tx_pin->get_pin(), true);
+
+        // Anchor the quiet-bus grace window at listen start so it measures
+        // actual listening time; sync() re-anchors it shortly after.
+        this->wall_panel_emulation_start_ = millis();
 
         this->traits_.set_features(HAS_DOOR_STATUS | HAS_LIGHT_TOGGLE | HAS_LOCK_TOGGLE);
     }
@@ -41,7 +50,13 @@ namespace secplus1 {
         }
         auto tx_cmd = this->pending_tx();
         if (
-            this->last_rx_ != 0 && // after boot, wait until we've heard the wall panel before transmitting, so we slot into the bus instead of colliding with an in-progress message
+            // After boot, wait until we've heard the wall panel before transmitting,
+            // so we slot into the bus instead of colliding with an in-progress
+            // message. If the bus stays silent past the grace period there is no
+            // active panel (none installed, or it is still booting) and it is safe
+            // to transmit — without this, a no-panel setup would hold its first
+            // command until emulation engages (~35s after boot).
+            (this->last_rx_ != 0 || millis() - this->wall_panel_emulation_start_ > BUS_QUIET_GRACE_MS) &&
             (millis() - this->last_tx_) > 200 && // don't send twice in a period
             (millis() - this->last_rx_) > 50 && // time to send it
             tx_cmd && // have pending command
@@ -457,6 +472,13 @@ namespace secplus1 {
     {
         auto cmd = this->pop_pending_tx();
         if (cmd) {
+            if (cmd.value() == CommandType::TOGGLE_LIGHT_PRESS || cmd.value() == CommandType::TOGGLE_LIGHT_RELEASE) {
+                // Key the readback-suppression window to the actual send time of
+                // the last light byte — transmission can lag the request when the
+                // bus is busy, and the window must not expire before the opener
+                // has seen the full press/release sequence.
+                this->light_command_at_ = millis();
+            }
             this->enqueue_command_pair(cmd.value());
             this->transmit_byte(static_cast<uint32_t>(cmd.value()));
         }

--- a/components/ratgdo/secplus1.cpp
+++ b/components/ratgdo/secplus1.cpp
@@ -453,6 +453,13 @@ namespace secplus1 {
         if (cmd == CommandType::TOGGLE_DOOR_PRESS) {
             this->enqueue_transmit(CommandType::TOGGLE_DOOR_RELEASE, now + 500);
         } else if (cmd == CommandType::TOGGLE_LIGHT_PRESS) {
+            // On some Security+1 openers a single light press + single release
+            // (~500ms apart) does not produce a stable toggle: the light flips,
+            // then reverts. The HomeKit ratgdo firmware sends the press followed
+            // by >= 2 releases, and a real wall panel transmits the release state
+            // continuously. Send a second release to match that and get one
+            // reliable toggle.
+            this->enqueue_transmit(CommandType::TOGGLE_LIGHT_RELEASE, now + 250);
             this->enqueue_transmit(CommandType::TOGGLE_LIGHT_RELEASE, now + 500);
         } else if (cmd == CommandType::TOGGLE_LOCK_PRESS) {
             this->enqueue_transmit(CommandType::TOGGLE_LOCK_RELEASE, now + 3500);

--- a/components/ratgdo/secplus1.cpp
+++ b/components/ratgdo/secplus1.cpp
@@ -41,6 +41,7 @@ namespace secplus1 {
         }
         auto tx_cmd = this->pending_tx();
         if (
+            this->last_rx_ != 0 && // after boot, wait until we've heard the wall panel before transmitting, so we slot into the bus instead of colliding with an in-progress message
             (millis() - this->last_tx_) > 200 && // don't send twice in a period
             (millis() - this->last_rx_) > 50 && // time to send it
             tx_cmd && // have pending command

--- a/components/ratgdo/secplus1.cpp
+++ b/components/ratgdo/secplus1.cpp
@@ -56,8 +56,7 @@ namespace secplus1 {
             // active panel (none installed, or it is still booting) and it is safe
             // to transmit — without this, a no-panel setup would hold its first
             // command until emulation engages (~35s after boot).
-            (this->last_rx_ != 0 || millis() - this->wall_panel_emulation_start_ > BUS_QUIET_GRACE_MS) &&
-            (millis() - this->last_tx_) > 200 && // don't send twice in a period
+            (this->last_rx_ != 0 || millis() - this->wall_panel_emulation_start_ > BUS_QUIET_GRACE_MS) && (millis() - this->last_tx_) > 200 && // don't send twice in a period
             (millis() - this->last_rx_) > 50 && // time to send it
             tx_cmd && // have pending command
             !(this->flags_.is_0x37_panel && tx_cmd.value() == CommandType::TOGGLE_LOCK_PRESS) && this->wall_panel_emulation_state_ != WallPanelEmulationState::RUNNING) {

--- a/components/ratgdo/secplus1.h
+++ b/components/ratgdo/secplus1.h
@@ -160,6 +160,7 @@ namespace secplus1 {
         uint32_t last_rx_ { 0 };
         uint32_t last_tx_ { 0 };
         uint32_t last_status_query_ { 0 };
+        uint32_t light_command_at_ { 0 }; // millis() of last light command (readback suppression)
 
         // Larger structures
         std::priority_queue<TxCommand, std::vector<TxCommand>, FirstToSend> pending_tx_;


### PR DESCRIPTION
Three small, related Security+ 1.0 reliability fixes, all in `secplus1`, found and hardware-tested together on a Chamberlain Security+ 1.0 opener with an 889LM-style wall panel (ratgdo32, `v32board_secplusv1`). The commits are independent — take any subset.

## 1. Light toggle nets no change (send a second release)

On some Security+ 1.0 openers, toggling the opener **light** makes it reach the requested state and then **revert ~1–2 s later**, ending unchanged. Reported by several users (e.g. #226, #120, #311).

A device log on an affected opener (one command to turn the light **on** while it was **off**) shows a single press + single release, and the polled `Light state` never changing:

```
Sent byte: [32]      (light press)
Sent byte: [33]      (light release, ~500 ms later)
Light state=OFF      (before AND after — net no change)
```

The current code sends one press + one release ~500 ms apart. The HomeKit ratgdo firmware sends the press followed by **at least two** releases (`set_light` → `sec1_light_release`, `std::max(2, n)`), and a real wall panel transmits the release state continuously. Empirically, a single delayed release does not produce a stable toggle on these openers, while a second release does. The exact opener-side cause isn't established from the logs — this mirrors the proven HomeKit / wall-panel behavior.

## 2. Reported light state bounces on/off/on (suppress stale readback)

Security+ 1.0 has no command ack; light state is learned only by polling `QUERY_OTHER_STATUS`, and there's a ~1 s settle window after a command during which a poll carrying the *old* state bounces the reported state. Record the command time and ignore polled light status for 2 s afterward — record-and-ignore only, it never asserts an unconfirmed state. Only visible once the light actually toggles (fix 1). Gated so it can't suppress readback during the first seconds after boot, and (per review) the window is stamped when the light bytes are **actually transmitted**, not just requested, so a congestion-delayed send can't let it expire early.

## 3. First command after a reboot can collide (wait for wall-panel traffic)

After a reboot the ratgdo joins an already-running bus. Its collision-avoidance keys off `last_rx_`, but that's `0` at boot, so it reads the bus as idle and can inject the first command into the middle of the wall panel's in-progress message, garbling it. Hold transmissions until we've actually heard the panel (`last_rx_ != 0`) — **or** until the bus has stayed silent for 2 s (`BUS_QUIET_GRACE_MS`), at which point no panel is actively transmitting and there is nothing to collide with. A present, running panel is heard within milliseconds, so panel setups key off real traffic; a no-panel setup waits at most ~2 s. *(The first version of this gate held no-panel setups until emulation engaged, ~35 s — caught in review and fixed.)*

## Testing

Hardware-confirmed on a Chamberlain Security+ 1.0 with an 889LM-style wall panel (ratgdo32, `v32board_secplusv1`):

- Fixes 1 + 2: the light now toggles once and stays, and the web UI no longer flickers. Confirmed over repeated toggles.
- Fix 3: addresses a **one-time** light revert seen only on the first command after a reboot (a bus collision before the ratgdo had synced). It's intermittent by nature, so it is reasoned from the boot / `last_rx_` behavior rather than reproduced on demand.
- Review follow-ups (quiet-bus grace, send-time window stamping): compile-verified. The no-panel grace path cannot be exercised on this hardware (a wall panel is present), so it is verified by inspection only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
