### PR TITLE
Give the distance sensor its own subclass to save RAM

### DIFF
--- a/components/ratgdo/sensor/__init__.py
+++ b/components/ratgdo/sensor/__init__.py
@@ -17,6 +17,7 @@ CONF_DISTANCE = "distance"
 DEPENDENCIES = ["ratgdo"]
 
 RATGDOSensor = ratgdo_ns.class_("RATGDOSensor", sensor.Sensor, cg.Component)
+RATGDODistanceSensor = ratgdo_ns.class_("RATGDODistanceSensor", RATGDOSensor)
 RATGDOSensorType = ratgdo_ns.enum("RATGDOSensorType")
 
 CONF_TYPE = "type"
@@ -41,6 +42,13 @@ def validate_unique_type(config: ConfigType) -> ConfigType:
     return config
 
 
+def _select_sensor_class(config: ConfigType) -> ConfigType:
+    """Override the ID type for the distance sensor, which needs its own class/storage."""
+    if config[CONF_TYPE] == CONF_DISTANCE:
+        config[CONF_ID].type = RATGDODistanceSensor
+    return config
+
+
 CONFIG_SCHEMA = cv.All(
     sensor.sensor_schema(RATGDOSensor)
     .extend(
@@ -50,6 +58,7 @@ CONFIG_SCHEMA = cv.All(
     )
     .extend(RATGDO_CLIENT_SCHMEA),
     validate_unique_type,
+    _select_sensor_class,
 )
 
 

--- a/components/ratgdo/sensor/ratgdo_distance_sensor.cpp
+++ b/components/ratgdo/sensor/ratgdo_distance_sensor.cpp
@@ -1,0 +1,77 @@
+#include "ratgdo_distance_sensor.h"
+
+#ifdef RATGDO_USE_DISTANCE_SENSOR
+#include "esphome/core/log.h"
+
+namespace esphome::ratgdo {
+
+static const char* const TAG = "ratgdo.sensor";
+static const int MIN_DISTANCE = 100; // ignore bugs crawling on the distance sensor & dust protection film
+static const int MAX_DISTANCE = 4500; // default maximum distance
+
+void RATGDODistanceSensor::setup()
+{
+    this->distance_sensor_.setI2cDevice(&I2C);
+    this->distance_sensor_.setXShutPin(32);
+    // I2C.begin(17,16);
+    I2C.begin(19, 18);
+    this->distance_sensor_.begin();
+    this->distance_sensor_.VL53L4CX_Off();
+    this->distance_sensor_.InitSensor(0x59);
+    this->distance_sensor_.VL53L4CX_SetDistanceMode(VL53L4CX_DISTANCEMODE_LONG);
+    this->distance_sensor_.VL53L4CX_StartMeasurement();
+    this->parent_->subscribe_distance_measurement([this](int16_t value) {
+        this->publish_state(value);
+    });
+}
+
+void RATGDODistanceSensor::dump_config()
+{
+    RATGDOSensor::dump_config();
+    ESP_LOGCONFIG(TAG, "  Type: Distance");
+}
+
+void RATGDODistanceSensor::loop()
+{
+    VL53L4CX_MultiRangingData_t distanceData;
+    VL53L4CX_MultiRangingData_t* pDistanceData = &distanceData;
+    uint8_t dataReady = 0;
+    int objCount = 0;
+    int16_t maxDistance = -1;
+    int status;
+
+    if (this->distance_sensor_.VL53L4CX_GetMeasurementDataReady(&dataReady) == 0 && dataReady) {
+        status = this->distance_sensor_.VL53L4CX_GetMultiRangingData(pDistanceData);
+        objCount = pDistanceData->NumberOfObjectsFound;
+
+        for (int i = 0; i < distanceData.NumberOfObjectsFound; i++) {
+            VL53L4CX_TargetRangeData_t* d = &pDistanceData->RangeData[i];
+            if (d->RangeStatus == 0) {
+                maxDistance = std::max(maxDistance, d->RangeMilliMeter);
+                maxDistance = maxDistance <= MIN_DISTANCE ? -1 : maxDistance;
+            }
+        }
+
+        if (maxDistance < 0)
+            maxDistance = MAX_DISTANCE;
+
+        // maxDistance = objCount == 0 ? -1 : pDistanceData->RangeData[objCount - 1].RangeMilliMeter;
+        /*
+         * if the sensor is pointed at glass, there are many error -1 readings which will fill the
+         * vector with out of range data. The sensor should be sensitive enough to detect the floor
+         * in most situations, but daylight and/or really high ceilings can cause long distance
+         * measurements to be out of range.
+         */
+        this->parent_->set_distance_measurement(maxDistance);
+
+        // ESP_LOGD(TAG,"# obj found %d; distance %d",objCount, maxDistance);
+
+        if (status == 0) {
+            status = this->distance_sensor_.VL53L4CX_ClearInterruptAndStartMeasurement();
+        }
+    }
+}
+
+} // namespace esphome::ratgdo
+
+#endif

--- a/components/ratgdo/sensor/ratgdo_distance_sensor.h
+++ b/components/ratgdo/sensor/ratgdo_distance_sensor.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "ratgdo_sensor.h"
+
+#ifdef RATGDO_USE_DISTANCE_SENSOR
+#include "Wire.h"
+#include "vl53l4cx_class.h"
+#define I2C Wire
+
+namespace esphome::ratgdo {
+
+class RATGDODistanceSensor : public RATGDOSensor {
+public:
+    void dump_config() override;
+    void setup() override;
+    void loop() override;
+
+protected:
+    VL53L4CX distance_sensor_;
+};
+
+} // namespace esphome::ratgdo
+
+#endif

--- a/components/ratgdo/sensor/ratgdo_sensor.cpp
+++ b/components/ratgdo/sensor/ratgdo_sensor.cpp
@@ -43,15 +43,16 @@ void RATGDOSensor::setup()
         break;
     case RATGDOSensorType::RATGDO_DISTANCE:
 #ifdef RATGDO_USE_DISTANCE_SENSOR
-        this->distance_sensor_.setI2cDevice(&I2C);
-        this->distance_sensor_.setXShutPin(32);
+        this->distance_sensor_ = new VL53L4CX();
+        this->distance_sensor_->setI2cDevice(&I2C);
+        this->distance_sensor_->setXShutPin(32);
         // I2C.begin(17,16);
         I2C.begin(19, 18);
-        this->distance_sensor_.begin();
-        this->distance_sensor_.VL53L4CX_Off();
-        this->distance_sensor_.InitSensor(0x59);
-        this->distance_sensor_.VL53L4CX_SetDistanceMode(VL53L4CX_DISTANCEMODE_LONG);
-        this->distance_sensor_.VL53L4CX_StartMeasurement();
+        this->distance_sensor_->begin();
+        this->distance_sensor_->VL53L4CX_Off();
+        this->distance_sensor_->InitSensor(0x59);
+        this->distance_sensor_->VL53L4CX_SetDistanceMode(VL53L4CX_DISTANCEMODE_LONG);
+        this->distance_sensor_->VL53L4CX_StartMeasurement();
         this->parent_->subscribe_distance_measurement([this](int16_t value) {
             this->publish_state(value);
         });
@@ -111,8 +112,8 @@ void RATGDOSensor::loop()
         int16_t maxDistance = -1;
         int status;
 
-        if (this->distance_sensor_.VL53L4CX_GetMeasurementDataReady(&dataReady) == 0 && dataReady) {
-            status = this->distance_sensor_.VL53L4CX_GetMultiRangingData(pDistanceData);
+        if (this->distance_sensor_->VL53L4CX_GetMeasurementDataReady(&dataReady) == 0 && dataReady) {
+            status = this->distance_sensor_->VL53L4CX_GetMultiRangingData(pDistanceData);
             objCount = pDistanceData->NumberOfObjectsFound;
 
             for (int i = 0; i < distanceData.NumberOfObjectsFound; i++) {
@@ -138,7 +139,7 @@ void RATGDOSensor::loop()
             // ESP_LOGD(TAG,"# obj found %d; distance %d",objCount, maxDistance);
 
             if (status == 0) {
-                status = this->distance_sensor_.VL53L4CX_ClearInterruptAndStartMeasurement();
+                status = this->distance_sensor_->VL53L4CX_ClearInterruptAndStartMeasurement();
             }
         }
     }

--- a/components/ratgdo/sensor/ratgdo_sensor.cpp
+++ b/components/ratgdo/sensor/ratgdo_sensor.cpp
@@ -5,8 +5,6 @@
 namespace esphome::ratgdo {
 
 static const char* const TAG = "ratgdo.sensor";
-static const int MIN_DISTANCE = 100; // ignore bugs crawling on the distance sensor & dust protection film
-static const int MAX_DISTANCE = 4500; // default maximum distance
 
 void RATGDOSensor::setup()
 {
@@ -41,23 +39,6 @@ void RATGDOSensor::setup()
             this->publish_state(value);
         });
         break;
-    case RATGDOSensorType::RATGDO_DISTANCE:
-#ifdef RATGDO_USE_DISTANCE_SENSOR
-        this->distance_sensor_ = new VL53L4CX();
-        this->distance_sensor_->setI2cDevice(&I2C);
-        this->distance_sensor_->setXShutPin(32);
-        // I2C.begin(17,16);
-        I2C.begin(19, 18);
-        this->distance_sensor_->begin();
-        this->distance_sensor_->VL53L4CX_Off();
-        this->distance_sensor_->InitSensor(0x59);
-        this->distance_sensor_->VL53L4CX_SetDistanceMode(VL53L4CX_DISTANCEMODE_LONG);
-        this->distance_sensor_->VL53L4CX_StartMeasurement();
-        this->parent_->subscribe_distance_measurement([this](int16_t value) {
-            this->publish_state(value);
-        });
-#endif
-        break;
     case RATGDOSensorType::RATGDO_ENCODER:
 #ifdef RATGDO_USE_ENCODER
         this->parent_->set_encoder_sensor(this);
@@ -90,9 +71,6 @@ void RATGDOSensor::dump_config()
     case RATGDOSensorType::RATGDO_PAIRED_ACCESSORIES:
         ESP_LOGCONFIG(TAG, "  Type: Paired Accessories");
         break;
-    case RATGDOSensorType::RATGDO_DISTANCE:
-        ESP_LOGCONFIG(TAG, "  Type: Distance");
-        break;
     case RATGDOSensorType::RATGDO_ENCODER:
         ESP_LOGCONFIG(TAG, "  Type: Encoder");
         break;
@@ -100,50 +78,5 @@ void RATGDOSensor::dump_config()
         break;
     }
 }
