### PR TITLE
Track unique entity type validation state in CORE.data

### DIFF
--- a/components/ratgdo/__init__.py
+++ b/components/ratgdo/__init__.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from esphome import automation, pins
 import esphome.codegen as cg
@@ -20,7 +20,7 @@ RATGDO = ratgdo_ns.class_("RATGDOComponent", cg.Component)
 
 @dataclass
 class RATGDOData:
-    """Track observable subscriber counts for compile-time sizing."""
+    """Per-run state: observable subscriber counts and used entity types."""
 
     door_state: int = 0
     door_action_delayed: int = 0
@@ -28,6 +28,7 @@ class RATGDOData:
     vehicle_detected: int = 0
     vehicle_arriving: int = 0
     vehicle_leaving: int = 0
+    used_types: dict[str, set[str]] = field(default_factory=dict)
 
 
 def _get_data() -> RATGDOData:
@@ -58,6 +59,19 @@ def subscribe_vehicle_arriving() -> None:
 
 def subscribe_vehicle_leaving() -> None:
     _get_data().vehicle_leaving += 1
+
+
+def validate_unique(kind: str, value: str, message: str) -> None:
+    """Raise cv.Invalid if (kind, value) was already seen in this validation run.
+
+    State lives in CORE.data (cleared by CORE.reset() between runs) rather than
+    a module-level global, which would leak across validation runs in
+    long-lived processes like the dashboard's `esphome vscode --ace` loop.
+    """
+    used = _get_data().used_types.setdefault(kind, set())
+    if value in used:
+        raise cv.Invalid(message)
+    used.add(value)
 
 
 @coroutine_with_priority(CoroPriority.FINAL)

