### PR TITLE
Fix -Wformat mismatches for millis() in log format strings

### DIFF
--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -15,6 +15,8 @@
 #include "common.h"
 #include "ratgdo_state.h"
 
+#include <cinttypes>
+
 #ifdef PROTOCOL_DRYCONTACT
 #include "dry_contact.h"
 #endif
@@ -526,7 +528,7 @@ void RATGDOComponent::schedule_door_position_sync(float update_period)
 {
     ESP_LOG1(
         TAG,
-        "Schedule position sync: delta %f, start position: %f, start moving: %d",
+        "Schedule position sync: delta %f, start position: %f, start moving: %" PRIu32,
         this->door_move_delta, this->door_start_position,
         this->door_start_moving);
     auto duration = this->door_move_delta > 0 ? *this->opening_duration
@@ -557,7 +559,7 @@ void RATGDOComponent::door_position_update()
         return;
     }
     auto position = this->door_start_position + (now - this->door_start_moving) / (1000 * duration);
-    ESP_LOG2(TAG, "[%d] Position update: %f", now, position);
+    ESP_LOG2(TAG, "[%" PRIu32 "] Position update: %f", now, position);
     this->door_position = clamp(position, 0.0f, 1.0f);
 }
 

--- a/components/ratgdo/secplus1.cpp
+++ b/components/ratgdo/secplus1.cpp
@@ -10,6 +10,8 @@
 #include "esphome/core/log.h"
 #include "esphome/core/scheduler.h"
 
