### PR TITLE
Support Hold and Release for TTC (aka automatic closing)

### DIFF
--- a/base.yaml
+++ b/base.yaml
@@ -56,6 +56,7 @@ sensor:
     type: ttc_countdown
     name: "Auto close countdown"
     unit_of_measurement: "s"
+    device_class: duration
     icon: mdi:timer-outline
   - platform: ratgdo
     id: ${id_prefix}_ttc_limit
@@ -63,6 +64,7 @@ sensor:
     entity_category: diagnostic
     name: "Auto close limit"
     unit_of_measurement: "s"
+    device_class: duration
     icon: mdi:timer-cog-outline
   - platform: ratgdo
     id: ${id_prefix}_openings

--- a/base.yaml
+++ b/base.yaml
@@ -52,6 +52,19 @@ ota:
 
 sensor:
   - platform: ratgdo
+    id: ${id_prefix}_ttc_countdown
+    type: ttc_countdown
+    name: "Auto close countdown"
+    unit_of_measurement: "s"
+    icon: mdi:timer-outline
+  - platform: ratgdo
+    id: ${id_prefix}_ttc_limit
+    type: ttc_limit
+    entity_category: diagnostic
+    name: "Auto close limit"
+    unit_of_measurement: "s"
+    icon: mdi:timer-cog-outline
+  - platform: ratgdo
     id: ${id_prefix}_openings
     type: openings
     entity_category: diagnostic
@@ -95,6 +108,11 @@ switch:
     name: "Learn"
     icon: mdi:plus-box
     entity_category: config
+  - platform: ratgdo
+    id: "${id_prefix}_auto_close"
+    type: auto_close
+    name: "Auto close"
+    icon: mdi:timer
 
 binary_sensor:
   - platform: ratgdo

--- a/base_enc.yaml
+++ b/base_enc.yaml
@@ -63,6 +63,21 @@ ota:
 
 sensor:
   - platform: ratgdo
+    id: ${id_prefix}_ttc_countdown
+    type: ttc_countdown
+    name: "Auto close countdown"
+    unit_of_measurement: "s"
+    device_class: duration
+    icon: mdi:timer-outline
+  - platform: ratgdo
+    id: ${id_prefix}_ttc_limit
+    type: ttc_limit
+    entity_category: diagnostic
+    name: "Auto close limit"
+    unit_of_measurement: "s"
+    device_class: duration
+    icon: mdi:timer-cog-outline
+  - platform: ratgdo
     id: ${id_prefix}_encoder
     type: encoder
     name: "Encoder"
@@ -113,6 +128,11 @@ switch:
     name: "Learn"
     icon: mdi:plus-box
     entity_category: config
+  - platform: ratgdo
+    id: "${id_prefix}_auto_close"
+    type: auto_close
+    name: "Auto close"
+    icon: mdi:timer
 
 binary_sensor:
   - platform: ratgdo

