### PR TITLE
Persist a per-firmware ccache across CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,12 +144,35 @@ jobs:
           echo ""
           echo "Changes made:"
           git diff --color=always
+      - name: Point ccache at a cached dir
+        # Exported via GITHUB_ENV so $HOME expands; the build action
+        # forwards CCACHE_DIR into its container, and the path sits
+        # inside the container's $HOME bind mount. esphome enables
+        # ccache automatically when the binary is on PATH (in the
+        # image base already): native ESP-IDF esp32 from the next
+        # release, esp8266 via esphome/esphome#17722.
+        run: echo "CCACHE_DIR=$HOME/.cache/esphome-ccache" >> "$GITHUB_ENV"
+      - name: Cache ccache objects
+        # Rolling key: restored from the newest prior entry for this
+        # firmware on every run, saved fresh each run.
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/esphome-ccache
+          key: ccache-${{ matrix.firmware.file }}-${{ github.run_id }}
+          restore-keys: |
+            ccache-${{ matrix.firmware.file }}-
       - name: Build firmware
         uses: ratgdo/esphome-build-action@main
         id: esphome-build
         with:
           yaml-file: ${{ matrix.firmware.file }}
           version: latest
+      - name: Show ccache usage
+        # The host runner has no ccache binary; size + object count is
+        # the cheap stand-in for ccache -s.
+        run: |
+          du -sh "$HOME/.cache/esphome-ccache" 2>/dev/null || echo "ccache dir empty (esphome version predates ccache support)"
+          find "$HOME/.cache/esphome-ccache" -type f 2>/dev/null | wc -l
       - name: Copy firmware and manifest
         run: |
           mkdir output

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,9 +149,12 @@ jobs:
         # forwards CCACHE_DIR into its container, and the path sits
         # inside the container's $HOME bind mount. esphome enables
         # ccache automatically when the binary is on PATH (in the
-        # image base already): native ESP-IDF esp32 from the next
-        # release, esp8266 via esphome/esphome#17722.
-        run: echo "CCACHE_DIR=$HOME/.cache/esphome-ccache" >> "$GITHUB_ENV"
+        # image base already): native ESP-IDF esp32 today, esp8266
+        # once esphome/esphome#17722 ships. mkdir keeps the cache
+        # save from warning on boards that leave the dir unused.
+        run: |
+          echo "CCACHE_DIR=$HOME/.cache/esphome-ccache" >> "$GITHUB_ENV"
+          mkdir -p "$HOME/.cache/esphome-ccache"
       - name: Cache ccache objects
         # Rolling key: restored from the newest prior entry for this
         # firmware on every run, saved fresh each run.


### PR DESCRIPTION
Companion to ratgdo/esphome-build-action#16, which forwards CCACHE_DIR into the build container. Each of the 26 matrix jobs points ccache at a dir under HOME (inside the container's bind mount) and persists it with a per-firmware rolling cache key, restored from the newest prior entry on every run and saved fresh each run; roughly 26 entries around 50 MB each cycle under the 10 GB LRU quota, and pip is the only other cache user here.

Active now for the esp32 boards: esphome 2026.7.0 enables ccache for native ESP-IDF builds whenever the binary is on PATH, and it already ships in the image base. The esp8266 boards are unaffected until esphome/esphome#17722 lands in a release; their dir is created up front so the cache save stays quiet.

Measured on this PR, cold seed run versus warm rerun of the Build firmware step:

| Firmware | Cold | Warm |
|---|---|---|
| V32 Board Security+ 2.0 (esp32) | 296s | 148s |
| V32 Dry Contact (esp32) | 281s | 142s |
| ESP32 D1 Mini (esp32) | 280s | 162s |
| V2.5i (esp8266, control) | 160s | 148s |

Same mechanism on esphome-device-builder's native IDF CI job went 90s to 33s.
