### PR TITLE
Changed ESP32 UART CLK to Default

### DIFF
--- a/components/ratgdo/ratgdo_uart_esp32.cpp
+++ b/components/ratgdo/ratgdo_uart_esp32.cpp
@@ -70,7 +70,7 @@ void RatgdoUART::begin(int baud, RatgdoUARTConfig config, int rx_pin,
     uart_config.parity = (config == RATGDO_UART_8E1) ? UART_PARITY_EVEN : UART_PARITY_DISABLE;
     uart_config.stop_bits = UART_STOP_BITS_1;
     uart_config.flow_ctrl = UART_HW_FLOWCTRL_DISABLE;
-    uart_config.source_clk = UART_SCLK_APB;
+    uart_config.source_clk = UART_SCLK_DEFAULT;
 
     ESP_ERROR_CHECK(
         uart_driver_install((uart_port_t)this->uart_num_, UART_RX_BUFFER_SIZE, 0, 0, NULL, 0));


### PR DESCRIPTION
This PR replaces UART_SCLK_APB with UART_SCLK_DEFAULT in line with https://github.com/esphome/esphome/pull/5533
This will allow the code to also work with ESP32C6 etc. microcontrollers