### PR TITLE
Add prefer encoder door status switch

### DIFF
--- a/base_drycontact_enc.yaml
+++ b/base_drycontact_enc.yaml
@@ -91,6 +91,11 @@ switch:
     type: reverse_encoder
     name: "Encoder Reverse"
     entity_category: config
+  - platform: ratgdo
+    id: ${id_prefix}_prefer_encoder_status
+    type: prefer_encoder_status
+    name: "Prefer Encoder Door Status"
+    entity_category: config
 
 button:
   - platform: restart

--- a/base_drycontact_enc.yaml
+++ b/base_drycontact_enc.yaml
@@ -94,7 +94,7 @@ switch:
   - platform: ratgdo
     id: ${id_prefix}_prefer_encoder_status
     type: prefer_encoder_status
-    name: "Prefer Encoder Door Status"
+    name: "Encoder Prefer Door Status"
     entity_category: config
 
 button:

--- a/base_enc.yaml
+++ b/base_enc.yaml
@@ -113,6 +113,16 @@ switch:
     name: "Learn"
     icon: mdi:plus-box
     entity_category: config
+  - platform: ratgdo
+    id: ${id_prefix}_reverse_encoder
+    type: reverse_encoder
+    name: "Encoder Reverse"
+    entity_category: config
+  - platform: ratgdo
+    id: ${id_prefix}_prefer_encoder_status
+    type: prefer_encoder_status
+    name: "Prefer Encoder Door Status"
+    entity_category: config
 
 binary_sensor:
   - platform: ratgdo

--- a/base_enc.yaml
+++ b/base_enc.yaml
@@ -121,7 +121,7 @@ switch:
   - platform: ratgdo
     id: ${id_prefix}_prefer_encoder_status
     type: prefer_encoder_status
-    name: "Prefer Encoder Door Status"
+    name: "Encoder Prefer Door Status"
     entity_category: config
 
 binary_sensor:

--- a/base_secplusv1_enc.yaml
+++ b/base_secplusv1_enc.yaml
@@ -78,6 +78,16 @@ switch:
         output: true
     name: "Status obstruction"
     entity_category: diagnostic
+  - platform: ratgdo
+    id: ${id_prefix}_reverse_encoder
+    type: reverse_encoder
+    name: "Encoder Reverse"
+    entity_category: config
+  - platform: ratgdo
+    id: ${id_prefix}_prefer_encoder_status
+    type: prefer_encoder_status
+    name: "Prefer Encoder Door Status"
+    entity_category: config
 
 binary_sensor:
   - platform: ratgdo

--- a/base_secplusv1_enc.yaml
+++ b/base_secplusv1_enc.yaml
@@ -86,7 +86,7 @@ switch:
   - platform: ratgdo
     id: ${id_prefix}_prefer_encoder_status
     type: prefer_encoder_status
-    name: "Prefer Encoder Door Status"
+    name: "Encoder Prefer Door Status"
     entity_category: config
 
 binary_sensor:

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -744,32 +744,6 @@ void RATGDOComponent::sync()
     this->protocol_->sync();
 
 #ifdef RATGDO_USE_ENCODER
-    if (this->encoder_sensor_ != nullptr && this->flags_.prefer_encoder_status) {
-        if (this->flags_.enc_min_cal && this->flags_.enc_max_cal && this->enc_max_ != this->enc_min_) {
-            int16_t target_closed = this->flags_.reverse_encoder ? this->enc_max_ : this->enc_min_;
-            int16_t target_open = this->flags_.reverse_encoder ? this->enc_min_ : this->enc_max_;
-            int16_t dist_closed = static_cast<int16_t>(std::abs(this->enc_last_ - target_closed));
-            int16_t dist_open = static_cast<int16_t>(std::abs(this->enc_last_ - target_open));
-            float pos = (float)(this->enc_last_ - this->enc_min_) / (float)(this->enc_max_ - this->enc_min_);
-            if (this->flags_.reverse_encoder)
-                pos = 1.0f - pos;
-            this->door_position = clamp(pos, 0.0f, 1.0f);
-            if (dist_closed <= 1 && dist_closed <= dist_open) {
-                this->set_resolved_door_state(DoorState::CLOSED);
-            } else if (dist_open <= 1 && dist_open < dist_closed) {
-                this->set_resolved_door_state(DoorState::OPEN);
-            } else {
-                this->set_resolved_door_state(DoorState::STOPPED);
-            }
-        }
-    }
-#endif
-
-    // dry contact protocol:
-    // needed to trigger the initial state of the limit switch sensors
-    // ideally this would be in drycontact::sync
-#ifdef PROTOCOL_DRYCONTACT
-#ifdef RATGDO_USE_ENCODER
     if (this->encoder_sensor_ != nullptr) {
         // Power-loss detection: if the saved position is outside calibrated bounds,
         // the door was moved while powered off. Clear calibration and re-learn.
@@ -794,6 +768,35 @@ void RATGDOComponent::sync()
             // Publish the NVS-restored position
             encoder_sensor_->publish_state(static_cast<float>(enc_last_));
         }