+#include <cinttypes>
+
 namespace esphome::ratgdo {
 namespace secplus1 {
 
@@ -260,14 +262,14 @@ namespace secplus1 {
 
                 if (ser_byte < 0x30 || ser_byte > 0x3A) {
                     char hex[format_hex_pretty_size(1)];
-                    ESP_LOG2(TAG, "[%d] Ignoring byte [%s], baud: %d", millis(), format_hex_pretty_to(hex, &ser_byte, 1), this->uart_.baudRate());
+                    ESP_LOG2(TAG, "[%" PRIu32 "] Ignoring byte [%s], baud: %d", millis(), format_hex_pretty_to(hex, &ser_byte, 1), this->uart_.baudRate());
                     this->rx_byte_count_ = 0;
                     continue;
                 }
                 this->rx_packet_[this->rx_byte_count_++] = ser_byte;
                 {
                     char hex[format_hex_pretty_size(1)];
-                    ESP_LOG2(TAG, "[%d] Received byte: [%s]", millis(), format_hex_pretty_to(hex, &ser_byte, 1));
+                    ESP_LOG2(TAG, "[%" PRIu32 "] Received byte: [%s]", millis(), format_hex_pretty_to(hex, &ser_byte, 1));
                 }
                 this->flags_.rx_reading_msg = true;
 
@@ -277,7 +279,7 @@ namespace secplus1 {
                     this->rx_byte_count_ = 0;
                     {
                         char hex[format_hex_pretty_size(1)];
-                        ESP_LOG2(TAG, "[%d] Received command: [%s]", millis(), format_hex_pretty_to(hex, &this->rx_packet_[0], 1));
+                        ESP_LOG2(TAG, "[%" PRIu32 "] Received command: [%s]", millis(), format_hex_pretty_to(hex, &this->rx_packet_[0], 1));
                     }
                     return this->decode_packet(this->rx_packet_);
                 }
@@ -292,7 +294,7 @@ namespace secplus1 {
                 this->rx_packet_[this->rx_byte_count_++] = ser_byte;
                 {
                     char hex[format_hex_pretty_size(1)];
-                    ESP_LOG2(TAG, "[%d] Received byte: [%s]", millis(), format_hex_pretty_to(hex, &ser_byte, 1));
+                    ESP_LOG2(TAG, "[%" PRIu32 "] Received byte: [%s]", millis(), format_hex_pretty_to(hex, &ser_byte, 1));
                 }
 
                 if (this->rx_byte_count_ == RX_LENGTH) {
@@ -309,7 +311,7 @@ namespace secplus1 {
                 // discard it so we can read the following packet correctly
                 {
                     char hex[format_hex_pretty_size(1)];
-                    ESP_LOGW(TAG, "[%d] Discard incomplete packet: [%s ...]", millis(), format_hex_pretty_to(hex, &this->rx_packet_[0], 1));
+                    ESP_LOGW(TAG, "[%" PRIu32 "] Discard incomplete packet: [%s ...]", millis(), format_hex_pretty_to(hex, &this->rx_packet_[0], 1));
                 }
                 this->flags_.rx_reading_msg = false;
                 this->rx_byte_count_ = 0;
@@ -323,14 +325,14 @@ namespace secplus1 {
     {
         constexpr size_t hex_size = format_hex_pretty_size(RX_LENGTH);
         char hex[hex_size];
-        ESP_LOG2(TAG, "[%d] Received packet: [%s]", millis(), format_hex_pretty_to(hex, packet, RX_LENGTH));
+        ESP_LOG2(TAG, "[%" PRIu32 "] Received packet: [%s]", millis(), format_hex_pretty_to(hex, packet, RX_LENGTH));
     }
 
     void Secplus1::print_tx_packet(const TxPacket& packet) const
     {
         constexpr size_t hex_size = format_hex_pretty_size(TX_LENGTH);
         char hex[hex_size];
-        ESP_LOG2(TAG, "[%d] Sending packet: [%s]", millis(), format_hex_pretty_to(hex, packet, TX_LENGTH));
+        ESP_LOG2(TAG, "[%" PRIu32 "] Sending packet: [%s]", millis(), format_hex_pretty_to(hex, packet, TX_LENGTH));
     }
 
     optional<RxCommand> Secplus1::decode_packet(const RxPacket& packet) const
@@ -502,7 +504,7 @@ namespace secplus1 {
         {
             uint8_t byte_val = static_cast<uint8_t>(value);
             char hex[format_hex_pretty_size(1)];
-            ESP_LOGD(TAG, "[%d] Sent byte: [%s]", millis(), format_hex_pretty_to(hex, &byte_val, 1));
+            ESP_LOGD(TAG, "[%" PRIu32 "] Sent byte: [%s]", millis(), format_hex_pretty_to(hex, &byte_val, 1));
         }
     }
 

--- a/components/ratgdo/secplus2.cpp
+++ b/components/ratgdo/secplus2.cpp
@@ -14,6 +14,8 @@ extern "C" {
 #include "secplus.h"
 }
 
+#include <cinttypes>
+
 namespace esphome::ratgdo {
 namespace secplus2 {
 
@@ -374,10 +376,10 @@ namespace secplus2 {
         data &= ~0xf000; // clear parity nibble
 
         if ((fixed & 0xFFFFFFFF) == this->client_id_) { // my commands
-            ESP_LOG1(TAG, "[%ld] received mine: rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, millis(), rolling, fixed, data);
+            ESP_LOG1(TAG, "[%" PRIu32 "] received mine: rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, millis(), rolling, fixed, data);
             return { };
         } else {
-            ESP_LOG1(TAG, "[%ld] received rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, millis(), rolling, fixed, data);
+            ESP_LOG1(TAG, "[%" PRIu32 "] received rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, millis(), rolling, fixed, data);
         }
 
         CommandType cmd_type = to_CommandType(cmd, CommandType::UNKNOWN);
@@ -468,7 +470,7 @@ namespace secplus2 {
         uint64_t fixed = ((cmd & ~0xff) << 24) | this->client_id_;
         uint32_t data = (static_cast<uint64_t>(command.byte2) << 24) | (static_cast<uint64_t>(command.byte1) << 16) | (static_cast<uint64_t>(command.nibble) << 8) | (cmd & 0xff);
 
-        ESP_LOG2(TAG, "[%ld] Encode for transmit rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, millis(), *this->rolling_code_counter_, fixed, data);
+        ESP_LOG2(TAG, "[%" PRIu32 "] Encode for transmit rolling=%07" PRIx32 " fixed=%010" PRIx64 " data=%08" PRIx32, millis(), *this->rolling_code_counter_, fixed, data);
         encode_wireline(*this->rolling_code_counter_, fixed, data, packet);
     }
 


### PR DESCRIPTION
Hi, thanks for making this. I just ordered a second non-disco for my side garage door since it works so much better than the old way. Here's a small fix for warnings I was seeing during compile. Flashed to my disco, it works as expected.

## What

Log statements that print `millis()` used `%d` and `%ld` conversions that do not match the argument type. This switches them to `PRIu32` and adds the `<cinttypes>` include where it was missing.

## Why

`millis()` returns `uint32_t`, which both the ESP32 and ESP8266 toolchains define as `long unsigned int`. Two of these calls, in `secplus1.cpp` at the `Discard incomplete packet` warning and the `Sent byte` debug line, sit on unconditional paths and emit `-Wformat` warnings on every board build. The rest are behind `ESP_LOG1` and `ESP_LOG2`, so they stay quiet until the logger level is raised to `very_verbose`, but they are wrong in the same way.

## How

Replace the mismatched conversions with `PRIu32` in `ratgdo.cpp`, `secplus1.cpp`, and `secplus2.cpp`. `secplus2.cpp` already used `PRIx32` and `PRIx64` through a transitive include; the explicit `<cinttypes>` there makes that dependency real rather than incidental. Format strings only, no behaviour change.

## Testing

`pytest tests/ -v` passes (15 tests), and `pre-commit run --files` passes on all three changed files, including `clang-format -style=Webkit`.

Flashed to a real ratgdo32 Disco driving a Security+ 1.0 opener with a digital wall panel. The `v32disco_secplusv1` build now compiles with zero warnings, where the two unconditional ones appeared before. The board ran clean after flashing with healthy Sec+1.0 packet decode, and the garage light was toggled from Home Assistant to exercise the transmit path that the `Sent byte` line logs from.

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Pytest: `python -m pytest tests/ -q`, 15 passed.

Pre-commit: `pre-commit run --files components/ratgdo/ratgdo.cpp components/ratgdo/secplus1.cpp components/ratgdo/secplus2.cpp`. trailing-whitespace, end-of-file-fixer, check-added-large-files, and clang-format all passed with no rewrites.

Hardware: 169 seconds of continuous log capture from the flashed board showed one boot banner and no repeats, ruling out a reboot loop. `Light state=OFF` and `Lock state=UNLOCKED` were each logged 337 times over that window from `RATGDOComponent::received(...)`, roughly two per second, confirming RX and packet decode are healthy on the patched firmware. WiFi held at -34 dBm with no errors.

Type note: `RATGDOComponent::door_start_moving` is declared `unsigned long` rather than `uint32_t`. On both target toolchains those are the same type, which is why the old `%d` warned there, so `PRIu32` matches. Retyping the member was left out to keep this to format strings.

</details>

Drafted with Claude Code (Opus 5); reviewed and hardware-tested by @martinemde (yes actually).