-
-#ifdef RATGDO_USE_DISTANCE_SENSOR
-void RATGDOSensor::loop()
-{
-    if (this->ratgdo_sensor_type_ == RATGDOSensorType::RATGDO_DISTANCE) {
-        VL53L4CX_MultiRangingData_t distanceData;
-        VL53L4CX_MultiRangingData_t* pDistanceData = &distanceData;
-        uint8_t dataReady = 0;
-        int objCount = 0;
-        int16_t maxDistance = -1;
-        int status;
-
-        if (this->distance_sensor_->VL53L4CX_GetMeasurementDataReady(&dataReady) == 0 && dataReady) {
-            status = this->distance_sensor_->VL53L4CX_GetMultiRangingData(pDistanceData);
-            objCount = pDistanceData->NumberOfObjectsFound;
-
-            for (int i = 0; i < distanceData.NumberOfObjectsFound; i++) {
-                VL53L4CX_TargetRangeData_t* d = &pDistanceData->RangeData[i];
-                if (d->RangeStatus == 0) {
-                    maxDistance = std::max(maxDistance, d->RangeMilliMeter);
-                    maxDistance = maxDistance <= MIN_DISTANCE ? -1 : maxDistance;
-                }
-            }
-
-            if (maxDistance < 0)
-                maxDistance = MAX_DISTANCE;
-
-            // maxDistance = objCount == 0 ? -1 : pDistanceData->RangeData[objCount - 1].RangeMilliMeter;
-            /*
-             * if the sensor is pointed at glass, there are many error -1 readings which will fill the
-             * vector with out of range data. The sensor should be sensitive enough to detect the floor
-             * in most situations, but daylight and/or really high ceilings can cause long distance
-             * measurements to be out of range.
-             */
-            this->parent_->set_distance_measurement(maxDistance);
-
-            // ESP_LOGD(TAG,"# obj found %d; distance %d",objCount, maxDistance);
-
-            if (status == 0) {
-                status = this->distance_sensor_->VL53L4CX_ClearInterruptAndStartMeasurement();
-            }
-        }
-    }
-}
-#endif
 
 } // namespace esphome::ratgdo