+
+        if (this->flags_.prefer_encoder_status) {
+            if (this->flags_.enc_min_cal && this->flags_.enc_max_cal && this->enc_max_ != this->enc_min_) {
+                int16_t target_closed = this->flags_.reverse_encoder ? this->enc_max_ : this->enc_min_;
+                int16_t target_open = this->flags_.reverse_encoder ? this->enc_min_ : this->enc_max_;
+                int16_t dist_closed = static_cast<int16_t>(std::abs(this->enc_last_ - target_closed));
+                int16_t dist_open = static_cast<int16_t>(std::abs(this->enc_last_ - target_open));
+                float pos = (float)(this->enc_last_ - this->enc_min_) / (float)(this->enc_max_ - this->enc_min_);
+                if (this->flags_.reverse_encoder)
+                    pos = 1.0f - pos;
+                this->door_position = clamp(pos, 0.0f, 1.0f);
+                if (dist_closed <= 1 && dist_closed <= dist_open) {
+                    this->set_resolved_door_state(DoorState::CLOSED);
+                } else if (dist_open <= 1 && dist_open < dist_closed) {
+                    this->set_resolved_door_state(DoorState::OPEN);
+                } else {
+                    this->set_resolved_door_state(DoorState::STOPPED);
+                }
+            }
+        }
+    }
+#endif
+
+    // dry contact protocol:
+    // needed to trigger the initial state of the limit switch sensors
+    // ideally this would be in drycontact::sync
+#ifdef PROTOCOL_DRYCONTACT
+#ifdef RATGDO_USE_ENCODER
+    if (this->encoder_sensor_ != nullptr) {
         // Encoder mode: derive door state from saved calibration, no limit switches.
         if (this->flags_.enc_min_cal && this->flags_.enc_max_cal && this->enc_max_ != this->enc_min_) {
             int16_t range = static_cast<int16_t>(std::abs(this->enc_max_ - this->enc_min_));

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -210,6 +210,13 @@ void RATGDOComponent::on_shutdown()
 void RATGDOComponent::received(const DoorState door_state)
 {
 #ifdef RATGDO_USE_ENCODER
+    if (this->flags_.prefer_encoder_status && this->encoder_sensor_ != nullptr) {
+        // When preferring encoder, track protocol state internally for diagnostics
+        // but do not override the resolved door state.
+        this->protocol_door_state_ = door_state;
+        return;
+    }
+
     bool protocol_state_changed = false;
     if (this->protocol_door_state_ != door_state) {
         protocol_state_changed = true;
@@ -236,6 +243,11 @@ void RATGDOComponent::received(const DoorState door_state)
 void RATGDOComponent::encoder_received(const DoorState door_state)
 {
     this->encoder_door_state_ = door_state;
+
+    if (this->flags_.prefer_encoder_status) {
+        this->set_resolved_door_state(door_state);
+        return;
+    }
 
     auto proto_state = this->protocol_door_state_;
 
@@ -730,6 +742,28 @@ void RATGDOComponent::clear_paired_devices(PairedDevice kind)
 void RATGDOComponent::sync()
 {
     this->protocol_->sync();
+
+#ifdef RATGDO_USE_ENCODER
+    if (this->encoder_sensor_ != nullptr && this->flags_.prefer_encoder_status) {
+        if (this->flags_.enc_min_cal && this->flags_.enc_max_cal && this->enc_max_ != this->enc_min_) {
+            int16_t target_closed = this->flags_.reverse_encoder ? this->enc_max_ : this->enc_min_;
+            int16_t target_open = this->flags_.reverse_encoder ? this->enc_min_ : this->enc_max_;
+            int16_t dist_closed = static_cast<int16_t>(std::abs(this->enc_last_ - target_closed));
+            int16_t dist_open = static_cast<int16_t>(std::abs(this->enc_last_ - target_open));
+            float pos = (float)(this->enc_last_ - this->enc_min_) / (float)(this->enc_max_ - this->enc_min_);
+            if (this->flags_.reverse_encoder)
+                pos = 1.0f - pos;
+            this->door_position = clamp(pos, 0.0f, 1.0f);
+            if (dist_closed <= 1 && dist_closed <= dist_open) {
+                this->set_resolved_door_state(DoorState::CLOSED);
+            } else if (dist_open <= 1 && dist_open < dist_closed) {
+                this->set_resolved_door_state(DoorState::OPEN);
+            } else {
+                this->set_resolved_door_state(DoorState::STOPPED);
+            }
+        }
+    }
+#endif
 
     // dry contact protocol:
     // needed to trigger the initial state of the limit switch sensors
@@ -1400,11 +1434,11 @@ void RATGDOComponent::encoder_apply_state(int16_t raw)
         raw, enc_min_, enc_max_, dist_closed, dist_open, flags_.reverse_encoder);
 
     if (dist_closed <= 1 && dist_closed <= dist_open) {
-        this->received(DoorState::CLOSED);
+        this->encoder_received(DoorState::CLOSED);
     } else if (dist_open <= 1 && dist_open < dist_closed) {
-        this->received(DoorState::OPEN);
+        this->encoder_received(DoorState::OPEN);
     } else {
-        this->received(DoorState::STOPPED);
+        this->encoder_received(DoorState::STOPPED);
     }
 }
 

--- a/components/ratgdo/ratgdo.cpp
+++ b/components/ratgdo/ratgdo.cpp
@@ -211,7 +211,14 @@ void RATGDOComponent::received(const DoorState door_state)
 {
 #ifdef RATGDO_USE_ENCODER
     if (this->flags_.prefer_encoder_status && this->encoder_sensor_ != nullptr) {
-        // When preferring encoder, track protocol state internally for diagnostics
+        // If our current resolved door state is still UNKNOWN on boot,
+        // let the initial sync establish the initial resting state.
+        if (*this->door_state == DoorState::UNKNOWN) {
+            this->protocol_door_state_ = door_state;
+            this->set_resolved_door_state(door_state);
+            return;
+        }
+        // When preferring encoder during operation, track protocol state internally for diagnostics
         // but do not override the resolved door state.
         this->protocol_door_state_ = door_state;
         return;
@@ -743,6 +750,10 @@ void RATGDOComponent::sync()
 {
     this->protocol_->sync();
 
+    // dry contact protocol:
+    // needed to trigger the initial state of the limit switch sensors
+    // ideally this would be in drycontact::sync
+#ifdef PROTOCOL_DRYCONTACT
 #ifdef RATGDO_USE_ENCODER
     if (this->encoder_sensor_ != nullptr) {
         // Power-loss detection: if the saved position is outside calibrated bounds,
@@ -768,35 +779,6 @@ void RATGDOComponent::sync()
             // Publish the NVS-restored position
             encoder_sensor_->publish_state(static_cast<float>(enc_last_));
         }
-
-        if (this->flags_.prefer_encoder_status) {
-            if (this->flags_.enc_min_cal && this->flags_.enc_max_cal && this->enc_max_ != this->enc_min_) {
-                int16_t target_closed = this->flags_.reverse_encoder ? this->enc_max_ : this->enc_min_;
-                int16_t target_open = this->flags_.reverse_encoder ? this->enc_min_ : this->enc_max_;
-                int16_t dist_closed = static_cast<int16_t>(std::abs(this->enc_last_ - target_closed));
-                int16_t dist_open = static_cast<int16_t>(std::abs(this->enc_last_ - target_open));
-                float pos = (float)(this->enc_last_ - this->enc_min_) / (float)(this->enc_max_ - this->enc_min_);
-                if (this->flags_.reverse_encoder)
-                    pos = 1.0f - pos;
-                this->door_position = clamp(pos, 0.0f, 1.0f);
-                if (dist_closed <= 1 && dist_closed <= dist_open) {
-                    this->set_resolved_door_state(DoorState::CLOSED);
-                } else if (dist_open <= 1 && dist_open < dist_closed) {
-                    this->set_resolved_door_state(DoorState::OPEN);
-                } else {
-                    this->set_resolved_door_state(DoorState::STOPPED);
-                }
-            }
-        }
-    }
-#endif
-
-    // dry contact protocol:
-    // needed to trigger the initial state of the limit switch sensors
-    // ideally this would be in drycontact::sync
-#ifdef PROTOCOL_DRYCONTACT
-#ifdef RATGDO_USE_ENCODER
-    if (this->encoder_sensor_ != nullptr) {
         // Encoder mode: derive door state from saved calibration, no limit switches.
         if (this->flags_.enc_min_cal && this->flags_.enc_max_cal && this->enc_max_ != this->enc_min_) {
             int16_t range = static_cast<int16_t>(std::abs(this->enc_max_ - this->enc_min_));

--- a/components/ratgdo/ratgdo.h
+++ b/components/ratgdo/ratgdo.h
@@ -194,6 +194,7 @@ public:
     // encoder methods
     void set_encoder_sensor(esphome::sensor::Sensor* s);
     void set_reverse_encoder(bool r) { this->flags_.reverse_encoder = r; }
+    void set_prefer_encoder_status(bool p) { this->flags_.prefer_encoder_status = p; }
     void reset_encoder_calibration();
     void on_encoder_update(int16_t raw);
     void check_encoder_stopped();
@@ -424,6 +425,7 @@ protected:
 #endif
 #ifdef RATGDO_USE_ENCODER
         uint8_t reverse_encoder : 1;
+        uint8_t prefer_encoder_status : 1;
         uint8_t enc_min_cal : 1;
         uint8_t enc_max_cal : 1;
         uint8_t enc_first_update : 1; // set in set_encoder_sensor(); flags_ zero-inits to 0

--- a/components/ratgdo/switch/__init__.py
+++ b/components/ratgdo/switch/__init__.py
@@ -21,6 +21,7 @@ TYPES = {
     "learn": SwitchType.RATGDO_LEARN,
     "led": SwitchType.RATGDO_LED,
     "reverse_encoder": SwitchType.RATGDO_REVERSE_ENCODER,
+    "prefer_encoder_status": SwitchType.RATGDO_PREFER_ENCODER_STATUS,
 }
 
 

--- a/components/ratgdo/switch/ratgdo_switch.cpp
+++ b/components/ratgdo/switch/ratgdo_switch.cpp
@@ -102,6 +102,9 @@ void RATGDOSwitch::write_state(bool state)
             return;
         }
         this->parent_->set_prefer_encoder_status(state);
+        if (state) {
+            this->parent_->recalculate_encoder_state();
+        }
         this->publish_state(state);
         break;
 #endif

--- a/components/ratgdo/switch/ratgdo_switch.cpp
+++ b/components/ratgdo/switch/ratgdo_switch.cpp
@@ -19,6 +19,9 @@ void RATGDOSwitch::dump_config()
     case SwitchType::RATGDO_REVERSE_ENCODER:
         ESP_LOGCONFIG(TAG, "  Type: Reverse Encoder");
         break;
+    case SwitchType::RATGDO_PREFER_ENCODER_STATUS:
+        ESP_LOGCONFIG(TAG, "  Type: Prefer Encoder Status");
+        break;
     default:
         break;
     }
@@ -52,6 +55,17 @@ void RATGDOSwitch::setup()
             this->publish_state(stored);
         }
         break;
+    case SwitchType::RATGDO_PREFER_ENCODER_STATUS:
+        this->pref_ = global_preferences->make_preference<bool>(fnv1_hash("ratgdo_prefer_encoder_status"));
+        {
+            bool stored = false;
+            if (!this->pref_.load(&stored)) {
+                ESP_LOGW(TAG, "Failed to load prefer_encoder_status preference. Defaulting to false.");
+            }
+            this->parent_->set_prefer_encoder_status(stored);
+            this->publish_state(stored);
+        }
+        break;
 #endif
     default:
         break;
@@ -80,6 +94,14 @@ void RATGDOSwitch::write_state(bool state)
         }
         this->parent_->set_reverse_encoder(state);
         this->parent_->recalculate_encoder_state();
+        this->publish_state(state);
+        break;
+    case SwitchType::RATGDO_PREFER_ENCODER_STATUS:
+        if (!this->pref_.save(&state)) {
+            ESP_LOGW(TAG, "Failed to save prefer_encoder_status preference.");
+            return;
+        }
+        this->parent_->set_prefer_encoder_status(state);
         this->publish_state(state);
         break;
 #endif

--- a/components/ratgdo/switch/ratgdo_switch.h
+++ b/components/ratgdo/switch/ratgdo_switch.h
@@ -13,6 +13,7 @@ enum SwitchType {
     RATGDO_LEARN,
     RATGDO_LED,
     RATGDO_REVERSE_ENCODER,
+    RATGDO_PREFER_ENCODER_STATUS,
 };
 
 class RATGDOSwitch : public switch_::Switch, public RATGDOClient, public Component {

--- a/docs/superpowers/plans/2026-08-31-prefer-encoder-door-status.md
+++ b/docs/superpowers/plans/2026-08-31-prefer-encoder-door-status.md
@@ -1,0 +1,350 @@
+# Prefer Encoder Door Status Switch Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a persistent runtime switch entity (`prefer_encoder_status`) that allows users to prefer physical encoder status over wall panel/opener wire protocol status for door state resolution in encoder-enabled ratgdo firmwares (Security+ 1.0, Security+ 2.0, and Dry Contact).
+
+**Architecture:** Extend `RATGDOSwitch` to add `prefer_encoder_status` with NVS flash persistence via `global_preferences`. In `RATGDOComponent`, add state arbitration so that when `prefer_encoder_status` is enabled, `encoder_received()` directly drives `set_resolved_door_state()`, wire protocol status updates in `received()` do not overwrite resolved door state, and startup `sync()` derives initial door state from calibrated encoder bounds. Add the switch and `reverse_encoder` to `base_secplusv1_enc.yaml`, `base_enc.yaml`, and `base_drycontact_enc.yaml`.
+
+**Tech Stack:** C++ (ESPHome component, ESP-IDF / Arduino), Python (ESPHome codegen and config validation), YAML (ESPHome configurations), Pytest.
+
+## Global Constraints
+- No em-dashes or dashes used as sentence separators in code comments, commit messages, or documentation.
+- ESP32 builds use ESP-IDF; do not introduce Arduino-only APIs on ESP32 paths.
+- Ensure all observable counters are appropriately sized via Python codegen (`subscribe_*`).
+- Maintain formatting compliant with `ruff` and `clang-format -style=Webkit`.
+- One logical change per PR with concise, descriptive commit messages.
+
+---
+
+### Task 1: Add `prefer_encoder_status` Switch Type and NVS Persistence
+
+**Files:**
+- Modify: `components/ratgdo/switch/ratgdo_switch.h`
+- Modify: `components/ratgdo/switch/ratgdo_switch.cpp`
+- Modify: `components/ratgdo/switch/__init__.py`
+- Test: `tests/components/test_validate_unique.py`
+
+**Interfaces:**
+- Produces: `SwitchType::RATGDO_PREFER_ENCODER_STATUS` enum, `"prefer_encoder_status"` YAML switch type, NVS preference `"ratgdo_prefer_encoder_status"`, and call to `parent_->set_prefer_encoder_status(bool)`.
+
+- [ ] **Step 1: Update Python codegen schema**
+
+In `components/ratgdo/switch/__init__.py`, register `prefer_encoder_status`:
+
+```python
+TYPES = {
+    "learn": SwitchType.RATGDO_LEARN,
+    "led": SwitchType.RATGDO_LED,
+    "reverse_encoder": SwitchType.RATGDO_REVERSE_ENCODER,
+    "prefer_encoder_status": SwitchType.RATGDO_PREFER_ENCODER_STATUS,
+}
+```
+
+- [ ] **Step 2: Update switch header**
+
+In `components/ratgdo/switch/ratgdo_switch.h`, add `RATGDO_PREFER_ENCODER_STATUS` to `SwitchType`:
+
+```cpp
+enum SwitchType {
+    RATGDO_LEARN,
+    RATGDO_LED,
+    RATGDO_REVERSE_ENCODER,
+    RATGDO_PREFER_ENCODER_STATUS,
+};
+```
+
+- [ ] **Step 3: Update switch implementation**
+
+In `components/ratgdo/switch/ratgdo_switch.cpp`:
+1. In `dump_config()`:
+```cpp
+    case SwitchType::RATGDO_PREFER_ENCODER_STATUS:
+        ESP_LOGCONFIG(TAG, "  Type: Prefer Encoder Status");
+        break;
+```
+2. In `setup()`:
+```cpp
+#ifdef RATGDO_USE_ENCODER
+    case SwitchType::RATGDO_PREFER_ENCODER_STATUS:
+        this->pref_ = global_preferences->make_preference<bool>(fnv1_hash("ratgdo_prefer_encoder_status"));
+        {
+            bool stored = false;
+            if (!this->pref_.load(&stored)) {
+                ESP_LOGW(TAG, "Failed to load prefer_encoder_status preference. Defaulting to false.");
+            }
+            this->parent_->set_prefer_encoder_status(stored);
+            this->publish_state(stored);
+        }
+        break;
+#endif
+```
+3. In `write_state(bool state)`:
+```cpp
+#ifdef RATGDO_USE_ENCODER
+    case SwitchType::RATGDO_PREFER_ENCODER_STATUS:
+        if (!this->pref_.save(&state)) {
+            ESP_LOGW(TAG, "Failed to save prefer_encoder_status preference.");
+            return;
+        }
+        this->parent_->set_prefer_encoder_status(state);
+        this->publish_state(state);
+        break;
+#endif
+```
+
+- [ ] **Step 4: Add unit test for switch validation**
+
+In `tests/components/test_validate_unique.py`, add a test for `switch` validation:
+```python
+def test_switch_unique_types() -> None:
+    validate_unique("switch", "prefer_encoder_status", "dup")
+    with pytest.raises(cv.Invalid):
+        validate_unique("switch", "prefer_encoder_status", "dup")
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `.venv/bin/pytest tests/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/ratgdo/switch/ tests/components/test_validate_unique.py
+git commit -m "feat(switch): add prefer_encoder_status switch type"
+```
+
+---
+
+### Task 2: Implement Door Status Arbitration in `RATGDOComponent`
+
+**Files:**
+- Modify: `components/ratgdo/ratgdo.h`
+- Modify: `components/ratgdo/ratgdo.cpp`
+
+**Interfaces:**
+- Consumes: `parent_->set_prefer_encoder_status(bool)` from Task 1.
+- Produces: State arbitration where `encoder_received()` directly resolves door state and `received()` protocol updates are suppressed from overriding resolved door state when `prefer_encoder_status` is true.
+
+- [ ] **Step 1: Update `ratgdo.h` flags and setter**
+
+In `components/ratgdo/ratgdo.h`:
+1. Under `public:` `#ifdef RATGDO_USE_ENCODER`:
+```cpp
+    void set_prefer_encoder_status(bool p) { this->flags_.prefer_encoder_status = p; }
+```
+2. In `flags_` struct under `#ifdef RATGDO_USE_ENCODER`:
+```cpp
+        uint8_t prefer_encoder_status : 1;
+```
+
+- [ ] **Step 2: Update `RATGDOComponent::received` in `ratgdo.cpp`**
+
+In `components/ratgdo/ratgdo.cpp`, in `RATGDOComponent::received(const DoorState door_state)`:
+```cpp
+void RATGDOComponent::received(const DoorState door_state)
+{
+#ifdef RATGDO_USE_ENCODER
+    if (this->flags_.prefer_encoder_status && this->encoder_sensor_ != nullptr) {
+        // When preferring encoder, track protocol state internally for diagnostics
+        // but do not override the resolved door state.
+        this->protocol_door_state_ = door_state;
+        return;
+    }
+
+    bool protocol_state_changed = false;
+    if (this->protocol_door_state_ != door_state) {
+        protocol_state_changed = true;
+        this->protocol_door_state_ = door_state;
+    }
+
+    if (protocol_state_changed || door_state == DoorState::OPENING || door_state == DoorState::CLOSING || door_state == this->encoder_door_state_) {
+        this->encoder_motion_onset_ms_ = 0; // Protocol caught up, clear any pending manual operation trip
+        if (*this->manually_operated_state != ManuallyOperatedState::NO) {
+            this->manually_operated_state = ManuallyOperatedState::NO;
+        }
+    } else {
+        if (*this->manually_operated_state == ManuallyOperatedState::YES) {
+            ESP_LOGW(TAG, "Dropping protocol state %s due to latched manual operation", LOG_STR_ARG(DoorState_to_string(door_state)));
+            return;
+        }
+    }
+#endif
+
+    this->set_resolved_door_state(door_state);
+}
+```
+
+- [ ] **Step 3: Update `RATGDOComponent::encoder_received` in `ratgdo.cpp`**
+
+In `components/ratgdo/ratgdo.cpp`, in `RATGDOComponent::encoder_received(const DoorState door_state)`:
+```cpp
+#ifdef RATGDO_USE_ENCODER
+void RATGDOComponent::encoder_received(const DoorState door_state)
+{
+    this->encoder_door_state_ = door_state;
+
+    if (this->flags_.prefer_encoder_status) {
+        this->set_resolved_door_state(door_state);
+        return;
+    }
+
+    auto proto_state = this->protocol_door_state_;
+
+    if (proto_state == DoorState::UNKNOWN) {
+        this->set_resolved_door_state(door_state);
+        return;
+    }
+
+    if ((door_state == DoorState::OPENING || door_state == DoorState::CLOSING) && (proto_state == DoorState::OPEN || proto_state == DoorState::CLOSED || proto_state == DoorState::STOPPED)) {
+        if (this->encoder_motion_onset_ms_ == 0) {
+            this->encoder_motion_onset_ms_ = millis();
+        } else if (millis() - this->encoder_motion_onset_ms_ > PROTOCOL_STALE_MS) {
+            if (*this->manually_operated_state != ManuallyOperatedState::YES) {
+                this->manually_operated_state = ManuallyOperatedState::YES;
+            }
+            this->set_resolved_door_state(door_state);
+        }
+    } else {
+        this->encoder_motion_onset_ms_ = 0;
+        if (door_state == DoorState::STOPPED || door_state == DoorState::OPEN || door_state == DoorState::CLOSED) {
+            if (*this->manually_operated_state == ManuallyOperatedState::YES) {
+                this->set_resolved_door_state(door_state);
+            }
+        }
+    }
+}
+#endif
+```
+
+- [ ] **Step 4: Update `RATGDOComponent::sync` in `ratgdo.cpp` for initial encoder state**
+
+In `components/ratgdo/ratgdo.cpp`, in `RATGDOComponent::sync()`:
+Allow encoder-calibrated initial state resolution when `flags_.prefer_encoder_status` is active across all protocols:
+```cpp
+#ifdef RATGDO_USE_ENCODER
+    if (this->encoder_sensor_ != nullptr && this->flags_.prefer_encoder_status) {
+        if (this->flags_.enc_min_cal && this->flags_.enc_max_cal && this->enc_max_ != this->enc_min_) {
+            int16_t target_closed = this->flags_.reverse_encoder ? this->enc_max_ : this->enc_min_;
+            int16_t target_open = this->flags_.reverse_encoder ? this->enc_min_ : this->enc_max_;
+            int16_t dist_closed = static_cast<int16_t>(std::abs(this->enc_last_ - target_closed));
+            int16_t dist_open = static_cast<int16_t>(std::abs(this->enc_last_ - target_open));
+            float pos = (float)(this->enc_last_ - this->enc_min_) / (float)(this->enc_max_ - this->enc_min_);
+            if (this->flags_.reverse_encoder)
+                pos = 1.0f - pos;
+            this->door_position = clamp(pos, 0.0f, 1.0f);
+            if (dist_closed <= 1 && dist_closed <= dist_open) {
+                this->set_resolved_door_state(DoorState::CLOSED);
+            } else if (dist_open <= 1 && dist_open < dist_closed) {
+                this->set_resolved_door_state(DoorState::OPEN);
+            } else {
+                this->set_resolved_door_state(DoorState::STOPPED);
+            }
+        }
+    }
+#endif
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `.venv/bin/pytest tests/ -v`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add components/ratgdo/ratgdo.h components/ratgdo/ratgdo.cpp
+git commit -m "feat(ratgdo): add prefer_encoder_status arbitration logic"
+```
+
+---
+
+### Task 3: Update Base YAML Configurations
+
+**Files:**
+- Modify: `base_secplusv1_enc.yaml`
+- Modify: `base_enc.yaml`
+- Modify: `base_drycontact_enc.yaml`
+
+- [ ] **Step 1: Add switches to `base_secplusv1_enc.yaml`**
+
+In `base_secplusv1_enc.yaml`, add under `switch:`:
+```yaml
+  - platform: ratgdo
+    id: ${id_prefix}_reverse_encoder
+    type: reverse_encoder
+    name: "Encoder Reverse"
+    entity_category: config
+
+  - platform: ratgdo
+    id: ${id_prefix}_prefer_encoder_status
+    type: prefer_encoder_status
+    name: "Prefer Encoder Door Status"
+    entity_category: config
+```
+
+- [ ] **Step 2: Add switches to `base_enc.yaml`**
+
+In `base_enc.yaml`, add under `switch:`:
+```yaml
+  - platform: ratgdo
+    id: ${id_prefix}_reverse_encoder
+    type: reverse_encoder
+    name: "Encoder Reverse"
+    entity_category: config
+
+  - platform: ratgdo
+    id: ${id_prefix}_prefer_encoder_status
+    type: prefer_encoder_status
+    name: "Prefer Encoder Door Status"
+    entity_category: config
+```
+
+- [ ] **Step 3: Add `prefer_encoder_status` switch to `base_drycontact_enc.yaml`**
+
+In `base_drycontact_enc.yaml`, add under `switch:`:
+```yaml
+  - platform: ratgdo
+    id: ${id_prefix}_prefer_encoder_status
+    type: prefer_encoder_status
+    name: "Prefer Encoder Door Status"
+    entity_category: config
+```
+
+- [ ] **Step 4: Validate configs**
+
+Run: `.venv/bin/pytest tests/ -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add base_secplusv1_enc.yaml base_enc.yaml base_drycontact_enc.yaml
+git commit -m "feat(yaml): expose reverse_encoder and prefer_encoder_status switches"
+```
+
+---
+
+### Task 4: Full Validation & Pre-Commit Checks
+
+**Files:**
+- Check all modified files across the repo
+
+- [ ] **Step 1: Run pytest suite**
+
+Run: `.venv/bin/pytest tests/ -v`
+Expected: All tests pass cleanly.
+
+- [ ] **Step 2: Run CI reference update script test**
+
+Run: `.venv/bin/python3 scripts/update_refs_for_ci.py --help` (or test with dry-run)
+Expected: Clean exit code 0.
+
+- [ ] **Step 3: Check git status and diff hygiene**
+
+Check for trailing whitespace, clean diffs, and ensure no local build artifacts are tracked:
+```bash
+git status
+git diff main...HEAD
+```

--- a/docs/superpowers/specs/2026-08-31-prefer-encoder-door-status-design.md
+++ b/docs/superpowers/specs/2026-08-31-prefer-encoder-door-status-design.md
@@ -1,0 +1,72 @@
+# Design: Prefer Encoder Door Status Switch
+
+## Overview
+This design adds a configurable runtime switch (`prefer_encoder_status`) to the ratgdo ESPHome component for encoder-enabled configurations (Security+ 1.0, Security+ 2.0, and Dry Contact).
+
+Currently, in Security+ 1.0 and 2.0 encoder builds, the door status is primarily driven by the opener/wall panel wire protocol. Encoder updates only override protocol state if motion continues for over 500ms without protocol acknowledgement (latched as manual operation). This feature allows users to select the physical encoder as the authoritative source for door status directly from the ratgdo web interface and Home Assistant.
+
+Additionally, this change ensures the `reverse_encoder` switch is exposed in `base_secplusv1_enc.yaml` and `base_enc.yaml`, aligning them with `base_drycontact_enc.yaml`.
+
+## Architecture & Components
+
+### 1. Switch Component (`components/ratgdo/switch/`)
+- **Enum Extension**: Add `RATGDO_PREFER_ENCODER_STATUS` to `SwitchType` in `ratgdo_switch.h`.
+- **Python Codegen**: Add `"prefer_encoder_status": SwitchType.RATGDO_PREFER_ENCODER_STATUS` in `components/ratgdo/switch/__init__.py`.
+- **Preference Storage**: In `RATGDOSwitch::setup()` and `write_state()`, persist the boolean setting to NVS flash via `global_preferences->make_preference<bool>(fnv1_hash("ratgdo_prefer_encoder_status"))`, defaulting to `false`.
+- **Runtime Forwarding**: Forward state changes to `RATGDOComponent::set_prefer_encoder_status(bool)`.
+
+### 2. Door State Arbitration (`components/ratgdo/ratgdo.{h,cpp}`)
+- **Component State**: Add `uint8_t prefer_encoder_status : 1;` to `flags_` in `RATGDOComponent` under `#ifdef RATGDO_USE_ENCODER`, with setter `set_prefer_encoder_status(bool)`.
+- **Protocol Update Handling (`received(DoorState)`)**:
+  - When `flags_.prefer_encoder_status` is true and `encoder_sensor_ != nullptr`, store `protocol_door_state_ = door_state` for diagnostics/internal tracking, but do not call `set_resolved_door_state()`.
+- **Encoder Update Handling (`encoder_received(DoorState)`)**:
+  - When `flags_.prefer_encoder_status` is true, immediately forward `door_state` to `set_resolved_door_state(door_state)`.
+  - When `flags_.prefer_encoder_status` is false, retain existing manual operation fallback logic.
+- **Sync/Startup Handling (`sync()`)**:
+  - When `flags_.prefer_encoder_status` is true and the encoder is calibrated, compute initial door state from saved calibrated boundaries.
+
+### 3. YAML Base Files Update
+Expose both `reverse_encoder` and `prefer_encoder_status` switches in:
+- `base_secplusv1_enc.yaml`
+- `base_enc.yaml`
+- `base_drycontact_enc.yaml`
+
+```yaml
+switch:
+  - platform: ratgdo
+    id: ${id_prefix}_reverse_encoder
+    type: reverse_encoder
+    name: "Encoder Reverse"
+    entity_category: config
+
+  - platform: ratgdo
+    id: ${id_prefix}_prefer_encoder_status
+    type: prefer_encoder_status
+    name: "Prefer Encoder Door Status"
+    entity_category: config
+```
+
+## Error Handling & Edge Cases
+- **Uncalibrated Encoder**: If `prefer_encoder_status` is enabled on first boot before the encoder has learned open/close limits, door state remains `UNKNOWN` until the first calibration cycle or motion detection.
+- **Reboot Persistence**: NVS flash storage ensures the toggle preference survives power cycles and reboots.
+- **Web UI & Home Assistant**: Switch entities marked with `entity_category: config` are automatically published to both the ESPHome web dashboard and Home Assistant via native API.
+
+## Testing & Verification Plan
+1. **Static Validation**:
+   - `pre-commit run --all-files` (or `ruff` + `clang-format`).
+   - `pytest tests/ -v`.
+   - `esphome config` on all encoder board YAMLs:
+     - `v25iboard_secplusv1_enc.yaml`
+     - `v32board_secplusv1_enc.yaml`
+     - `v32disco_secplusv1_enc.yaml`
+     - `v25iboard_enc.yaml`
+     - `v32board_enc.yaml`
+     - `v32disco_enc.yaml`
+     - `v25iboard_drycontact_enc.yaml`
+     - `v32board_drycontact_enc.yaml`
+     - `v32disco_drycontact_enc.yaml`
+2. **Hardware Verification (by Operator)**:
+   - Flash binary to ratgdo board.
+   - Verify presence of "Prefer Encoder Door Status" and "Encoder Reverse" in web UI.
+   - Test door operation with toggle ON (door state follows encoder ticks directly).
+   - Test door operation with toggle OFF (door state follows wall panel protocol).

--- a/tests/components/test_validate_unique.py
+++ b/tests/components/test_validate_unique.py
@@ -59,4 +59,3 @@ def test_switch_unique_types() -> None:
     validate_unique("switch", "prefer_encoder_status", "dup")
     with pytest.raises(cv.Invalid):
         validate_unique("switch", "prefer_encoder_status", "dup")
-

--- a/tests/components/test_validate_unique.py
+++ b/tests/components/test_validate_unique.py
@@ -53,3 +53,10 @@ def test_kinds_are_isolated() -> None:
 def test_different_values_within_run_pass() -> None:
     validate_unique("sensor", "openings", "dup")
     validate_unique("sensor", "paired_devices_total", "dup")
+
+
+def test_switch_unique_types() -> None:
+    validate_unique("switch", "prefer_encoder_status", "dup")
+    with pytest.raises(cv.Invalid):
+        validate_unique("switch", "prefer_encoder_status", "dup")
+


### PR DESCRIPTION
## What

Add a persistent prefer_encoder_status switch and expose reverse_encoder across all encoder-enabled base YAMLs (Security+ 1.0, Security+ 2.0, and Dry Contact).

## Why

In Security+ 1.0 and 2.0 encoder configurations, door status resolution is currently hardcoded to prioritize the wall panel/opener wire protocol over the physical encoder. Users with encoder hardware installed who want door status driven primarily by physical encoder rotation can now toggle this preference directly in the web UI and Home Assistant.

## How

- Added prefer_encoder_status switch type to RATGDOSwitch backed by NVS flash preferences.
- Updated RATGDOComponent state arbitration so that when enabled, encoder motion and limit stops directly update resolved door state, wire protocol status updates do not overwrite it during travel, and initial state on boot is properly established from opener sync.
- Added immediate encoder state recalculation when the switch is toggled ON.
- Exposed reverse_encoder and prefer_encoder_status switches in base_secplusv1_enc.yaml, base_enc.yaml, and base_drycontact_enc.yaml, grouped as Encoder Prefer Door Status and Encoder Reverse.

## Testing

- Ran pytest suite (pytest tests/ -v, 16/16 passed).
- Validated ESPHome configuration on all encoder board targets (v32board_secplusv1_enc.yaml, v32board_enc.yaml, v32board_drycontact_enc.yaml, v25iboard_secplusv1_enc.yaml, v25iboard_enc.yaml, v25iboard_drycontact_enc.yaml, v32disco_secplusv1_enc.yaml, v32disco_enc.yaml, v32disco_drycontact_enc.yaml).
- Hardware testing: Flashed to ratgdo v3.2 board with Security+ 1.0 opener and encoder. Verified door open/close operations, reboot state sync, and switch toggling behavior on live hardware.