--- a/components/ratgdo/protocol.h
+++ b/components/ratgdo/protocol.h
@@ -76,6 +76,8 @@ namespace protocol {
     struct ClearPairedDevices {
         PairedDevice kind;
     };
+    struct TtcToggleHoldTx {
+    };
 
     // a poor man's sum-type, because C++
     SUM_TYPE(Args,
@@ -88,7 +90,8 @@ namespace protocol {
         (InactivateLearn, inactivate_learn),
         (QueryPairedDevices, query_paired_devices),
         (QueryPairedDevicesAll, query_paired_devices_all),
-        (ClearPairedDevices, clear_paired_devices), )
+        (ClearPairedDevices, clear_paired_devices),
+        (TtcToggleHoldTx, ttc_toggle_hold_tx), )
 
     struct RollingCodeCounter {
         single_observable<uint32_t>* value;

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -586,19 +586,7 @@ void RATGDOComponent::received(const TtcCountdown countdown)
 void RATGDOComponent::received(const TtcToggleHold)
 {
     ESP_LOGD(TAG, "TTC_TOGGLE_HOLD observed");
-    if (ttc_is_counting(*this->ttc_state)) {
-        // Wall panel paused the countdown; stop decrementing locally,
-        // cancel the countdown watchdog, and go to HOLDING state.
-        this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
-        this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
-        this->ttc_countdown = 0;
-        this->ttc_state = TtcState::HOLDING;
-    } else if (*this->ttc_state == TtcState::HOLDING) {
-        // Wall panel transmitted toggle TTC to release hold. Restart the local
-        // countdown and refresh the TTC limit from the next countdown broadcast.
-        this->flags_.ttc_limit_learned = false;
-        this->start_or_sync_ttc_countdown(*this->ttc_limit);
-    }
+    this->apply_ttc_toggle();
 }
 
 void RATGDOComponent::received(const BatteryState battery_state)
@@ -1127,14 +1115,24 @@ void RATGDOComponent::ttc_toggle_hold()
 {
     ESP_LOGD(TAG, "Toggle TTC");
     this->protocol_->call(TtcToggleHoldTx { });
+    this->apply_ttc_toggle();
+}
+
+// Shared pause/release state-machine transition for TTC hold, applied
+// whether the toggle was observed on the wire (from the wall panel) or
+// initiated by RATGDO.
+void RATGDOComponent::apply_ttc_toggle()
+{
     if (ttc_is_counting(*this->ttc_state)) {
+        // Pause the countdown: stop decrementing locally, cancel the
+        // countdown watchdog, and go to HOLDING state.
         this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
         this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
         this->ttc_countdown = 0;
         this->ttc_state = TtcState::HOLDING;
     } else if (*this->ttc_state == TtcState::HOLDING) {
-        // We are transmitting toggle TTC to release hold. Restart the local
-        // countdown and refresh the TTC limit from the next countdown broadcast.
+        // Release hold. Restart the local countdown and refresh the TTC
+        // limit from the next countdown broadcast.
         this->flags_.ttc_limit_learned = false;
         this->start_or_sync_ttc_countdown(*this->ttc_limit);
     }

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -586,7 +586,7 @@ void RATGDOComponent::received(const TtcCountdown countdown)
 void RATGDOComponent::received(const TtcToggleHold)
 {
     ESP_LOGD(TAG, "TTC_TOGGLE_HOLD observed");
-    if (*this->ttc_state == TtcState::COUNTING || *this->ttc_state == TtcState::COUNTING_FINISHED) {
+    if (ttc_is_counting(*this->ttc_state)) {
         // Wall panel paused the countdown; stop decrementing locally,
         // cancel the countdown watchdog, and go to HOLDING state.
         this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
@@ -1127,7 +1127,7 @@ void RATGDOComponent::ttc_toggle_hold()
 {
     ESP_LOGD(TAG, "Toggle TTC");
     this->protocol_->call(TtcToggleHoldTx { });
-    if (*this->ttc_state == TtcState::COUNTING || *this->ttc_state == TtcState::COUNTING_FINISHED) {
+    if (ttc_is_counting(*this->ttc_state)) {
         this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
         this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
         this->ttc_countdown = 0;

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -207,6 +207,41 @@ void RATGDOComponent::on_shutdown()
     }
 }
 
+// Common method to start or resynchronize the local TTC countdown.
+//  - sets COUNTING state
+//  - starts (or restarts) the 5s local decrement interval
+//  - starts (or restarts) the 90s countdown watchdog
+// Used both when the countdown is beginning fresh (a release) and when an
+// already-running countdown is being resynced to a fresh broadcast value,
+// so all three call sites behave identically.
+void RATGDOComponent::start_or_sync_ttc_countdown(uint16_t seconds)
+{
+    this->ttc_countdown = seconds;
+    this->ttc_state = TtcState::COUNTING;
+    this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
+    this->set_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG, 90000, [this]() {
+        // Didn't see a TTC_COUNTDOWN broadcast to confirm this within 90
+        // seconds. Assume comms failure and transition to UNKNOWN state.
+        this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
+        this->ttc_countdown = 0;
+        this->ttc_state = TtcState::UNKNOWN;
+    });
+    this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
+    this->set_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT, TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL * 1000, [this]() {
+        uint16_t current = *this->ttc_countdown;
+        if (current > TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL) {
+            this->ttc_countdown = current - TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL;
+        } else {
+            // Local estimate ran out before either a new broadcast or the
+            // watchdog fired. From here we wait for the door close,
+            // or the watchdog timer to fire.
+            this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
+            this->ttc_countdown = 0;
+            this->ttc_state = TtcState::COUNTING_FINISHED;
+        }
+    });
+}
+
 void RATGDOComponent::received(const DoorState door_state)
 {
 #ifdef RATGDO_USE_ENCODER
@@ -535,46 +570,24 @@ void RATGDOComponent::received(const TtcCountdown countdown)
         this->ttc_limit = countdown.seconds;
         this->flags_.ttc_limit_learned = true;
     }
-    this->ttc_countdown = countdown.seconds;
-    this->ttc_state = TtcState::COUNTING;
-    this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
-    this->set_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG, 90000, [this]() {
-        this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
-        this->ttc_countdown = 0;
-        // Was counting down but didn't see a TTC_COUNTDOWN message from the GDO
-        // in 90 seconds. Assume comms failure and transition to UNKNOWN state.
-        this->ttc_state = TtcState::UNKNOWN;
-    });
-    this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
-    this->set_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT, TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL * 1000, [this]() {
-        uint16_t current = *this->ttc_countdown;
-        if (current > TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL) {
-            this->ttc_countdown = current - TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL;
-        } else {
-            // Local estimate ran out before either a new broadcast or the
-            // watchdog fired. From here we wait for the door close,
-            // or the watchdog timer to fire.
-            this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
-            this->ttc_countdown = 0;
-            this->ttc_state = TtcState::COUNTING_FINISHED;
-        }
-    });
+    this->start_or_sync_ttc_countdown(countdown.seconds);
 }
 
 void RATGDOComponent::received(const TtcToggleHold)
 {
     ESP_LOGD(TAG, "TTC_TOGGLE_HOLD observed");
     if (*this->ttc_state == TtcState::COUNTING || *this->ttc_state == TtcState::COUNTING_FINISHED) {
-        // Wall panel paused the countdown; stop decrementing locally instead
-        // of waiting for the 90s watchdog to notice broadcasts stopped.
+        // Wall panel paused the countdown; stop decrementing locally,
+        // cancel the countdown watchdog, and go to HOLDING state.
         this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
         this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
         this->ttc_countdown = 0;
         this->ttc_state = TtcState::HOLDING;
     } else if (*this->ttc_state == TtcState::HOLDING) {
-        // Held countdown is being released; the next countdown broadcast
-        // should be trusted even if it's lower than a stale limit.
+        // Wall panel transmitted toggle TTC to release hold. Restart the local
+        // countdown and refresh the TTC limit from the next countdown broadcast.
         this->flags_.ttc_limit_learned = false;
+        this->start_or_sync_ttc_countdown(*this->ttc_limit);
     }
 }
 
@@ -1110,15 +1123,10 @@ void RATGDOComponent::ttc_toggle_hold()
         this->ttc_countdown = 0;
         this->ttc_state = TtcState::HOLDING;
     } else if (*this->ttc_state == TtcState::HOLDING) {
-        this->ttc_state = TtcState::COUNTING;
+        // We are transmitting toggle TTC to release hold. Restart the local
+        // countdown and refresh the TTC limit from the next countdown broadcast.
         this->flags_.ttc_limit_learned = false;
-        this->set_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG, 90000, [this]() {
-            // Sent TTC_TOGGLE_HOLD while HOLDING, transitioned to COUNTING state,
-            // but then didn't receive TTC_COUNTDOWN from GDO within 90 seconds.
-            // Assume comms failure and transition to UNKNOWN state.
-            this->ttc_countdown = 0;
-            this->ttc_state = TtcState::UNKNOWN;
-        });
+        this->start_or_sync_ttc_countdown(*this->ttc_limit);
     }
 }
 

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -326,6 +326,8 @@ void RATGDOComponent::set_resolved_door_state(const DoorState door_state)
 
     if (door_state == DoorState::OPENING) {
         // door started opening
+        this->flags_.ttc_limit_learned = false; // force relearn ttc_limit from this cycle's broadcasts
+                                                // These can start before OPEN is reached
         if (prev_door_state == DoorState::CLOSING) {
             this->door_position_update();
             this->cancel_position_sync_callbacks();
@@ -382,6 +384,10 @@ void RATGDOComponent::set_resolved_door_state(const DoorState door_state)
     } else if (door_state == DoorState::CLOSED) {
         this->door_position = 0.0;
         this->cancel_position_sync_callbacks();
+        this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
+        this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
+        this->ttc_state = TtcState::UNKNOWN;
+        this->ttc_countdown = 0;
 #ifdef RATGDO_USE_ENCODER
         enc_intended_dir_ = 0; // close intent satisfied
 #endif
@@ -511,9 +517,54 @@ void RATGDOComponent::received(const PairedDeviceCount pdc)
     }
 }
 