--- a/components/ratgdo/sensor/ratgdo_sensor.h
+++ b/components/ratgdo/sensor/ratgdo_sensor.h
@@ -6,12 +6,6 @@
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
 
-#ifdef RATGDO_USE_DISTANCE_SENSOR
-#include "Wire.h"
-#include "vl53l4cx_class.h"
-#define I2C Wire
-#endif
-
 namespace esphome::ratgdo {
 
 enum RATGDOSensorType : uint8_t {
@@ -29,17 +23,10 @@ class RATGDOSensor : public sensor::Sensor, public RATGDOClient, public Componen
 public:
     void dump_config() override;
     void setup() override;
-#ifdef RATGDO_USE_DISTANCE_SENSOR
-    void loop() override;
-#endif
     void set_ratgdo_sensor_type(RATGDOSensorType ratgdo_sensor_type_) { this->ratgdo_sensor_type_ = ratgdo_sensor_type_; }
 
 protected:
     RATGDOSensorType ratgdo_sensor_type_;
-
-#ifdef RATGDO_USE_DISTANCE_SENSOR
-    VL53L4CX* distance_sensor_ { nullptr };
-#endif
 };
 
 } // namespace esphome::ratgdo

--- a/components/ratgdo/sensor/ratgdo_sensor.h
+++ b/components/ratgdo/sensor/ratgdo_sensor.h
@@ -38,7 +38,7 @@ protected:
     RATGDOSensorType ratgdo_sensor_type_;
 
 #ifdef RATGDO_USE_DISTANCE_SENSOR