--- a/components/ratgdo/binary_sensor/__init__.py
+++ b/components/ratgdo/binary_sensor/__init__.py
@@ -2,6 +2,7 @@ import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 from .. import (
     RATGDO_CLIENT_SCHMEA,
@@ -10,12 +11,10 @@ from .. import (
     subscribe_vehicle_arriving,
     subscribe_vehicle_detected,
     subscribe_vehicle_leaving,
+    validate_unique,
 )
 
 DEPENDENCIES = ["ratgdo"]
-
-# Track which sensor types have been used
-USED_TYPES: set[str] = set()
 
 RATGDOBinarySensor = ratgdo_ns.class_(
     "RATGDOBinarySensor", binary_sensor.BinarySensor, cg.Component
@@ -37,12 +36,14 @@ TYPES = {
 VEHICLE_SENSOR_TYPES = {"vehicle_detected", "vehicle_arriving", "vehicle_leaving"}
 
 
-def validate_unique_type(config):
+def validate_unique_type(config: ConfigType) -> ConfigType:
     """Validate that each sensor type is only used once."""
     sensor_type = config[CONF_TYPE]
-    if sensor_type in USED_TYPES:
-        raise cv.Invalid(f"Only one binary sensor of type '{sensor_type}' is allowed")
-    USED_TYPES.add(sensor_type)
+    validate_unique(
+        "binary_sensor",
+        sensor_type,
+        f"Only one binary sensor of type '{sensor_type}' is allowed",
+    )
     return config
 
 

--- a/components/ratgdo/light/__init__.py
+++ b/components/ratgdo/light/__init__.py
@@ -2,25 +2,20 @@ import esphome.codegen as cg
 from esphome.components import light
 import esphome.config_validation as cv
 from esphome.const import CONF_OUTPUT_ID  # New in 2023.5
+from esphome.types import ConfigType
 
-from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child
+from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child, validate_unique
 
 DEPENDENCIES = ["ratgdo"]
-
-# Track if light has been used
-USED_LIGHTS: set[str] = set()
 
 RATGDOLightOutput = ratgdo_ns.class_(
     "RATGDOLightOutput", light.LightOutput, cg.Component
 )
 
 
-def validate_single_light(config):
+def validate_single_light(config: ConfigType) -> ConfigType:
     """Validate that only one RATGDO light is configured."""
-    light_id = "ratgdo_light"
-    if light_id in USED_LIGHTS:
-        raise cv.Invalid("Only one RATGDO light is allowed")
-    USED_LIGHTS.add(light_id)
+    validate_unique("light", "ratgdo_light", "Only one RATGDO light is allowed")
     return config
 
 

--- a/components/ratgdo/lock/__init__.py
+++ b/components/ratgdo/lock/__init__.py
@@ -2,23 +2,18 @@ import esphome.codegen as cg
 from esphome.components import lock
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
-from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child
+from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child, validate_unique
 
 DEPENDENCIES = ["ratgdo"]
-
-# Track if lock has been used
-USED_LOCKS: set[str] = set()
 
 RATGDOLock = ratgdo_ns.class_("RATGDOLock", lock.Lock, cg.Component)
 
 
-def validate_single_lock(config):
+def validate_single_lock(config: ConfigType) -> ConfigType:
     """Validate that only one RATGDO lock is configured."""
-    lock_id = "ratgdo_lock"
-    if lock_id in USED_LOCKS:
-        raise cv.Invalid("Only one RATGDO lock is allowed")
-    USED_LOCKS.add(lock_id)
+    validate_unique("lock", "ratgdo_lock", "Only one RATGDO lock is allowed")
     return config
 
 

--- a/components/ratgdo/number/__init__.py
+++ b/components/ratgdo/number/__init__.py
@@ -2,13 +2,11 @@ import esphome.codegen as cg
 from esphome.components import number
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
-from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child
+from .. import RATGDO_CLIENT_SCHMEA, ratgdo_ns, register_ratgdo_child, validate_unique
 
 DEPENDENCIES = ["ratgdo"]
-
-# Track which number types have been used
-USED_TYPES: set[str] = set()
 
 RATGDONumber = ratgdo_ns.class_("RATGDONumber", number.Number, cg.Component)
 NumberType = ratgdo_ns.enum("NumberType")
@@ -24,12 +22,12 @@ TYPES = {
 }
 
 
-def validate_unique_type(config):
+def validate_unique_type(config: ConfigType) -> ConfigType:
     """Validate that each number type is only used once."""
     number_type = config[CONF_TYPE]
-    if number_type in USED_TYPES:
-        raise cv.Invalid(f"Only one number of type '{number_type}' is allowed")
-    USED_TYPES.add(number_type)
+    validate_unique(
+        "number", number_type, f"Only one number of type '{number_type}' is allowed"
+    )
     return config
 
 

--- a/components/ratgdo/sensor/__init__.py
+++ b/components/ratgdo/sensor/__init__.py
@@ -2,20 +2,19 @@ import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
 from esphome.const import CONF_ID
+from esphome.types import ConfigType
 
 from .. import (
     RATGDO_CLIENT_SCHMEA,
     ratgdo_ns,
     register_ratgdo_child,
     subscribe_distance,
+    validate_unique,
 )
 
 CONF_DISTANCE = "distance"
 
 DEPENDENCIES = ["ratgdo"]
-
-# Track which sensor types have been used
-USED_TYPES: set[str] = set()
 
 RATGDOSensor = ratgdo_ns.class_("RATGDOSensor", sensor.Sensor, cg.Component)
 RATGDOSensorType = ratgdo_ns.enum("RATGDOSensorType")
@@ -33,12 +32,12 @@ TYPES = {
 }
 
 
-def validate_unique_type(config):
+def validate_unique_type(config: ConfigType) -> ConfigType:
     """Validate that each sensor type is only used once."""
     sensor_type = config[CONF_TYPE]
-    if sensor_type in USED_TYPES:
-        raise cv.Invalid(f"Only one sensor of type '{sensor_type}' is allowed")
-    USED_TYPES.add(sensor_type)
+    validate_unique(
+        "sensor", sensor_type, f"Only one sensor of type '{sensor_type}' is allowed"
+    )
     return config
 
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,5 @@
 # Test dependencies
+esphome>=2025.12.0
 pytest>=7.4.0
 pytest-cov>=4.1.0
 pytest-mock>=3.11.0

--- a/tests/components/__init__.py
+++ b/tests/components/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for ESPHome component config validation."""

--- a/tests/components/test_validate_unique.py
+++ b/tests/components/test_validate_unique.py
@@ -8,6 +8,7 @@ then revalidate, so state stored outside CORE.data would raise false
 Regression test for https://github.com/ratgdo/esphome-ratgdo/issues/625.
 """
 
+from collections.abc import Generator
 from pathlib import Path
 import sys
 
@@ -23,32 +24,32 @@ from components.ratgdo import validate_unique  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
-def reset_core():
+def reset_core() -> Generator[None, None, None]:
     """Start and leave each test with clean per-run state."""
     CORE.reset()
     yield
     CORE.reset()
 
 
-def test_duplicate_within_run_raises():
+def test_duplicate_within_run_raises() -> None:
     validate_unique("sensor", "openings", "Only one openings sensor is allowed")
     with pytest.raises(cv.Invalid, match="Only one openings sensor is allowed"):
         validate_unique("sensor", "openings", "Only one openings sensor is allowed")
 
 
-def test_state_does_not_leak_across_runs():
+def test_state_does_not_leak_across_runs() -> None:
     validate_unique("sensor", "openings", "Only one openings sensor is allowed")
     CORE.reset()
     # A new validation run of the same config must pass
     validate_unique("sensor", "openings", "Only one openings sensor is allowed")
 
 
-def test_kinds_are_isolated():
+def test_kinds_are_isolated() -> None:
     # The same type name under different platforms must not collide
     validate_unique("sensor", "openings", "sensor dup")
     validate_unique("binary_sensor", "openings", "binary_sensor dup")
 
 
-def test_different_values_within_run_pass():
+def test_different_values_within_run_pass() -> None:
     validate_unique("sensor", "openings", "dup")
     validate_unique("sensor", "paired_devices_total", "dup")

--- a/tests/components/test_validate_unique.py
+++ b/tests/components/test_validate_unique.py
@@ -1,0 +1,54 @@
+"""Tests for the validate_unique helper in components/ratgdo/__init__.py.
+
+The unique type checks must reject duplicates within a single validation
+run but must not leak state across runs. Long lived processes such as the
+dashboard editor validator (esphome vscode --ace) call CORE.reset() and
+then revalidate, so state stored outside CORE.data would raise false
+"Only one ... is allowed" errors on every validation after the first.
+Regression test for https://github.com/ratgdo/esphome-ratgdo/issues/625.
+"""
+
+from pathlib import Path
+import sys
+
+import pytest
+
+# Add repo root to path so components.ratgdo is importable
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+import esphome.config_validation as cv  # noqa: E402
+from esphome.core import CORE  # noqa: E402
+
+from components.ratgdo import validate_unique  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def reset_core():
+    """Start and leave each test with clean per-run state."""
+    CORE.reset()
+    yield
+    CORE.reset()
+
+
+def test_duplicate_within_run_raises():
+    validate_unique("sensor", "openings", "Only one openings sensor is allowed")
+    with pytest.raises(cv.Invalid, match="Only one openings sensor is allowed"):
+        validate_unique("sensor", "openings", "Only one openings sensor is allowed")
+
+
+def test_state_does_not_leak_across_runs():
+    validate_unique("sensor", "openings", "Only one openings sensor is allowed")
+    CORE.reset()
+    # A new validation run of the same config must pass
+    validate_unique("sensor", "openings", "Only one openings sensor is allowed")
+
+
+def test_kinds_are_isolated():
+    # The same type name under different platforms must not collide
+    validate_unique("sensor", "openings", "sensor dup")
+    validate_unique("binary_sensor", "openings", "binary_sensor dup")
+
+
+def test_different_values_within_run_pass():
+    validate_unique("sensor", "openings", "dup")
+    validate_unique("sensor", "paired_devices_total", "dup")


### PR DESCRIPTION
The unique type checks for sensor, binary sensor, number, lock and light stored their seen types in module level sets that are never cleared. In a long lived validation process like the dashboard editor validator (esphome vscode --ace), the first validation populates the sets and every later validation of a valid config fails with errors like "Only one sensor of type 'openings' is allowed"; a fresh CLI run passes, which is why the reports only show up in the dashboard and Device Builder.

This moves the state into CORE.data, which CORE.reset() clears between runs, using the same RATGDOData pattern already used for subscriber counts. Duplicate types within a single config are still rejected.

Verified by running validate_config twice in one process, mimicking the editor loop; before the change the second run failed, after the change both runs pass, and a config with two openings sensors still errors on both runs.

Fixes #625