-void RATGDOComponent::received(const TimeToClose ttc)
+void RATGDOComponent::received(const TtcLimit limit)
 {
-    ESP_LOGD(TAG, "Time to close (TTC): %ds", ttc.seconds);
+    ESP_LOGD(TAG, "Time to close (TTC) limit: %ds", limit.seconds);
+    this->ttc_limit = limit.seconds;
+    this->flags_.ttc_limit_learned = true;
+}
+
+void RATGDOComponent::received(const TtcCountdown countdown)
+{
+    ESP_LOGD(TAG, "TTC countdown broadcast: %ds remaining", countdown.seconds);
+    // First countdown broadcast of a cycle is highest count, so it tells us the limit.
+    // Or if this countdown is larger than our saved limit, we know our limit needs to be updated.
+    auto ds = *this->door_state;
+    if ((!this->flags_.ttc_limit_learned && (ds == DoorState::OPENING || ds == DoorState::OPEN))
+        || countdown.seconds > *this->ttc_limit) {
+        this->ttc_limit = countdown.seconds;
+        this->flags_.ttc_limit_learned = true;
+    }
+    this->ttc_countdown = countdown.seconds;
+    this->ttc_state = TtcState::COUNTING;
+    this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
+    this->set_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG, 90000, [this]() {
+        this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
+        this->ttc_countdown = 0;
+        this->ttc_state = TtcState::HOLDING;
+    });
+    this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
+    this->set_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT, TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL * 1000, [this]() {
+        uint16_t current = *this->ttc_countdown;
+        this->ttc_countdown = current > TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL ? current - TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL : 0;
+    });
+}
+
+void RATGDOComponent::received(const TtcToggleHold)
+{
+    ESP_LOGD(TAG, "TTC_TOGGLE_HOLD observed");
+    if (*this->ttc_state == TtcState::COUNTING) {
+        // Wall panel paused the countdown; stop decrementing locally instead
+        // of waiting for the 90s watchdog to notice broadcasts stopped.
+        this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
+        this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
+        this->ttc_countdown = 0;
+        this->ttc_state = TtcState::HOLDING;
+    } else if (*this->ttc_state == TtcState::HOLDING) {
+        // Held countdown is being released; the next countdown broadcast
+        // should be trusted even if it's lower than a stale limit.
+        this->flags_.ttc_limit_learned = false;
+    }
 }
 
 void RATGDOComponent::received(const BatteryState battery_state)
@@ -1036,6 +1087,25 @@ void RATGDOComponent::lock_toggle()
 {
     this->lock_state = lock_state_toggle(*this->lock_state);
     this->protocol_->lock_action(LockAction::TOGGLE);
+}
+
+void RATGDOComponent::ttc_toggle_hold()
+{
+    ESP_LOGD(TAG, "Toggle TTC");
+    this->protocol_->call(TtcToggleHoldTx { });
+    if (*this->ttc_state == TtcState::COUNTING) {
+        this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
+        this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
+        this->ttc_countdown = 0;
+        this->ttc_state = TtcState::HOLDING;
+    } else if (*this->ttc_state == TtcState::HOLDING) {
+        this->ttc_state = TtcState::COUNTING;
+        this->flags_.ttc_limit_learned = false;
+        this->set_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG, 90000, [this]() {
+            this->ttc_countdown = 0;
+            this->ttc_state = TtcState::HOLDING;
+        });
+    }
 }
 
 // Learn functions

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -373,6 +373,7 @@ void RATGDOComponent::set_resolved_door_state(const DoorState door_state)
         // door started opening
         this->flags_.ttc_limit_learned = false; // force relearn ttc_limit from this cycle's broadcasts
                                                 // These can start before OPEN is reached
+        this->reset_ttc_state();
         if (prev_door_state == DoorState::CLOSING) {
             this->door_position_update();
             this->cancel_position_sync_callbacks();
@@ -391,6 +392,7 @@ void RATGDOComponent::set_resolved_door_state(const DoorState door_state)
         }
     } else if (door_state == DoorState::CLOSING) {
         // door started closing
+        this->reset_ttc_state();
         if (prev_door_state == DoorState::OPENING) {
             this->door_position_update();
             this->cancel_position_sync_callbacks();
@@ -408,6 +410,7 @@ void RATGDOComponent::set_resolved_door_state(const DoorState door_state)
                 this->schedule_door_position_sync();
         }
     } else if (door_state == DoorState::STOPPED) {
+        this->reset_ttc_state();
 #ifdef RATGDO_USE_ENCODER
         if (encoder_sensor_ == nullptr)
 #endif
@@ -429,10 +432,7 @@ void RATGDOComponent::set_resolved_door_state(const DoorState door_state)
     } else if (door_state == DoorState::CLOSED) {
         this->door_position = 0.0;
         this->cancel_position_sync_callbacks();
-        this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
-        this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
-        this->ttc_state = TtcState::UNKNOWN;
-        this->ttc_countdown = 0;
+        this->reset_ttc_state();
 #ifdef RATGDO_USE_ENCODER
         enc_intended_dir_ = 0; // close intent satisfied
 #endif
@@ -1162,6 +1162,17 @@ void RATGDOComponent::apply_ttc_toggle()
         this->flags_.ttc_limit_learned = false;
         this->start_or_sync_ttc_countdown(*this->ttc_limit);
     }
+}
+
+// Resets local TTC state to UNKNOWN and cancels its timers.
+// TTC only runs while the door is fully open, so this is called
+// for all other states.
+void RATGDOComponent::reset_ttc_state()
+{
+    this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
+    this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
+    this->ttc_state = TtcState::UNKNOWN;
+    this->ttc_countdown = 0;
 }
 
 // Learn functions

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -214,14 +214,24 @@ void RATGDOComponent::on_shutdown()
 // Used both when the countdown is beginning fresh (a release) and when an
 // already-running countdown is being resynced to a fresh broadcast value,
 // so all three call sites behave identically.