-    VL53L4CX distance_sensor_;
+    VL53L4CX* distance_sensor_ { nullptr };
 #endif
 };
 


### PR DESCRIPTION
## What

`RATGDOSensor` is shared by every sensor type (openings, paired devices, encoder, distance, etc). It "has a" VL53L4CX struct/object, which means every sensor instance occupies the memory needed for it, even for sensors that don't use the distance sensor. Since that struct is almost 10k bytes (~8% of total RAM each), that was an unfair burden on other sensors.

This adds a `RATGDODistanceSensor` subclass that holds the VL53L4CX object, used only for the entity actually configured as the distance sensor. ESPHome's codegen picks this class for sensor `type: distance`; everything else stays a plain `RATGDOSensor`, with no memory penalty from the distance sensor.

## Why

Found while investigating a CI failure (out of DRAM during the link phase) in an unrelated feature branch (TTC hold/release) that added two new sensor entities. In the case of ratgdo32disco sec2+ where the failure was observed, this took 3 instances of the struct out of bss.

An earlier version of this PR moved the member to a pointer and allocated it dynamically at runtime instead. That also solved the RAM problem, but @bdraco pointed out that dynamic memory allocation is not desirable on an embedded processor, so this was reworked into a dedicated subclass instead — keeping everything in static storage with no heap allocation at all.

## Testing

Compiled `v32disco.yaml` before/after locally: DRAM usage is now 84,704 bytes (68.0% used) — fully static, no heap allocation — down from 103,696 bytes (83.2%) before any fix. `esphome config` validated cleanly across the full board matrix. `pytest tests/ -v` passes (15/15).

Compiled and uploaded to three v2.5i boards (Raynor Aviator II openers, 880LM wall controls) along with my ttc hold/release feature and nothing appears to be broken. However, since I don't have a v32disco or a distance_sensor, this isn't really a true verification of the new code. I am not actually able to verify that configuration. Anyone who can test on that config would be very helpful.

Drafted with Claude Sonnet 5; reviewed/edited by webbzell (Chip Webb).
