### PR TITLE
Core clean-ups: accurate received() logging, secplus2 dead code, reachable UART diagnostic

### DIFF
--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -348,7 +348,7 @@ void RATGDOComponent::received(const ObstructionState obstruction_state)
 {
     if (!this->flags_.obstruction_sensor_detected) {
         ESP_LOGD(TAG, "Obstruction: state=%s",
-            LOG_STR_ARG(ObstructionState_to_string(*this->obstruction_state)));
+            LOG_STR_ARG(ObstructionState_to_string(obstruction_state)));
 
         this->obstruction_state = obstruction_state;
         // This isn't very fast to update, but its still better
@@ -360,21 +360,21 @@ void RATGDOComponent::received(const ObstructionState obstruction_state)
 void RATGDOComponent::received(const MotorState motor_state)
 {
     ESP_LOGD(TAG, "Motor: state=%s",
-        LOG_STR_ARG(MotorState_to_string(*this->motor_state)));
+        LOG_STR_ARG(MotorState_to_string(motor_state)));
     this->motor_state = motor_state;
 }
 
 void RATGDOComponent::received(const ButtonState button_state)
 {
     ESP_LOGD(TAG, "Button state=%s",
-        LOG_STR_ARG(ButtonState_to_string(*this->button_state)));
+        LOG_STR_ARG(ButtonState_to_string(button_state)));
     this->button_state = button_state;
 }
 
 void RATGDOComponent::received(const MotionState motion_state)
 {
     ESP_LOGD(TAG, "Motion: %s",
-        LOG_STR_ARG(MotionState_to_string(*this->motion_state)));
+        LOG_STR_ARG(MotionState_to_string(motion_state)));
     this->motion_state = motion_state;
     if (motion_state == MotionState::DETECTED) {
         this->set_timeout(TIMEOUT_CLEAR_MOTION, 3000,
@@ -586,8 +586,8 @@ void RATGDOComponent::obstruction_loop()
     // are tricky because the voltage drops slowly when falling asleep and is high
     // without pulses when waking up
 
-    // If at least 3 low pulses are counted within 50ms, the door is awake, not
-    // obstructed and we don't have to check anything else
+    // If more than PULSES_LOWER_LIMIT (i.e. 4+) low pulses are counted within
+    // 50ms, the door is awake, not obstructed and we don't have to check anything else
 
     constexpr uint32_t CHECK_PERIOD = 50;
     constexpr uint32_t PULSES_LOWER_LIMIT = 3;

--- a/components/ratgdo/ratgdo_uart_esp32.cpp
+++ b/components/ratgdo/ratgdo_uart_esp32.cpp
@@ -165,8 +165,12 @@ int RatgdoUART::available()
     size_t length = 0;
     uart_get_buffered_data_len((uart_port_t)this->uart_num_, &length);
 
-    if (length >= UART_RX_BUFFER_SIZE) {
-        ESP_LOGD(TAG, "UART buffer overflow detected!");
+    if (length >= UART_RX_BUFFER_SIZE * 3 / 4) {
+        // Warn while nearing capacity. The IDF ring buffer never reports a
+        // completely full length, so the old "== buffer size" check could
+        // never fire. Diagnostic only — no flush, to avoid dropping a valid
+        // in-flight frame.
+        ESP_LOGW(TAG, "UART RX buffer high: %u/%u bytes", (unsigned)length, (unsigned)UART_RX_BUFFER_SIZE);
     }
 
     return length;

--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -399,7 +399,6 @@ namespace secplus2 {
             this->ratgdo_->received(to_DoorState(cmd.nibble, DoorState::UNKNOWN));
             this->ratgdo_->received(to_LightState((cmd.byte2 >> 1) & 1, LightState::UNKNOWN));
             this->ratgdo_->received(to_LockState((cmd.byte2 & 1), LockState::UNKNOWN));
-            // ESP_LOGD(TAG, "Obstruction: reading from byte2, bit2, status=%d", ((byte2 >> 2) & 1) == 1);
             this->ratgdo_->received(to_ObstructionState((cmd.byte1 >> 6) & 1, ObstructionState::UNKNOWN));
             this->ratgdo_->received(to_LearnState((cmd.byte2 >> 5) & 1, LearnState::UNKNOWN));
         } else if (cmd.type == CommandType::LIGHT) {
@@ -466,7 +465,7 @@ namespace secplus2 {
     {
         auto cmd = static_cast<uint64_t>(command.type);
         uint64_t fixed = ((cmd & ~0xff) << 24) | this->client_id_;
-        uint32_t data = (static_cast<uint64_t>(command.byte2) << 24) | (static_cast<uint64_t>(command.byte1) << 16) | (static_cast<uint64_t>(command.nibble) << 8) | (cmd & 0xff);
+        uint32_t data = (static_cast<uint32_t>(command.byte2) << 24) | (static_cast<uint32_t>(command.byte1) << 16) | (static_cast<uint32_t>(command.nibble) << 8) | (static_cast<uint32_t>(cmd) & 0xff);
 
         ESP_LOG2(TAG, "[%ld] Encode for transmit rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, millis(), *this->rolling_code_counter_, fixed, data);
         encode_wireline(*this->rolling_code_counter_, fixed, data, packet);

--- a/components/ratgdo/secplus2.h
+++ b/components/ratgdo/secplus2.h
@@ -186,7 +186,6 @@ namespace secplus2 {
 
         // Small members at the end
         uint16_t rx_byte_count_ { 0 };
-        LearnState learn_state_ { LearnState::UNKNOWN };
         struct {
             uint8_t transmit_pending : 1;
             uint8_t rx_reading_msg : 1;


### PR DESCRIPTION
Small, independent clean-ups found while working on #647 — none change device behavior (one changes a log line's content, one makes a dead diagnostic reachable). Three commits, take any subset:

## 1. `received()` handlers log the previous state, not the incoming one

The obstruction / motor / button / motion handlers log `*this->member` *before* assigning the new value, so every debug line reports the state **before** the transition — e.g. the log says `Motion: CLEAR` at the exact moment motion is detected. Log the incoming argument instead. Also fixes the obstruction pulse-count comment ("at least 3" vs the actual `> 3` check).

## 2. secplus2 dead code / misleading casts / stale comment

- `learn_state_` is declared and initialized but never read or written anywhere.
- `encode_packet()` casts the `data` terms to `uint64_t` and immediately truncates back to `uint32_t`; every term fits in 32 bits. (The `uint64_t` cast on `fixed` is the one that matters and is untouched.)
- A commented-out debug line claims obstruction is read from "byte2, bit2" while the active decode uses `byte1` bit 6 — stale and actively misleading.

## 3. Unreachable UART RX-buffer diagnostic (ESP32)

`available()` warns at `length >= UART_RX_BUFFER_SIZE`, but the IDF ring buffer never reports a completely full length, so the message can never fire. Warn at 3/4 capacity with the actual fill level instead. Deliberately no flush — dropping a valid in-flight frame would be worse than the warning.

## Testing

No functional change intended in any commit. These clean-ups have been running on real hardware (Chamberlain Security+ 1.0, ratgdo32, `v32board_secplusv1`) as part of a private build alongside the #647 fixes, with no anomalies — but since they are diagnostic/dead-code changes, the meaningful verification is review + CI compile across the board matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