+//
+// The watchdog's purpose is to handle comms failures. It needs to be long
+// enough that normal timing differences between the GDO and local countdown
+// don't set it off accidentally, but short enough that comms failures are
+// quickly and safely detected. The GDO nominally transmits TTC_COUNTDOWN
+// messages every minute, but in testing these were spaced 63 seconds apart.
+// Setting the watchdog to 90 seconds (TTC_COUNTDOWN_WATCHDOG_TIMEOUT)
+// allows 30 seconds of margin beyond the expected countdown message interval,
+// which is ten times larger than the 3 second variation observed in testing.
+//
 void RATGDOComponent::start_or_sync_ttc_countdown(uint16_t seconds)
 {
     this->ttc_countdown = seconds;
     this->ttc_state = TtcState::COUNTING;
     this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
-    this->set_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG, 90000, [this]() {
-        // Didn't see a TTC_COUNTDOWN broadcast to confirm this within 90
-        // seconds. Assume comms failure and transition to UNKNOWN state.
+    this->set_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG, TTC_COUNTDOWN_WATCHDOG_TIMEOUT * 1000, [this]() {
+        // Didn't see a TTC_COUNTDOWN broadcast within TTC_COUNTDOWN_WATCHDOG_TIMEOUT (90) seconds.
+        // Assume comms failure and transition to UNKNOWN state.
         this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
         this->ttc_countdown = 0;
         this->ttc_state = TtcState::UNKNOWN;

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -541,19 +541,30 @@ void RATGDOComponent::received(const TtcCountdown countdown)
     this->set_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG, 90000, [this]() {
         this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
         this->ttc_countdown = 0;
-        this->ttc_state = TtcState::HOLDING;
+        // Was counting down but didn't see a TTC_COUNTDOWN message from the GDO
+        // in 90 seconds. Assume comms failure and transition to UNKNOWN state.
+        this->ttc_state = TtcState::UNKNOWN;
     });
     this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
     this->set_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT, TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL * 1000, [this]() {
         uint16_t current = *this->ttc_countdown;
-        this->ttc_countdown = current > TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL ? current - TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL : 0;
+        if (current > TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL) {
+            this->ttc_countdown = current - TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL;
+        } else {
+            // Local estimate ran out before either a new broadcast or the
+            // watchdog fired. From here we wait for the door close,
+            // or the watchdog timer to fire.
+            this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
+            this->ttc_countdown = 0;
+            this->ttc_state = TtcState::COUNTING_FINISHED;
+        }
     });
 }
 
 void RATGDOComponent::received(const TtcToggleHold)
 {
     ESP_LOGD(TAG, "TTC_TOGGLE_HOLD observed");
-    if (*this->ttc_state == TtcState::COUNTING) {
+    if (*this->ttc_state == TtcState::COUNTING || *this->ttc_state == TtcState::COUNTING_FINISHED) {
         // Wall panel paused the countdown; stop decrementing locally instead
         // of waiting for the 90s watchdog to notice broadcasts stopped.
         this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
@@ -1093,7 +1104,7 @@ void RATGDOComponent::ttc_toggle_hold()
 {
     ESP_LOGD(TAG, "Toggle TTC");
     this->protocol_->call(TtcToggleHoldTx { });
-    if (*this->ttc_state == TtcState::COUNTING) {
+    if (*this->ttc_state == TtcState::COUNTING || *this->ttc_state == TtcState::COUNTING_FINISHED) {
         this->cancel_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG);
         this->cancel_interval(scheduler_ids::TTC_COUNTDOWN_LOCAL_DECREMENT);
         this->ttc_countdown = 0;
@@ -1102,8 +1113,11 @@ void RATGDOComponent::ttc_toggle_hold()
         this->ttc_state = TtcState::COUNTING;
         this->flags_.ttc_limit_learned = false;
         this->set_timeout(scheduler_ids::TTC_COUNTDOWN_WATCHDOG, 90000, [this]() {
+            // Sent TTC_TOGGLE_HOLD while HOLDING, transitioned to COUNTING state,
+            // but then didn't receive TTC_COUNTDOWN from GDO within 90 seconds.
+            // Assume comms failure and transition to UNKNOWN state.
             this->ttc_countdown = 0;
-            this->ttc_state = TtcState::HOLDING;
+            this->ttc_state = TtcState::UNKNOWN;
         });
     }
 }

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -1113,6 +1113,12 @@ void RATGDOComponent::lock_toggle()
 
 void RATGDOComponent::ttc_toggle_hold()
 {
+    if (ttc_is_unknown(*this->ttc_state)) {
+        // Don't transmit while we haven't observed any TTC activity on the
+        // wire this cycle: we can't meaningfully pause or resume something
+        // we have no confirmed state for.
+        return;
+    }
     ESP_LOGD(TAG, "Toggle TTC");
     this->protocol_->call(TtcToggleHoldTx { });
     this->apply_ttc_toggle();

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -562,6 +562,28 @@ void RATGDOComponent::received(const PairedDeviceCount pdc)
     }
 }
 
+// The TTC_SET_LIMIT message is only transmitted by the wall control
+// when the user is changing the limit. So it might only ever be
+// transmitted one time when the GDO is installed. Therefore it might
+// seem hard to determine the ttc_limit. However, the ttc limit can
+// be inferred from the TTC_COUNTDOWN messages, because the first
+// TTC_COUNTDOWN broadcast of a cycle is equal to the configured
+// ttc_limit.
+//
+// So RATGDO captures and remembers the first TTC_COUNTDOWN value
+// after a door open (or release) as the ttc_limit value.
+// Alternatively, if a TTC_COUNTDOWN message contains a value larger
+// than the currently saved ttc_limit, then the saved ttc_limit must
+// be out of date, and it is updated accordingly.
+//
+// NOTE: The value of ttc_limit is only stored in RAM, so it is lost
+// during a reboot. If a reboot happens in the middle of a ttc
+// countdown, there's no way to know the true limit value (the limit
+// may have changed while ratgdo was offline). The logic described
+// above will incorrectly capture a too-small limit for this
+// cycle. This is acceptable because it self-corrects on the very next
+// release or door-open cycle, both of which set ttc_limit_learned=false
+// and let a fresh broadcast capture the real value.
 void RATGDOComponent::received(const TtcLimit limit)
 {
     ESP_LOGD(TAG, "Time to close (TTC) limit: %ds", limit.seconds);
@@ -572,8 +594,6 @@ void RATGDOComponent::received(const TtcLimit limit)
 void RATGDOComponent::received(const TtcCountdown countdown)
 {
     ESP_LOGD(TAG, "TTC countdown broadcast: %ds remaining", countdown.seconds);
-    // First countdown broadcast of a cycle is highest count, so it tells us the limit.
-    // Or if this countdown is larger than our saved limit, we know our limit needs to be updated.
     auto ds = *this->door_state;
     if ((!this->flags_.ttc_limit_learned && (ds == DoorState::OPENING || ds == DoorState::OPEN))
         || countdown.seconds > *this->ttc_limit) {

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -272,6 +272,7 @@ public:
 
     // TTC (time-to-close)
     void ttc_toggle_hold();
+    void start_or_sync_ttc_countdown(uint16_t seconds);
 
     // Learn & Paired
     void activate_learn();

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -169,6 +169,13 @@ public:
     single_observable<ButtonState> button_state { ButtonState::UNKNOWN };
     single_observable<MotionState> motion_state { MotionState::UNKNOWN };
     single_observable<LearnState> learn_state { LearnState::UNKNOWN };
+
+    single_observable<TtcState> ttc_state { TtcState::UNKNOWN };
+    single_observable<uint16_t> ttc_countdown { 0 };
+    single_observable<uint16_t> ttc_limit { 0 };
+
+    static constexpr uint16_t TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL = 5;
+
 #ifdef RATGDO_USE_VEHICLE_SENSORS
     observable<VehicleDetectedState, RATGDO_MAX_VEHICLE_DETECTED_SUBSCRIBERS> vehicle_detected_state { VehicleDetectedState::NO };
     observable<VehicleArrivingState, RATGDO_MAX_VEHICLE_ARRIVING_SUBSCRIBERS> vehicle_arriving_state { VehicleArrivingState::NO };
@@ -219,7 +226,9 @@ public:
     void received(const MotionState motion_state);
     void received(const LearnState light_state);
     void received(const Openings openings);
-    void received(const TimeToClose ttc);
+    void received(const TtcLimit limit);
+    void received(const TtcCountdown countdown);
+    void received(const TtcToggleHold toggle_hold);
     void received(const PairedDeviceCount pdc);
     void received(const BatteryState pdc);
 
@@ -260,6 +269,9 @@ public:
     void lock_toggle();
     void lock();
     void unlock();
+
+    // TTC (time-to-close)
+    void ttc_toggle_hold();
 
     // Learn & Paired
     void activate_learn();
@@ -389,6 +401,12 @@ public:
     template <typename F>
     void subscribe_learn_state(F&& f);
     template <typename F>
+    void subscribe_ttc_state(F&& f);
+    template <typename F>
+    void subscribe_ttc_countdown(F&& f);
+    template <typename F>
+    void subscribe_ttc_limit(F&& f);
+    template <typename F>
     void subscribe_door_action_delayed(F&& f);
 #ifdef RATGDO_USE_DISTANCE_SENSOR
     template <typename F>
@@ -419,6 +437,7 @@ protected:
     struct {
         uint8_t obstruction_sensor_detected : 1;
         uint8_t obst_sleep_low : 1;
+        uint8_t ttc_limit_learned : 1; // whether ttc_limit reflects the current open cycle
 #ifdef RATGDO_USE_VEHICLE_SENSORS
         uint8_t presence_detect_window_active : 1;
 #endif
@@ -542,6 +561,9 @@ namespace scheduler_ids {
         DEFER_BUTTON_STATE,
         DEFER_MOTION_STATE,
         DEFER_LEARN_STATE,
+        DEFER_TTC_STATE,
+        DEFER_TTC_COUNTDOWN,
+        DEFER_TTC_LIMIT,
 
         // Named timeout IDs (replacing string-based names)
         TIMEOUT_DOOR_QUERY_STATE,
@@ -558,6 +580,8 @@ namespace scheduler_ids {
         TIMEOUT_SYNC,
         INTERVAL_STATUS_WATCHDOG,
         TIMEOUT_ENCODER_STOPPED,
+        TTC_COUNTDOWN_WATCHDOG,
+        TTC_COUNTDOWN_LOCAL_DECREMENT,
     };
 } // namespace scheduler_ids
 
@@ -737,6 +761,30 @@ void RATGDOComponent::subscribe_learn_state(F&& f)
 {
     this->learn_state.subscribe([this, f](LearnState state) {
         defer(scheduler_ids::DEFER_LEARN_STATE, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_ttc_state(F&& f)
+{
+    this->ttc_state.subscribe([this, f](TtcState state) {
+        defer(scheduler_ids::DEFER_TTC_STATE, [f, state] { f(state); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_ttc_countdown(F&& f)
+{
+    this->ttc_countdown.subscribe([this, f](uint16_t seconds) {
+        defer(scheduler_ids::DEFER_TTC_COUNTDOWN, [f, seconds] { f(seconds); });
+    });
+}
+
+template <typename F>
+void RATGDOComponent::subscribe_ttc_limit(F&& f)
+{
+    this->ttc_limit.subscribe([this, f](uint16_t seconds) {
+        defer(scheduler_ids::DEFER_TTC_LIMIT, [f, seconds] { f(seconds); });
     });
 }
 

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -175,6 +175,7 @@ public:
     single_observable<uint16_t> ttc_limit { 0 };
 
     static constexpr uint16_t TTC_COUNTDOWN_LOCAL_DECREMENT_INTERVAL = 5;
+    static constexpr uint16_t TTC_COUNTDOWN_WATCHDOG_TIMEOUT = 90; // for explanation, see start_or_sync_ttc_countdown()
 
 #ifdef RATGDO_USE_VEHICLE_SENSORS
     observable<VehicleDetectedState, RATGDO_MAX_VEHICLE_DETECTED_SUBSCRIBERS> vehicle_detected_state { VehicleDetectedState::NO };

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -274,6 +274,7 @@ public:
     // TTC (time-to-close)
     void ttc_toggle_hold();
     void start_or_sync_ttc_countdown(uint16_t seconds);
+    void apply_ttc_toggle();
 
     // Learn & Paired
     void activate_learn();

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -275,6 +275,7 @@ public:
     void ttc_toggle_hold();
     void start_or_sync_ttc_countdown(uint16_t seconds);
     void apply_ttc_toggle();
+    void reset_ttc_state();
 
     // Learn & Paired
     void activate_learn();

--- a/components/ratgdo/ratgdo_state.h
+++ b/components/ratgdo/ratgdo_state.h
@@ -136,8 +136,20 @@ struct PairedDeviceCount {
     uint8_t count;
 };
 
-struct TimeToClose {
+struct TtcLimit {
     uint16_t seconds;
 };
+
+struct TtcCountdown {
+    uint16_t seconds;
+};
+
+struct TtcToggleHold {
+};
+
+ENUM(TtcState, uint8_t,
+    (UNKNOWN, 0),
+    (COUNTING, 1),
+    (HOLDING, 2))
 
 } // namespace esphome::ratgdo

--- a/components/ratgdo/ratgdo_state.h
+++ b/components/ratgdo/ratgdo_state.h
@@ -150,6 +150,7 @@ struct TtcToggleHold {
 ENUM(TtcState, uint8_t,
     (UNKNOWN, 0),
     (COUNTING, 1),
-    (HOLDING, 2))
+    (COUNTING_FINISHED, 2),
+    (HOLDING, 3))
 
 } // namespace esphome::ratgdo

--- a/components/ratgdo/ratgdo_state.h
+++ b/components/ratgdo/ratgdo_state.h
@@ -153,4 +153,16 @@ ENUM(TtcState, uint8_t,
     (COUNTING_FINISHED, 2),
     (HOLDING, 3))
 
+// True before any TTC activity has been observed on the wire this cycle.
+inline constexpr bool ttc_is_unknown(TtcState state)
+{
+    return state == TtcState::UNKNOWN;
+}
+
+// True when counting down or just finished
+inline constexpr bool ttc_is_counting(TtcState state)
+{
+    return state == TtcState::COUNTING || state == TtcState::COUNTING_FINISHED;
+}
+
 } // namespace esphome::ratgdo

--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -196,6 +196,8 @@ namespace secplus2 {
             this->activate_learn();
         } else if (args.tag == Tag::inactivate_learn) {
             this->inactivate_learn();
+        } else if (args.tag == Tag::ttc_toggle_hold_tx) {
+            this->send_command(Command { CommandType::TTC_TOGGLE_HOLD, 1, 4, 0 });
         }
         return { };
     }
@@ -413,8 +415,12 @@ namespace secplus2 {
             this->ratgdo_->received(MotionState::DETECTED);
         } else if (cmd.type == CommandType::OPENINGS) {
             this->ratgdo_->received(Openings { static_cast<uint16_t>((cmd.byte1 << 8) | cmd.byte2), cmd.nibble });
-        } else if (cmd.type == CommandType::SET_TTC) {
-            this->ratgdo_->received(TimeToClose { static_cast<uint16_t>((cmd.byte1 << 8) | cmd.byte2) });
+        } else if (cmd.type == CommandType::TTC_SET_LIMIT) {
+            this->ratgdo_->received(TtcLimit { static_cast<uint16_t>((cmd.byte1 << 8) | cmd.byte2) });
+        } else if (cmd.type == CommandType::TTC_TOGGLE_HOLD) {
+            this->ratgdo_->received(TtcToggleHold { });
+        } else if (cmd.type == CommandType::TTC_COUNTDOWN) {
+            this->ratgdo_->received(TtcCountdown { static_cast<uint16_t>((cmd.byte1 << 8) | cmd.byte2) });
         } else if (cmd.type == CommandType::PAIRED_DEVICES) {
             PairedDeviceCount pdc;
             pdc.kind = to_PairedDevice(cmd.nibble, PairedDevice::UNKNOWN);

--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -197,6 +197,11 @@ namespace secplus2 {
         } else if (args.tag == Tag::inactivate_learn) {
             this->inactivate_learn();
         } else if (args.tag == Tag::ttc_toggle_hold_tx) {
+            // The "HOLD" and "REL" (release) buttons on an 880LM wall control were
+            // pressed repeatedly, and the resulting messages were captured from the wire
+            // as log messages in ratgdo's web console. The same message was observed
+            // for both the HOLD and REL-ease functions. Therefore it's a toggle function.
+            // nibble=1, byte1=4, byte2=0: These values were determined empirically.
             this->send_command(Command { CommandType::TTC_TOGGLE_HOLD, 1, 4, 0 });
         }
         return { };

--- a/components/ratgdo/secplus2.h
+++ b/components/ratgdo/secplus2.h
@@ -57,9 +57,9 @@ namespace secplus2 {
 
         (PAIR_2, 0x400),
         (PAIR_2_RESP, 0x401),
-        (SET_TTC, 0x402), // ttc_in_seconds = (byte1<<8)+byte2
-        (CANCEL_TTC, 0x408), // ?
-        (TTC, 0x40a), // Time to close
+        (TTC_SET_LIMIT, 0x402), // Command to set TTC in seconds => (byte1<<8)+byte2
+        (TTC_TOGGLE_HOLD, 0x408), // Toggles TTC countdown between *hold* & *release*
+        (TTC_COUNTDOWN, 0x40a), // Periodic countdown broadcast message (sent every 60 seconds) while TTC counting down
         (GET_OPENINGS, 0x48b),
         (OPENINGS, 0x48c), // openings = (byte1<<8)+byte2
     )

--- a/components/ratgdo/sensor/__init__.py
+++ b/components/ratgdo/sensor/__init__.py
@@ -29,6 +29,8 @@ TYPES = {
     "paired_devices_accessories": RATGDOSensorType.RATGDO_PAIRED_ACCESSORIES,
     "distance": RATGDOSensorType.RATGDO_DISTANCE,
     "encoder": RATGDOSensorType.RATGDO_ENCODER,
+    "ttc_countdown": RATGDOSensorType.RATGDO_TTC_COUNTDOWN,  # only meaningful with protocol: secplusv2
+    "ttc_limit": RATGDOSensorType.RATGDO_TTC_LIMIT,  # only meaningful with protocol: secplusv2
 }
 
 

--- a/components/ratgdo/sensor/ratgdo_sensor.cpp
+++ b/components/ratgdo/sensor/ratgdo_sensor.cpp
@@ -43,15 +43,16 @@ void RATGDOSensor::setup()
         break;
     case RATGDOSensorType::RATGDO_DISTANCE:
 #ifdef RATGDO_USE_DISTANCE_SENSOR
-        this->distance_sensor_.setI2cDevice(&I2C);
-        this->distance_sensor_.setXShutPin(32);
+        this->distance_sensor_ = new VL53L4CX();
+        this->distance_sensor_->setI2cDevice(&I2C);
+        this->distance_sensor_->setXShutPin(32);
         // I2C.begin(17,16);
         I2C.begin(19, 18);
-        this->distance_sensor_.begin();
-        this->distance_sensor_.VL53L4CX_Off();
-        this->distance_sensor_.InitSensor(0x59);
-        this->distance_sensor_.VL53L4CX_SetDistanceMode(VL53L4CX_DISTANCEMODE_LONG);
-        this->distance_sensor_.VL53L4CX_StartMeasurement();
+        this->distance_sensor_->begin();
+        this->distance_sensor_->VL53L4CX_Off();
+        this->distance_sensor_->InitSensor(0x59);
+        this->distance_sensor_->VL53L4CX_SetDistanceMode(VL53L4CX_DISTANCEMODE_LONG);
+        this->distance_sensor_->VL53L4CX_StartMeasurement();
         this->parent_->subscribe_distance_measurement([this](int16_t value) {
             this->publish_state(value);
         });
@@ -111,8 +112,8 @@ void RATGDOSensor::loop()
         int16_t maxDistance = -1;
         int status;
 
-        if (this->distance_sensor_.VL53L4CX_GetMeasurementDataReady(&dataReady) == 0 && dataReady) {
-            status = this->distance_sensor_.VL53L4CX_GetMultiRangingData(pDistanceData);
+        if (this->distance_sensor_->VL53L4CX_GetMeasurementDataReady(&dataReady) == 0 && dataReady) {
+            status = this->distance_sensor_->VL53L4CX_GetMultiRangingData(pDistanceData);
             objCount = pDistanceData->NumberOfObjectsFound;
 
             for (int i = 0; i < distanceData.NumberOfObjectsFound; i++) {
@@ -138,7 +139,7 @@ void RATGDOSensor::loop()
             // ESP_LOGD(TAG,"# obj found %d; distance %d",objCount, maxDistance);
 
             if (status == 0) {
-                status = this->distance_sensor_.VL53L4CX_ClearInterruptAndStartMeasurement();
+                status = this->distance_sensor_->VL53L4CX_ClearInterruptAndStartMeasurement();
             }
         }
     }

--- a/components/ratgdo/sensor/ratgdo_sensor.cpp
+++ b/components/ratgdo/sensor/ratgdo_sensor.cpp
@@ -63,6 +63,16 @@ void RATGDOSensor::setup()
         this->parent_->set_encoder_sensor(this);
 #endif
         break;
+    case RATGDOSensorType::RATGDO_TTC_COUNTDOWN:
+        this->parent_->subscribe_ttc_countdown([this](uint16_t seconds) {
+            this->publish_state(seconds);
+        });
+        break;
+    case RATGDOSensorType::RATGDO_TTC_LIMIT:
+        this->parent_->subscribe_ttc_limit([this](uint16_t seconds) {
+            this->publish_state(seconds);
+        });
+        break;
     default:
         break;
     }
@@ -95,6 +105,12 @@ void RATGDOSensor::dump_config()
         break;
     case RATGDOSensorType::RATGDO_ENCODER:
         ESP_LOGCONFIG(TAG, "  Type: Encoder");
+        break;
+    case RATGDOSensorType::RATGDO_TTC_COUNTDOWN:
+        ESP_LOGCONFIG(TAG, "  Type: TTC Countdown");
+        break;
+    case RATGDOSensorType::RATGDO_TTC_LIMIT:
+        ESP_LOGCONFIG(TAG, "  Type: TTC Limit");
         break;
     default:
         break;

--- a/components/ratgdo/sensor/ratgdo_sensor.h
+++ b/components/ratgdo/sensor/ratgdo_sensor.h
@@ -23,6 +23,8 @@ enum RATGDOSensorType : uint8_t {
     RATGDO_PAIRED_ACCESSORIES,
     RATGDO_DISTANCE,
     RATGDO_ENCODER,
+    RATGDO_TTC_COUNTDOWN,
+    RATGDO_TTC_LIMIT,
 };
 
 class RATGDOSensor : public sensor::Sensor, public RATGDOClient, public Component {

--- a/components/ratgdo/sensor/ratgdo_sensor.h
+++ b/components/ratgdo/sensor/ratgdo_sensor.h
@@ -38,7 +38,7 @@ protected:
     RATGDOSensorType ratgdo_sensor_type_;
 
 #ifdef RATGDO_USE_DISTANCE_SENSOR
-    VL53L4CX distance_sensor_;
+    VL53L4CX* distance_sensor_ { nullptr };
 #endif
 };
 

--- a/components/ratgdo/switch/__init__.py
+++ b/components/ratgdo/switch/__init__.py
@@ -21,6 +21,7 @@ TYPES = {
     "learn": SwitchType.RATGDO_LEARN,
     "led": SwitchType.RATGDO_LED,
     "reverse_encoder": SwitchType.RATGDO_REVERSE_ENCODER,
+    "auto_close": SwitchType.RATGDO_AUTO_CLOSE,  # only meaningful with protocol: secplusv2
 }
 
 

--- a/components/ratgdo/switch/ratgdo_switch.cpp
+++ b/components/ratgdo/switch/ratgdo_switch.cpp
@@ -58,7 +58,7 @@ void RATGDOSwitch::setup()
 #endif
     case SwitchType::RATGDO_AUTO_CLOSE:
         this->parent_->subscribe_ttc_state([this](TtcState state) {
-            this->publish_state(state == TtcState::COUNTING);
+            this->publish_state(state == TtcState::COUNTING || state == TtcState::COUNTING_FINISHED);
         });
         break;
     default:

--- a/components/ratgdo/switch/ratgdo_switch.cpp
+++ b/components/ratgdo/switch/ratgdo_switch.cpp
@@ -93,6 +93,9 @@ void RATGDOSwitch::write_state(bool state)
 #endif
     case SwitchType::RATGDO_AUTO_CLOSE:
         if (*this->parent_->ttc_state == TtcState::UNKNOWN) {
+            // no publish_state() here because doing so would make the switch
+            // "available" and we don't want it to be available unless
+            // we see TTC messages on the wire first.
             return;
         }
         this->parent_->ttc_toggle_hold();

--- a/components/ratgdo/switch/ratgdo_switch.cpp
+++ b/components/ratgdo/switch/ratgdo_switch.cpp
@@ -92,12 +92,11 @@ void RATGDOSwitch::write_state(bool state)
         break;
 #endif
     case SwitchType::RATGDO_AUTO_CLOSE:
-        if (ttc_is_unknown(*this->parent_->ttc_state)) {
-            // no publish_state() here because doing so would make the switch
-            // "available" and we don't want it to be available unless
-            // we see TTC messages on the wire first.
-            return;
-        }
+        // NOTE: No publish_state() call here: The auto_close switch's
+        // published state comes entirely from the subscribe_ttc_state()
+        // callback, not from write_state(). ttc_toggle_hold() guards
+        // against being called while ttc_state is UNKNOWN itself, so
+        // that doesn't need checking here either.
         if (state != ttc_is_counting(*this->parent_->ttc_state)) {
             // The user interface is a switch, but the message protocol
             // is toggle. So only send a ttc toggle message if the state

--- a/components/ratgdo/switch/ratgdo_switch.cpp
+++ b/components/ratgdo/switch/ratgdo_switch.cpp
@@ -19,6 +19,9 @@ void RATGDOSwitch::dump_config()
     case SwitchType::RATGDO_REVERSE_ENCODER:
         ESP_LOGCONFIG(TAG, "  Type: Reverse Encoder");
         break;
+    case SwitchType::RATGDO_AUTO_CLOSE:
+        ESP_LOGCONFIG(TAG, "  Type: Auto Close");
+        break;
     default:
         break;
     }
@@ -53,6 +56,11 @@ void RATGDOSwitch::setup()
         }
         break;
 #endif
+    case SwitchType::RATGDO_AUTO_CLOSE:
+        this->parent_->subscribe_ttc_state([this](TtcState state) {
+            this->publish_state(state == TtcState::COUNTING);
+        });
+        break;
     default:
         break;
     }
@@ -83,6 +91,12 @@ void RATGDOSwitch::write_state(bool state)
         this->publish_state(state);
         break;
 #endif
+    case SwitchType::RATGDO_AUTO_CLOSE:
+        if (*this->parent_->ttc_state == TtcState::UNKNOWN) {
+            return;
+        }
+        this->parent_->ttc_toggle_hold();
+        break;
     default:
         break;
     }

--- a/components/ratgdo/switch/ratgdo_switch.cpp
+++ b/components/ratgdo/switch/ratgdo_switch.cpp
@@ -58,7 +58,7 @@ void RATGDOSwitch::setup()
 #endif
     case SwitchType::RATGDO_AUTO_CLOSE:
         this->parent_->subscribe_ttc_state([this](TtcState state) {
-            this->publish_state(state == TtcState::COUNTING || state == TtcState::COUNTING_FINISHED);
+            this->publish_state(ttc_is_counting(state));
         });
         break;
     default:
@@ -92,13 +92,18 @@ void RATGDOSwitch::write_state(bool state)
         break;
 #endif
     case SwitchType::RATGDO_AUTO_CLOSE:
-        if (*this->parent_->ttc_state == TtcState::UNKNOWN) {
+        if (ttc_is_unknown(*this->parent_->ttc_state)) {
             // no publish_state() here because doing so would make the switch
             // "available" and we don't want it to be available unless
             // we see TTC messages on the wire first.
             return;
         }
-        this->parent_->ttc_toggle_hold();
+        if (state != ttc_is_counting(*this->parent_->ttc_state)) {
+            // The user interface is a switch, but the message protocol
+            // is toggle. So only send a ttc toggle message if the state
+            // really needs to change.
+            this->parent_->ttc_toggle_hold();
+        }
         break;
     default:
         break;

--- a/components/ratgdo/switch/ratgdo_switch.h
+++ b/components/ratgdo/switch/ratgdo_switch.h
@@ -13,6 +13,7 @@ enum SwitchType {
     RATGDO_LEARN,
     RATGDO_LED,
     RATGDO_REVERSE_ENCODER,
+    RATGDO_AUTO_CLOSE,
 };
 
 class RATGDOSwitch : public switch_::Switch, public RATGDOClient, public Component {


### PR DESCRIPTION
## What

Allows "Hold" and "Release" of the TTC (Time To Close) feature from RATGDO or a Home Assistant (HA) dashboard. This implements an "Auto close" switch to pause/resume the countdown, and "Auto close countdown" / "Auto close limit" sensors. TTC is sometimes called auto close and is supported in certain Security+ 2.0 GDOs.

## Why

I want to control TTC hold/release from RATGDO and Home Assistant, just as I can from my wall-mounted control, plus have visibility into the countdown timer and time limit.

SAFETY: In this PR, TTC cannot be configured from RATGDO; only the wall control can perform these functions, since an accidental low value (e.g. 5 seconds) would be risky. The auto_close switch shows as unavailable until the first TTC activity is observed on the wire after boot; after that first observation it always reflects a real on/off state.

## How

Receives and decodes TTC_SET_LIMIT, TTC_TOGGLE_HOLD, and TTC_COUNTDOWN on the wire, following the existing dispatch pattern. Transmits TTC_TOGGLE_HOLD to enable or disable the TTC countdown, but only if a countdown already started. Maintains local countdown state: UNKNOWN, COUNTING, HOLDING.

A local countdown ticks down every 5s between the opener's ~60s broadcasts and resyncs on each one; a 90s watchdog stops the countdown if broadcasts stop arriving. The limit is inferred from the wire (an explicit TTC_SET_LIMIT, the first broadcast of each door-open cycle, or any later broadcast that's larger).

Wall-panel-initiated commands for hold/release and setting/enabling the limit are handled so that RATGDO is functionally a peer of the wall control for hold and release.

These features are only available for protocol: secplusv2.

## Testing

`esphome config` validated cleanly across every board YAML in the repo. `pytest tests/ -v` passes (15/15).

Flashed to three v2.5i boards (Raynor Aviator II openers, 880LM wall controls) and exercised hold, release, countdown, and limit behavior on real doors over a week of soak testing, including through Home Assistant. Spousal testing passed.

NOTE: My GDO's countdown broadcasts are actually transmitted about 63 seconds apart in time, but they declare that only 60 seconds has elapsed. Thus my GDO countdown runs a little slower than real time. To prevent divergence between the GDO and RATGDO, the RATGDO accepts and resynchronizes to each new countdown broadcast as received.

Drafted with Claude Sonnet 5; reviewed/edited by webbzell (Chip Webb).

